### PR TITLE
PR4: Harden Databricks load contracts and tests

### DIFF
--- a/apps_script_tools/testing/database/loadDatabricksTable.js
+++ b/apps_script_tools/testing/database/loadDatabricksTable.js
@@ -1,0 +1,112 @@
+const DATABASE_LOAD_DATABRICKS_TABLE_TESTS = [
+  {
+    description: 'loadDatabricksTable() should require mergeKey in merge mode',
+    test: () => {
+      try {
+        loadDatabricksTable({
+          arrays: [
+            ['id', 'name'],
+            [1, 'Alice']
+          ],
+          tableName: 'analytics.users',
+          tableSchema: { id: 'INT', name: 'STRING' },
+          mode: 'merge',
+          databricks_parameters: {
+            host: 'dbc.example.com',
+            sqlWarehouseId: 'w-1',
+            schema: 'analytics',
+            token: 'token'
+          }
+        });
+        throw new Error('Expected mergeKey validation error, but none was thrown');
+      } catch (error) {
+        if (!error.message.includes('mergeKey is required for merge mode')) {
+          throw new Error(`Unexpected error message: ${error.message}`);
+        }
+      }
+    },
+  },
+  {
+    description: 'loadDatabricksTable() should wrap provider failures with DatabricksLoadError',
+    test: () => {
+      const originalRunDatabricksSql = runDatabricksSql;
+
+      runDatabricksSql = () => {
+        const providerError = new Error('statement failed');
+        providerError.name = 'DatabricksSqlError';
+        throw providerError;
+      };
+
+      try {
+        loadDatabricksTable({
+          arrays: [
+            ['id', 'name'],
+            [1, 'Alice']
+          ],
+          tableName: 'analytics.users',
+          tableSchema: { id: 'INT', name: 'STRING' },
+          mode: 'insert',
+          databricks_parameters: {
+            host: 'dbc.example.com',
+            sqlWarehouseId: 'w-1',
+            schema: 'analytics',
+            token: 'token'
+          }
+        });
+        throw new Error('Expected DatabricksLoadError, but none was thrown');
+      } catch (error) {
+        if (error.name !== 'DatabricksLoadError') {
+          throw new Error(`Expected DatabricksLoadError, got ${error.name}`);
+        }
+      } finally {
+        runDatabricksSql = originalRunDatabricksSql;
+      }
+    },
+  },
+  {
+    description: 'loadDatabricksTable() should forward polling options to Databricks SQL statements',
+    test: () => {
+      const originalRunDatabricksSql = runDatabricksSql;
+      const capturedOptions = [];
+
+      runDatabricksSql = (sql, parameters, placeholders, options) => {
+        capturedOptions.push(options);
+        return {};
+      };
+
+      try {
+        loadDatabricksTable({
+          arrays: [
+            ['id', 'name'],
+            [1, 'Alice']
+          ],
+          tableName: 'analytics.users',
+          tableSchema: { id: 'INT', name: 'STRING' },
+          mode: 'insert',
+          databricks_parameters: {
+            host: 'dbc.example.com',
+            sqlWarehouseId: 'w-1',
+            schema: 'analytics',
+            token: 'token'
+          },
+          options: {
+            maxWaitMs: 2000,
+            pollIntervalMs: 250
+          }
+        });
+      } finally {
+        runDatabricksSql = originalRunDatabricksSql;
+      }
+
+      if (capturedOptions.length === 0) {
+        throw new Error('Expected runDatabricksSql to be called');
+      }
+
+      const expected = JSON.stringify({ maxWaitMs: 2000, pollIntervalMs: 250 });
+      const hasMismatch = capturedOptions.some(options => JSON.stringify(options) !== expected);
+      if (hasMismatch) {
+        throw new Error(`Expected all calls to receive ${expected}, got ${JSON.stringify(capturedOptions)}`);
+      }
+    },
+  },
+];

--- a/apps_script_tools/testing/runTests.js
+++ b/apps_script_tools/testing/runTests.js
@@ -238,6 +238,7 @@ async function runAllTests() {
 
     // database Tests
 
+    ...DATABASE_LOAD_DATABRICKS_TABLE_TESTS,
     ...DATABASE_RUN_DATABRICKS_SQL_TESTS,
     ...DATABASE_RUN_SQL_QUERY_TESTS,
   ];

--- a/docs/api/sql-contracts.md
+++ b/docs/api/sql-contracts.md
@@ -117,6 +117,8 @@ Use `toTable` to write dataframe rows to provider tables.
 - Unsafe placeholders without explicit opt-in: throws.
 - `toTable` with missing `config.tableSchema`: throws.
 - BigQuery load mode not in (`insert`, `overwrite`): throws.
+- Databricks load mode not in (`insert`, `overwrite`, `merge`): throws.
+- Databricks merge mode without `mergeKey`: throws.
 
 ## Provider error semantics
 
@@ -124,6 +126,10 @@ Use `toTable` to write dataframe rows to provider tables.
 - BigQuery execution/load failures throw errors from the provider path.
 - Databricks execution failures throw `DatabricksSqlError` with:
   - `name: "DatabricksSqlError"`
