### PR TITLE
PR3: Add Databricks timeout controls and reliability parity

### DIFF
--- a/apps_script_tools/testing/database/runDatabricksSql.js
+++ b/apps_script_tools/testing/database/runDatabricksSql.js
@@ -1,0 +1,92 @@
+const DATABASE_RUN_DATABRICKS_SQL_TESTS = [
+  {
+    description: 'runDatabricksSql() should reject pollIntervalMs greater than maxWaitMs',
+    test: () => {
+      try {
+        runDatabricksSql(
+          'select 1',
+          {
+            host: 'dbc.example.com',
+            sqlWarehouseId: 'w-1',
+            schema: 'default',
+            token: 'token'
+          },
+          {},
+          {
+            maxWaitMs: 100,
+            pollIntervalMs: 200
+          }
+        );
+        throw new Error('Expected options validation error, but none was thrown');
+      } catch (error) {
+        if (!error.message.includes('options.pollIntervalMs cannot be greater than options.maxWaitMs')) {
+          throw new Error(`Unexpected error message: ${error.message}`);
+        }
+      }
+    },
+  },
+  {
+    description: 'runDatabricksSql() should cap final polling sleep to remaining timeout budget',
+    test: () => {
+      const originalFetch = UrlFetchApp.fetch;
+      const originalSleep = Utilities.sleep;
+      const originalDateNow = Date.now;
+
+      let now = 0;
+      const sleepDurations = [];
+
+      UrlFetchApp.fetch = (_url, options = {}) => {
+        if (options.method === 'post') {
+          return {
+            getContentText: () => JSON.stringify({ statement_id: 'stmt-timeout' })
+          };
+        }
+
+        return {
+          getContentText: () => JSON.stringify({
+            status: { state: 'RUNNING' }
+          })
+        };
+      };
+
+      Utilities.sleep = ms => {
+        sleepDurations.push(ms);
+        now += ms;
+      };
+
+      Date.now = () => now;
+
+      try {
+        runDatabricksSql(
+          'select 1',
+          {
+            host: 'dbc.example.com',
+            sqlWarehouseId: 'w-1',
+            schema: 'default',
+            token: 'token'
+          },
+          {},
+          {
+            maxWaitMs: 1000,
+            pollIntervalMs: 600
+          }
+        );
+        throw new Error('Expected timeout error, but none was thrown');
+      } catch (error) {
+        if (!error.message.includes('timed out after 1000ms')) {
+          throw new Error(`Unexpected error message: ${error.message}`);
+        }
+      } finally {
+        UrlFetchApp.fetch = originalFetch;
+        Utilities.sleep = originalSleep;
+        Date.now = originalDateNow;
+      }
+
+      const expected = JSON.stringify([600, 400]);
+      const actual = JSON.stringify(sleepDurations);
+      if (actual !== expected) {
+        throw new Error(`Expected sleep durations ${expected}, got ${actual}`);
+      }
+    },
+  },
+];

--- a/apps_script_tools/testing/runTests.js
+++ b/apps_script_tools/testing/runTests.js
@@ -238,6 +238,7 @@ async function runAllTests() {
 
     // database Tests
 
+    ...DATABASE_RUN_DATABRICKS_SQL_TESTS,
     ...DATABASE_RUN_SQL_QUERY_TESTS,
   ];
 

--- a/docs/api/sql-contracts.md
+++ b/docs/api/sql-contracts.md
@@ -41,6 +41,7 @@ Validation rules:
 Notes:
 
 - Query execution uses Databricks SQL statements API.
+- Polling timeout is controlled by `options.maxWaitMs` / `options.pollIntervalMs`.
 - Results are downloaded in chunks and combined into a `DataFrame`.
 - Provider errors throw `DatabricksSqlError`.
 
@@ -101,6 +102,10 @@ Use `toTable` to write dataframe rows to provider tables.
     sqlWarehouseId: 'warehouse-id',
     schema: 'analytics',
     token: 'dapi...'
+  },
+  options: {
+    maxWaitMs: 120000,
+    pollIntervalMs: 500
   }
 }
 ```

--- a/tests/local/load-databricks-table.test.mjs
+++ b/tests/local/load-databricks-table.test.mjs
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createGasContext, loadScripts } from './helpers.mjs';
+
+const SCRIPT = 'apps_script_tools/database/databricks/loadDatabricksTable.js';
+
+function baseConfig(mode = 'insert') {
+  return {
+    arrays: [
+      ['id', 'name'],
+      [1, 'Alice'],
+      [2, 'Bob']
+    ],
+    tableName: 'analytics.users',
+    tableSchema: { id: 'INT', name: 'STRING' },
+    mode,
+    databricks_parameters: {
+      host: 'dbc.example.com',
+      sqlWarehouseId: 'warehouse-1',
+      schema: 'analytics',
+      token: 'token'
+    },
+    options: {
+      maxWaitMs: 5000,
+      pollIntervalMs: 250
+    }
+  };
+}
+
+test('loadDatabricksTable forwards options to each Databricks SQL statement', () => {
+  const captured = [];
+  const context = createGasContext({
+    runDatabricksSql: (...args) => {
+      captured.push(args);
+      return {};
+    }
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/utilities/array/arrayChunk.js',
+    SCRIPT
+  ]);
+
+  context.loadDatabricksTable(baseConfig('insert'));
+
+  assert.ok(captured.length >= 2);
+  assert.equal(
+    JSON.stringify(captured.map(args => args[3])),
+    JSON.stringify([
+      { maxWaitMs: 5000, pollIntervalMs: 250 },
+      { maxWaitMs: 5000, pollIntervalMs: 250 }
+    ])
+  );
+});
+
+test('loadDatabricksTable throws for unsupported write mode', () => {
+  const context = createGasContext({
+    runDatabricksSql: () => ({})
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/utilities/array/arrayChunk.js',
+    SCRIPT
+  ]);
+
+  assert.throws(
+    () => context.loadDatabricksTable(baseConfig('upsert')),
+    /Unsupported mode/
+  );
+});


### PR DESCRIPTION
## Summary
- add elapsed-time timeout controls to `runDatabricksSql` via `options.maxWaitMs` and `options.pollIntervalMs`
- enforce poll interval validation (`pollIntervalMs <= maxWaitMs`) in direct Databricks SQL calls
- forward table-load `config.options` through `loadDatabricksTable` into all Databricks SQL statements
- expand local and GAS tests for Databricks timeout behavior, option forwarding, and routing coverage
- update SQL contract docs for Databricks polling and table-load options

## Validation
- npm run lint
- npm run test:local
- npm run test:perf:check
- mkdocs build --strict
- clasp push
- clasp run runAllTests
- clasp run runPerformanceBenchmarks
