### PR TITLE
docs: sync Jobs namespace coverage across README and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   - `get`, `set`, `delete`, `invalidateByTag`, `stats`
   - `backends`, `capabilities`
   - `configure`, `getConfig`, `clearConfig`, `clear`
+- New `AST.Jobs` namespace with:
+  - `run`, `enqueue`, `resume`, `status`, `list`, `cancel`
+  - `configure`, `getConfig`, `clearConfig`
 - Cache backend support:
   - `memory`
   - `drive_json`

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - `AST.Storage`: object storage CRUD for GCS, S3, and DBFS
 - `AST.Cache`: backend-agnostic caching (memory, Drive JSON, script properties, Storage URI)
 - `AST.Telemetry`: trace spans/events with redaction and sink controls
+- `AST.Jobs`: checkpointed multi-step job orchestration with retry/resume semantics
 - `AST.AI`: unified AI providers, structured outputs, tools, and image flows
 - `AST.RAG`: Drive indexing, retrieval, and grounded Q&A with citations
 - `AST.Sql`: Databricks/BigQuery execution with prepared statements + status/cancel controls
@@ -58,6 +59,7 @@ Current release state:
 - SQL ergonomics: `prepare`, `executePrepared`, `status`, and `cancel` on top of provider-routed `run`.
 - New `AST.Cache` module with deterministic TTL semantics, tag invalidation, and backend selection.
 - New `AST.Telemetry` module with typed spans/events, secret redaction, and `logger`/Drive NDJSON sinks.
+- New `AST.Jobs` module with persisted checkpoint store and run/enqueue/resume/status/list/cancel contracts.
 - DataFrame schema contracts with `validateSchema(...)` reporting and `enforceSchema(...)` strict/coercion pathways.
 - `AST.AI.tools(...)` guardrails for timeout, payload caps, retries, and idempotent replay.
 - `AST.AI.structured(...)` reliability policy with schema retries and optional JSON/LLM repair.