+  - `provider: "databricks"`
+  - optional `details` and `cause` fields for diagnostics
+- Databricks table-load failures throw `DatabricksLoadError` with:
+  - `name: "DatabricksLoadError"`
   - `provider: "databricks"`
   - optional `details` and `cause` fields for diagnostics
 

--- a/tests/local/load-databricks-table.test.mjs
+++ b/tests/local/load-databricks-table.test.mjs
@@ -68,3 +68,153 @@ test('loadDatabricksTable throws for unsupported write mode', () => {
     /Unsupported mode/
   );
 });
+
+test('loadDatabricksTable requires mergeKey in merge mode', () => {
+  const context = createGasContext({
+    runDatabricksSql: () => ({})
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/utilities/array/arrayChunk.js',
+    SCRIPT
+  ]);
+
+  const config = baseConfig('merge');
+  delete config.mergeKey;
+
+  assert.throws(
+    () => context.loadDatabricksTable(config),
+    /mergeKey is required for merge mode/
+  );
+});
+
+test('loadDatabricksTable validates mergeKey exists in headers', () => {
+  const context = createGasContext({
+    runDatabricksSql: () => ({})
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/utilities/array/arrayChunk.js',
+    SCRIPT
+  ]);
+
+  const config = baseConfig('merge');
+  config.mergeKey = 'missing_id';
+
+  assert.throws(
+    () => context.loadDatabricksTable(config),
+    /must exist in header columns/
+  );
+});
+
+test('loadDatabricksTable validates row width matches header width', () => {
+  const context = createGasContext({
+    runDatabricksSql: () => ({})
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/utilities/array/arrayChunk.js',
+    SCRIPT
+  ]);
+
+  const config = baseConfig('insert');
+  config.arrays = [
+    ['id', 'name'],
+    [1]
+  ];
+
+  assert.throws(
+    () => context.loadDatabricksTable(config),
+    /has length 1, expected 2/
+  );
+});
+
+test('loadDatabricksTable validates schema coverage for headers', () => {
+  const context = createGasContext({
+    runDatabricksSql: () => ({})
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/utilities/array/arrayChunk.js',
+    SCRIPT
+  ]);
+
+  const config = baseConfig('insert');
+  config.tableSchema = { id: 'INT' };
+
+  assert.throws(
+    () => context.loadDatabricksTable(config),
+    /tableSchema is missing definitions for columns: name/
+  );
+});
+
+test('loadDatabricksTable validates polling options', () => {
+  const context = createGasContext({
+    runDatabricksSql: () => ({})
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/utilities/array/arrayChunk.js',
+    SCRIPT
+  ]);
+
+  const config = baseConfig('insert');
+  config.options = {
+    maxWaitMs: 100,
+    pollIntervalMs: 200
+  };
+
+  assert.throws(
+    () => context.loadDatabricksTable(config),
+    /options\.pollIntervalMs cannot be greater than options\.maxWaitMs/
+  );
+});
+
+test('loadDatabricksTable wraps statement failures in DatabricksLoadError', () => {
+  const context = createGasContext({
+    runDatabricksSql: () => {
+      const err = new Error('statement failed');
+      err.name = 'DatabricksSqlError';
+      throw err;
+    }
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/utilities/array/arrayChunk.js',
+    SCRIPT
+  ]);
+
+  assert.throws(
+    () => context.loadDatabricksTable(baseConfig('insert')),
+    error => {
+      assert.equal(error.name, 'DatabricksLoadError');
+      assert.match(error.message, /Databricks load failed during create table/);
+      assert.equal(error.provider, 'databricks');
+      assert.equal(error.cause.name, 'DatabricksSqlError');
+      return true;
+    }
+  );
+});
+
+test('loadDatabricksTable executes merge statements when mergeKey is valid', () => {
+  const capturedSql = [];
+  const context = createGasContext({
+    runDatabricksSql: (sql) => {
+      capturedSql.push(sql);
+      return {};
+    }
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/utilities/array/arrayChunk.js',
+    SCRIPT
+  ]);
+
+  const config = baseConfig('merge');
+  config.mergeKey = 'id';
+
+  context.loadDatabricksTable(config);
+
+  const hasMergeStatement = capturedSql.some(sql => String(sql).toLowerCase().includes('merge into'));
+  assert.equal(hasMergeStatement, true);
+});


### PR DESCRIPTION
## Summary
- Harden loadDatabricksTable config and payload validation with typed DatabricksLoadError.
- Wrap Databricks SQL statement failures with deterministic load-phase errors and preserved cause.
- Add local and GAS tests for merge key requirements, option validation, row/schema validation, error wrapping, and option forwarding.
- Document Databricks table-load error semantics in SQL contracts docs.

## Validation
- npm run lint
- npm run test:local
- npm run test:perf:check
- mkdocs build --strict
- clasp run runAllTests (1447/1447)
- clasp run runPerformanceBenchmarks
