### PR TITLE
PR5: Enforce clasp hygiene guardrails

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,6 +33,16 @@ Use a local `.clasp.json` (not committed):
 
 - root `.claspignore` is the only authoritative ignore file for `clasp` operations.
 - do not add nested `.claspignore` files under `apps_script_tools/`.
+- keep `.clasp.json` local-only (untracked) and use `.clasp.json.example` as the committed template.
+
+Repository guardrails (enforced by `npm run lint`):
+
+- root `.claspignore` must exist.
+- `apps_script_tools/.claspignore` must not exist.
+- `.clasp.json.example` must remain a valid template with:
+  - `"scriptId": "<YOUR_SCRIPT_ID>"`
+  - `"rootDir": "apps_script_tools"`
+- tracked secret/config files are blocked (`.clasp.json`, `.clasprc.json`, `creds.json`, `client_secret.json`).
 
 Publish flow:
 

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -43,6 +43,31 @@ if (!Array.isArray(manifest.oauthScopes) || manifest.oauthScopes.length === 0) {
   findings.push('Manifest must declare explicit oauthScopes');
 }
 
+const rootClaspIgnorePath = path.join(ROOT, '.claspignore');
+if (!fs.existsSync(rootClaspIgnorePath)) {
+  findings.push('Root .claspignore is required and is the only allowed clasp ignore file.');
+}
+
+const claspTemplatePath = path.join(ROOT, '.clasp.json.example');
+if (!fs.existsSync(claspTemplatePath)) {
+  findings.push('Missing .clasp.json.example template.');
+} else {
+  try {
+    const claspTemplate = JSON.parse(readText(claspTemplatePath));
+    if (typeof claspTemplate.scriptId !== 'string' || claspTemplate.scriptId.trim().length === 0) {
+      findings.push('.clasp.json.example must define a non-empty scriptId placeholder.');
+    } else if (claspTemplate.scriptId !== '<YOUR_SCRIPT_ID>') {
+      findings.push('.clasp.json.example scriptId should remain <YOUR_SCRIPT_ID> placeholder.');
+    }
+
+    if (claspTemplate.rootDir !== 'apps_script_tools') {
+      findings.push('.clasp.json.example rootDir must be "apps_script_tools".');
+    }
+  } catch (error) {
+    findings.push(`.clasp.json.example must be valid JSON: ${error.message}`);
+  }
+}
+
 const nestedClaspIgnorePath = path.join(APPS_DIR, '.claspignore');
 if (fs.existsSync(nestedClaspIgnorePath)) {
   findings.push('Nested apps_script_tools/.claspignore is not allowed. Use root .claspignore only.');


### PR DESCRIPTION
## Summary
- enforce root clasp model in lint by requiring root .claspignore
- enforce canonical .clasp.json.example template shape and placeholder values
- retain existing nested .claspignore and tracked-secret guards, now with explicit release documentation
- document repository guardrails in RELEASE.md

## Validation
- npm run lint
- npm run test:local
- mkdocs build --strict