--- a/docs/api/jobs-contracts.md
+++ b/docs/api/jobs-contracts.md
@@ -1,0 +1,188 @@
+# Jobs Contracts
+
+`ASTX.Jobs` provides checkpointed job orchestration for bounded multi-step workflows in Apps Script.
+
+## Import pattern
+
+```javascript
+const ASTX = ASTLib.AST || ASTLib;
+```
+
+## Public API
+
+```javascript
+ASTX.Jobs.run(request)
+ASTX.Jobs.enqueue(request)
+ASTX.Jobs.resume(jobId, options)
+ASTX.Jobs.status(jobId, options)
+ASTX.Jobs.list(filters, options)
+ASTX.Jobs.cancel(jobId, options)
+ASTX.Jobs.configure(config, options)
+ASTX.Jobs.getConfig()
+ASTX.Jobs.clearConfig()
+```
+
+## Run/Enqueue request contract
+
+```javascript
+{
+  name: 'job-name',
+  steps: [
+    {
+      id: 'step_id',
+      handler: 'globalFunctionName', // or named function reference
+      dependsOn: ['optional_step_id'],
+      payload: { ... } // optional
+    }
+  ],
+  options: {
+    maxRetries: 2,               // 0..20
+    maxRuntimeMs: 240000,        // 1000..600000
+    checkpointStore: 'properties',
+    autoResume: true,
+    propertyPrefix: 'AST_JOBS_JOB_'
+  }
+}
+```
+
+Validation rules:
+
+- `name` must be a non-empty string.
+- `steps` must be non-empty with unique `id`.
+- dependency graph must be valid (no unknown refs, no cycles, no self dependency).
+- step handlers must resolve to globally available named functions.
+- async step handlers are not supported.
+- step outputs must be JSON serializable.
+
+## Job status model
+
+Job status values:
+
+- `queued`
+- `running`
+- `paused`
+- `failed`
+- `completed`
+- `canceled`
+
+Step status values:
+
+- `pending`
+- `running`
+- `completed`
+- `failed`
+- `canceled`
+
+## List filters
+
+```javascript
+{
+  status: 'queued|running|paused|failed|completed|canceled',
+  name: 'optional exact job name',
+  limit: 100 // 1..1000
+}
+```
+
+## Runtime config and precedence
+
+Runtime config can be set with:
+
+```javascript
+ASTX.Jobs.configure({
+  maxRetries: 2,
+  maxRuntimeMs: 240000,
+  checkpointStore: 'properties',
+  propertyPrefix: 'AST_JOBS_JOB_'
+});
+```
+
+Resolution precedence:
+
+1. per-call request/options
+2. `ASTX.Jobs.configure(...)` runtime config
+3. script properties
+4. built-in defaults
+
+Supported script property keys:
+
+- `AST_JOBS_DEFAULT_MAX_RETRIES`
+- `AST_JOBS_DEFAULT_MAX_RUNTIME_MS`
+- `AST_JOBS_CHECKPOINT_STORE`
+- `AST_JOBS_PROPERTY_PREFIX`
+
+Current capability note:
+
+- `checkpointStore='properties'` is currently the only supported checkpoint store.
+
+## Response shape
+
+All operational calls (`run`, `enqueue`, `resume`, `status`, `cancel`) return a persisted job record:
+
+```javascript
+{
+  id: 'job_...',
+  name: 'job-name',
+  status: 'queued|running|paused|failed|completed|canceled',
+  createdAt: 'ISO-8601',
+  updatedAt: 'ISO-8601',
+  startedAt: 'ISO-8601|null',
+  completedAt: 'ISO-8601|null',
+  pausedAt: 'ISO-8601|null',
+  canceledAt: 'ISO-8601|null',
+  lastError: { name, message, details } | null,
+  options: { ...resolvedOptions },
+  steps: [
+    {
+      id,
+      handlerName,
+      dependsOn: [],
+      state,
+      attempts,
+      startedAt,
+      completedAt,
+      lastError
+    }
+  ],
+  results: {
+    step_id: {}
+  }
+}
+```
+
+`ASTX.Jobs.list(...)` returns an array of job records.
+
+## Typed errors
+
+- `AstJobsError`
+- `AstJobsValidationError`
+- `AstJobsNotFoundError`
+- `AstJobsConflictError`
+- `AstJobsStepExecutionError`
+- `AstJobsCapabilityError`
+
+## Example
+
+```javascript
+function extractStep(ctx) {
+  return { rows: 100, payload: ctx.payload };
+}
+
+function publishStep(ctx) {
+  return { published: true, previous: ctx.results.extract };
+}
+
+function runJobsExample() {
+  const ASTX = ASTLib.AST || ASTLib;
+
+  const queued = ASTX.Jobs.enqueue({
+    name: 'demo-job',
+    steps: [
+      { id: 'extract', handler: 'extractStep', payload: { source: 'sheet' } },
+      { id: 'publish', handler: 'publishStep', dependsOn: ['extract'] }
+    ]
+  });
+
+  const completed = ASTX.Jobs.resume(queued.id);
+  Logger.log(completed.status);
+}
+```

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -22,6 +22,7 @@ ASTX.RAG
 ASTX.Cache
 ASTX.Storage
 ASTX.Telemetry
+ASTX.Jobs
 ASTX.Sql
 ASTX.Utils
 ```
@@ -193,6 +194,20 @@ ASTX.Telemetry.recordEvent(event)
 ASTX.Telemetry.getTrace(traceId)
 ```
 
+## `Jobs` essentials
+
+```javascript
+ASTX.Jobs.run(request)
+ASTX.Jobs.enqueue(request)
+ASTX.Jobs.resume(jobId, options)
+ASTX.Jobs.status(jobId, options)
+ASTX.Jobs.list(filters, options)
+ASTX.Jobs.cancel(jobId, options)
+ASTX.Jobs.configure(config, options)
+ASTX.Jobs.getConfig()
+ASTX.Jobs.clearConfig()
+```
+
 ## High-signal behavior notes
 
 - `Series.query` rejects string predicates.
