### PR TITLE
PR9: SQL provider adapter routing for ASTX.Sql.run

### DIFF
--- a/apps_script_tools/database/general/sqlProviderAdapters.js
+++ b/apps_script_tools/database/general/sqlProviderAdapters.js
@@ -1,0 +1,77 @@
+function buildSqlProviderValidationError(message, details = {}, cause = null) {
+  const error = new Error(message);
+  error.name = 'SqlProviderValidationError';
+  error.provider = details.provider || 'sql_router';
+  error.details = details;
+  if (cause) {
+    error.cause = cause;
+  }
+  return error;
+}
+
+function astCreateBigQuerySqlAdapter() {
+  return {
+    provider: 'bigquery',
+    capabilities: {
+      supportsPlaceholders: true,
+      supportsTimeoutOptions: true,
+      supportsTableLoad: true
+    },
+    validateRequest: request => request,
+    executeQuery: request => {
+      return runBigQuerySql(
+        request.sql,
+        request.parameters,
+        request.placeholders,
+        request.options
+      );
+    },
+    classifyError: error => error
+  };
+}
+
+function astCreateDatabricksSqlAdapter() {
+  return {
+    provider: 'databricks',
+    capabilities: {
+      supportsPlaceholders: true,
+      supportsTimeoutOptions: true,
+      supportsTableLoad: true
+    },
+    validateRequest: request => request,
+    executeQuery: request => {
+      return runDatabricksSql(
+        request.sql,
+        request.parameters,
+        request.placeholders,
+        request.options
+      );
+    },
+    classifyError: error => error
+  };
+}
+
+const AST_SQL_PROVIDER_ADAPTERS = {
+  bigquery: astCreateBigQuerySqlAdapter(),
+  databricks: astCreateDatabricksSqlAdapter()
+};
+
+function astGetSqlProviderAdapter(provider) {
+  const adapter = AST_SQL_PROVIDER_ADAPTERS[provider];
+
+  if (!adapter) {
+    throw buildSqlProviderValidationError(
+      'Provider must be one of: databricks, bigquery',
+      {
+        provider,
+        supportedProviders: Object.keys(AST_SQL_PROVIDER_ADAPTERS)
+      }
+    );
+  }
+
+  return adapter;
+}
+
+function astListSqlProviders() {
+  return Object.keys(AST_SQL_PROVIDER_ADAPTERS);
+}