@@ -223,3 +238,5 @@ ASTX.Telemetry.getTrace(traceId)
 - Storage `exists` returns `output.exists.exists` instead of throwing on not-found.
 - Storage `copy/move` require same-provider source and destination in this release.
 - Telemetry records redact secrets by default and can emit to `logger` or Drive NDJSON (`drive_json`).
+- Jobs step handlers must be globally resolvable named functions and return JSON-serializable values.
+- Jobs checkpoint storage currently supports `checkpointStore='properties'` only.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -98,6 +98,33 @@ function quickstartUtils() {
 }
 ```
 
+## Jobs workflow
+
+```javascript
+function quickstartJobs() {
+  const ASTX = ASTLib.AST || ASTLib;
+
+  const queued = ASTX.Jobs.enqueue({
+    name: 'quickstart-job',
+    steps: [
+      { id: 'step_one', handler: 'quickstartStepOne' },
+      { id: 'step_two', handler: 'quickstartStepTwo', dependsOn: ['step_one'] }
+    ]
+  });
+
+  const result = ASTX.Jobs.resume(queued.id);
+  Logger.log(result.status);
+}
+
+function quickstartStepOne() {
+  return { ok: true };
+}
+
+function quickstartStepTwo(context) {
+  return { previous: context.results.step_one };
+}
+```
+
 ## AI text workflow
 
 ```javascript

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@
 - `AST.Storage`: cross-provider object storage for GCS, S3, and DBFS.
 - `AST.Cache`: backend-agnostic cache layer for repeated computations and API responses.
 - `AST.Telemetry`: request-level tracing spans/events with redaction and sink controls.
+- `AST.Jobs`: checkpointed multi-step job runner with retry/resume and status controls.
 - `AST.Sql`: validated SQL execution for Databricks and BigQuery.
 - `AST.Utils`: utility helpers (`arraySum`, `dateAdd`, `toSnakeCase`, and others).
 
@@ -38,6 +39,7 @@ flowchart LR
     B --> M[AST.Storage]
     B --> Q[AST.Cache]
     B --> O[AST.Telemetry]
+    B --> T[AST.Jobs]
     D --> F[BigQuery]
     D --> G[Databricks SQL API]
     I --> J[OpenAI / Gemini / Vertex / OpenRouter / Perplexity]
@@ -45,6 +47,7 @@ flowchart LR
     M --> N[GCS / S3 / DBFS APIs]
     Q --> R[Memory / Drive JSON / Script Properties]
     O --> P[Logger / Drive NDJSON]
+    T --> U[Script Properties Checkpoints]
     C --> H[Records / Arrays / Sheets]
 ```
 
@@ -64,6 +67,7 @@ flowchart LR
 - `AST.Storage` unified CRUD contracts (`list`, `head`, `read`, `write`, `delete`) for `gcs`, `s3`, and `dbfs`.
 - `AST.Cache` cache contracts (`get`, `set`, `delete`, `invalidateByTag`, `stats`) for `memory`, `drive_json`, `script_properties`, and `storage_json` (`gcs://`, `s3://`, `dbfs:/`).
 - `AST.Telemetry` observability foundation (`startSpan`, `endSpan`, `recordEvent`, `getTrace`) with redaction and sink control.
+- `AST.Jobs` orchestration contracts (`run`, `enqueue`, `resume`, `status`, `list`, `cancel`) with persisted checkpoint state.
 
 ## Import pattern
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
     - Quick Reference: api/quick-reference.md
     - Tools: api/tools.md
     - Telemetry Contracts: api/telemetry-contracts.md
+    - Jobs Contracts: api/jobs-contracts.md
     - AI Contracts: api/ai-contracts.md
     - AI Providers: api/ai-providers.md
     - AI Tool Calling: api/ai-tool-calling.md


### PR DESCRIPTION
Summary
- add missing AST.Jobs namespace coverage in README and docs home/quick-reference/tools pages
- add dedicated Jobs API contract page with request/response/error model
- add Jobs quickstart snippet and wire Jobs Contracts into MkDocs nav
- align changelog release-line docs coverage to include AST.Jobs

Validation
- npm run lint
- mkdocs build --strict