--- a/apps_script_tools/testing/database/runSqlQuery.js
+++ b/apps_script_tools/testing/database/runSqlQuery.js
@@ -1,5 +1,28 @@
 const DATABASE_RUN_SQL_QUERY_TESTS = [
   {
+    description: 'sql provider adapter registry should list supported providers',
+    test: () => {
+      const providers = astListSqlProviders();
+      const expected = JSON.stringify(['bigquery', 'databricks']);
+      if (JSON.stringify(providers) !== expected) {
+        throw new Error(`Expected providers ${expected}, got ${JSON.stringify(providers)}`);
+      }
+    },
+  },
+  {
+    description: 'sql provider adapter registry should throw typed validation errors for unknown providers',
+    test: () => {
+      try {
+        astGetSqlProviderAdapter('snowflake');
+        throw new Error('Expected astGetSqlProviderAdapter to throw');
+      } catch (error) {
+        if (error.name !== 'SqlProviderValidationError') {
+          throw new Error(`Expected SqlProviderValidationError, got ${error.name}`);
+        }
+      }
+    },
+  },
+  {
     description: 'runSqlQuery() should reject unsafe placeholders by default',
     test: () => {
       const request = {

--- a/docs/api/sql-contracts.md
+++ b/docs/api/sql-contracts.md
@@ -27,6 +27,12 @@ Validation rules:
 - `options.maxWaitMs` and `options.pollIntervalMs` must be positive integers when provided.
 - `options.pollIntervalMs` cannot be greater than `options.maxWaitMs`.
 
+Internal routing notes:
+
+- `ASTX.Sql.run(...)` resolves provider execution through an internal adapter registry.
+- adapters expose `validateRequest`, `executeQuery`, and `classifyError` contracts.
+- this adapter layer is internal; public request/response behavior remains unchanged.
+
 ### Databricks parameters
 
 ```javascript
@@ -119,6 +125,7 @@ Use `toTable` to write dataframe rows to provider tables.
 - BigQuery load mode not in (`insert`, `overwrite`): throws.
 - Databricks load mode not in (`insert`, `overwrite`, `merge`): throws.
 - Databricks merge mode without `mergeKey`: throws.
+- Adapter lookup for unknown providers throws `SqlProviderValidationError`.
 
 ## Provider error semantics
 

--- a/tests/local/sql-provider-adapters.test.mjs
+++ b/tests/local/sql-provider-adapters.test.mjs
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createGasContext, loadScripts } from './helpers.mjs';
+
+function createContext(overrides = {}) {
+  return createGasContext({
+    runDatabricksSql: () => ({ provider: 'databricks' }),
+    runBigQuerySql: () => ({ provider: 'bigquery' }),
+    ...overrides
+  });
+}
+
+test('astListSqlProviders returns supported provider keys', () => {
+  const context = createContext();
+
+  loadScripts(context, [
+    'apps_script_tools/database/general/sqlProviderAdapters.js'
+  ]);
+
+  assert.equal(
+    JSON.stringify(context.astListSqlProviders()),
+    JSON.stringify(['bigquery', 'databricks'])
+  );
+});
+
+test('astGetSqlProviderAdapter returns typed validation error for unknown providers', () => {
+  const context = createContext();
+
+  loadScripts(context, [
+    'apps_script_tools/database/general/sqlProviderAdapters.js'
+  ]);
+
+  assert.throws(
+    () => context.astGetSqlProviderAdapter('snowflake'),
+    error => {
+      assert.equal(error.name, 'SqlProviderValidationError');
+      assert.equal(error.provider, 'snowflake');
+      assert.match(error.message, /Provider must be one of: databricks, bigquery/);
+      return true;
+    }
+  );
+});
+
+test('runSqlQuery uses adapter registry dispatch for provider execution', () => {
+  const calls = [];
+  const context = createContext({
+    runDatabricksSql: () => {
+      calls.push('databricks');
+      return { provider: 'databricks' };
+    },
+    runBigQuerySql: () => {
+      calls.push('bigquery');
+      return { provider: 'bigquery' };
+    }
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/database/general/validateSqlRequest.js',
+    'apps_script_tools/database/general/sqlProviderAdapters.js',
+    'apps_script_tools/database/general/runSqlQuery.js'
+  ]);
+
+  context.runSqlQuery({
+    provider: 'bigquery',
+    sql: 'select 1',
+    parameters: { projectId: 'project-1' }
+  });
+
+  context.runSqlQuery({
+    provider: 'databricks',
+    sql: 'select 1',
+    parameters: {
+      host: 'dbc.example.com',
+      sqlWarehouseId: 'warehouse',
+      schema: 'default',
+      token: 'token'
+    }
+  });
+
+  assert.equal(JSON.stringify(calls), JSON.stringify(['bigquery', 'databricks']));
+});

--- a/tests/local/sql-provider-validation.test.mjs
+++ b/tests/local/sql-provider-validation.test.mjs
@@ -10,6 +10,7 @@ test('runSqlQuery validates required BigQuery parameters', () => {
 
   loadScripts(context, [
     'apps_script_tools/database/general/validateSqlRequest.js',
+    'apps_script_tools/database/general/sqlProviderAdapters.js',
     'apps_script_tools/database/general/runSqlQuery.js'
   ]);
 
@@ -30,6 +31,7 @@ test('runSqlQuery validates required Databricks parameters', () => {
 
   loadScripts(context, [
     'apps_script_tools/database/general/validateSqlRequest.js',
+    'apps_script_tools/database/general/sqlProviderAdapters.js',
     'apps_script_tools/database/general/runSqlQuery.js'
   ]);
 
@@ -58,6 +60,7 @@ test('runSqlQuery forwards normalized options to BigQuery provider', () => {
 
   loadScripts(context, [
     'apps_script_tools/database/general/validateSqlRequest.js',
+    'apps_script_tools/database/general/sqlProviderAdapters.js',
     'apps_script_tools/database/general/runSqlQuery.js'
   ]);
 
@@ -99,6 +102,7 @@ test('runSqlQuery forwards default options to Databricks provider', () => {
 
   loadScripts(context, [
     'apps_script_tools/database/general/validateSqlRequest.js',
+    'apps_script_tools/database/general/sqlProviderAdapters.js',
     'apps_script_tools/database/general/runSqlQuery.js'
   ]);
 
@@ -135,6 +139,7 @@ test('runSqlQuery forwards custom options to Databricks provider', () => {
 
   loadScripts(context, [
     'apps_script_tools/database/general/validateSqlRequest.js',
+    'apps_script_tools/database/general/sqlProviderAdapters.js',
     'apps_script_tools/database/general/runSqlQuery.js'
   ]);
 
@@ -180,6 +185,7 @@ test('runSqlQuery rejects options.pollIntervalMs larger than options.maxWaitMs',
 
   loadScripts(context, [
     'apps_script_tools/database/general/validateSqlRequest.js',
+    'apps_script_tools/database/general/sqlProviderAdapters.js',
     'apps_script_tools/database/general/runSqlQuery.js'
   ]);
 

--- a/tests/local/sql-validation.test.mjs
+++ b/tests/local/sql-validation.test.mjs
@@ -10,6 +10,7 @@ test('runSqlQuery rejects placeholders unless unsafe option is enabled', () => {
 
   loadScripts(context, [
     'apps_script_tools/database/general/validateSqlRequest.js',
+    'apps_script_tools/database/general/sqlProviderAdapters.js',
     'apps_script_tools/database/general/runSqlQuery.js'
   ]);
 


### PR DESCRIPTION
Summary
- add internal SQL provider adapter registry with adapter contracts for BigQuery and Databricks
- refactor runSqlQuery to dispatch via adapter validate/execute/classify methods
- add adapter contract coverage in local and GAS tests
- keep public ASTX.Sql.run request/response behavior unchanged
- document adapter routing notes in SQL contracts docs

Validation
- npm run lint
- npm run test:local
- npm run test:perf:check
- mkdocs build --strict
- clasp push
- clasp run runAllTests (1457/1457)
- clasp run runPerformanceBenchmarks
