### PR TITLE
Add AST Config/Runtime bootstrap and TelemetryHelpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - New `AST.Jobs` namespace with:
   - `run`, `enqueue`, `resume`, `status`, `list`, `cancel`
   - `configure`, `getConfig`, `clearConfig`
+- New `AST.Config` namespace with:
+  - `fromScriptProperties(options)` for normalized script property snapshots.
+- New `AST.Runtime` namespace with:
+  - `configureFromProps(options)` and `modules()` for one-shot runtime bootstrap.
 - Cache backend support:
   - `memory`
   - `drive_json`
@@ -39,6 +43,9 @@
 - New `AST.Telemetry` namespace with:
   - `configure`, `getConfig`, `clearConfig`
   - `startSpan`, `endSpan`, `recordEvent`, `getTrace`
+- New `AST.TelemetryHelpers` namespace with:
+  - `startSpanSafe`, `endSpanSafe`, `recordEventSafe`
+  - `withSpan`, `wrap`
 - Telemetry foundation module with:
   - typed errors (`AstTelemetryError`, `AstTelemetryValidationError`, `AstTelemetryCapabilityError`)
   - secret redaction (`apiKey`, `token`, `authorization`, `cookie`, etc.)
@@ -116,7 +123,10 @@
 - `AST` namespace now exposes `AST.RAG`.
 - `AST` namespace now exposes `AST.Cache`.
 - `AST` namespace now exposes `AST.Storage`.
+- `AST` namespace now exposes `AST.Config`.
+- `AST` namespace now exposes `AST.Runtime`.
 - `AST` namespace now exposes `AST.Telemetry`.
+- `AST` namespace now exposes `AST.TelemetryHelpers`.
 - Local test harness defaults now include `Utilities.base64Encode` and `MimeType.PLAIN_TEXT` for deterministic RAG runtime tests.
 - GAS functional suite now includes RAG namespace and grounded-answer smoke coverage.
 - GAS functional suite now includes telemetry namespace smoke coverage.

--- a/apps_script_tools/AST.js
+++ b/apps_script_tools/AST.js
@@ -145,8 +145,20 @@ Object.defineProperties(AST, {
     get: () => resolveAstBinding('AST_STORAGE', () => (typeof AST_STORAGE === 'undefined' ? undefined : AST_STORAGE)),
     enumerable: true
   },
+  Config: {
+    get: () => resolveAstBinding('AST_CONFIG', () => (typeof AST_CONFIG === 'undefined' ? undefined : AST_CONFIG)),
+    enumerable: true
+  },
+  Runtime: {
+    get: () => resolveAstBinding('AST_RUNTIME', () => (typeof AST_RUNTIME === 'undefined' ? undefined : AST_RUNTIME)),
+    enumerable: true
+  },
   Telemetry: {
     get: () => resolveAstBinding('AST_TELEMETRY', () => (typeof AST_TELEMETRY === 'undefined' ? undefined : AST_TELEMETRY)),
+    enumerable: true
+  },
+  TelemetryHelpers: {
+    get: () => resolveAstBinding('AST_TELEMETRY_HELPERS', () => (typeof AST_TELEMETRY_HELPERS === 'undefined' ? undefined : AST_TELEMETRY_HELPERS)),
     enumerable: true
   },
   Jobs: {

--- a/apps_script_tools/config/Config.js
+++ b/apps_script_tools/config/Config.js
@@ -1,0 +1,210 @@
+function astConfigIsPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function astConfigNormalizeString(value, fallback = '') {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function astConfigNormalizeBoolean(value, fallback = false) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  return fallback;
+}
+
+function astConfigNormalizeKeys(keys) {
+  if (!Array.isArray(keys)) {
+    return null;
+  }
+
+  const output = [];
+  const seen = {};
+
+  for (let idx = 0; idx < keys.length; idx += 1) {
+    const normalized = astConfigNormalizeString(keys[idx], '');
+    if (!normalized || seen[normalized]) {
+      continue;
+    }
+
+    seen[normalized] = true;
+    output.push(normalized);
+  }
+
+  return output;
+}
+
+function astConfigNormalizeValue(value, includeEmpty = false) {
+  if (value == null) {
+    return includeEmpty ? '' : null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+
+    return includeEmpty ? '' : null;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return null;
+}
+
+function astConfigResolveScriptPropertiesHandle(options = {}) {
+  const providedHandle = options.scriptProperties;
+  if (
+    providedHandle &&
+    (
+      typeof providedHandle.getProperties === 'function'
+      || typeof providedHandle.getProperty === 'function'
+    )
+  ) {
+    return providedHandle;
+  }
+
+  try {
+    if (
+      typeof PropertiesService !== 'undefined'
+      && PropertiesService
+      && typeof PropertiesService.getScriptProperties === 'function'
+    ) {
+      return PropertiesService.getScriptProperties();
+    }
+  } catch (_error) {
+    // Intentionally swallow script property access failures.
+  }
+
+  return null;
+}
+
+function astConfigReadEntriesFromHandle(handle, requestedKeys = null) {
+  if (!handle) {
+    return {};
+  }
+
+  const output = {};
+  const hasRequestedKeys = Array.isArray(requestedKeys);
+
+  if (typeof handle.getProperties === 'function') {
+    const map = handle.getProperties();
+    if (astConfigIsPlainObject(map)) {
+      const keys = hasRequestedKeys ? requestedKeys : Object.keys(map);
+
+      for (let idx = 0; idx < keys.length; idx += 1) {
+        const key = keys[idx];
+        if (Object.prototype.hasOwnProperty.call(map, key)) {
+          output[key] = map[key];
+        }
+      }
+    }
+  }
+
+  if (hasRequestedKeys && typeof handle.getProperty === 'function') {
+    for (let idx = 0; idx < requestedKeys.length; idx += 1) {
+      const key = requestedKeys[idx];
+      if (Object.prototype.hasOwnProperty.call(output, key)) {
+        continue;
+      }
+
+      const value = handle.getProperty(key);
+      if (typeof value !== 'undefined') {
+        output[key] = value;
+      }
+    }
+  }
+
+  return output;
+}
+
+function astConfigBuildOutput(entries, options = {}) {
+  const includeEmpty = astConfigNormalizeBoolean(options.includeEmpty, false);
+  const requestedKeys = astConfigNormalizeKeys(options.keys);
+  const prefix = astConfigNormalizeString(options.prefix, '');
+  const stripPrefix = astConfigNormalizeBoolean(options.stripPrefix, false);
+  const keys = Array.isArray(requestedKeys) ? requestedKeys : Object.keys(entries || {}).sort();
+  const output = {};
+
+  for (let idx = 0; idx < keys.length; idx += 1) {
+    const sourceKey = astConfigNormalizeString(keys[idx], '');
+    if (!sourceKey) {
+      continue;
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(entries, sourceKey)) {
+      continue;
+    }
+
+    if (prefix && !sourceKey.startsWith(prefix)) {
+      continue;
+    }
+
+    const targetKey = stripPrefix && prefix
+      ? sourceKey.slice(prefix.length)
+      : sourceKey;
+
+    const normalizedKey = astConfigNormalizeString(targetKey, '');
+    if (!normalizedKey) {
+      continue;
+    }
+
+    const normalizedValue = astConfigNormalizeValue(entries[sourceKey], includeEmpty);
+    if (normalizedValue == null) {
+      continue;
+    }
+
+    output[normalizedKey] = normalizedValue;
+  }
+
+  return output;
+}
+
+function astConfigFromScriptProperties(options = {}) {
+  if (!astConfigIsPlainObject(options)) {
+    throw new Error('AST.Config.fromScriptProperties options must be an object');
+  }
+
+  const requestedKeys = astConfigNormalizeKeys(options.keys);
+
+  if (astConfigIsPlainObject(options.properties)) {
+    return astConfigBuildOutput(options.properties, Object.assign({}, options, {
+      keys: requestedKeys
+    }));
+  }
+
+  if (
+    astConfigIsPlainObject(options.scriptProperties)
+    && typeof options.scriptProperties.getProperties !== 'function'
+    && typeof options.scriptProperties.getProperty !== 'function'
+  ) {
+    return astConfigBuildOutput(options.scriptProperties, Object.assign({}, options, {
+      keys: requestedKeys
+    }));
+  }
+
+  const scriptProperties = astConfigResolveScriptPropertiesHandle(options);
+  const entries = astConfigReadEntriesFromHandle(scriptProperties, requestedKeys);
+  return astConfigBuildOutput(entries, Object.assign({}, options, {
+    keys: requestedKeys
+  }));
+}
+
+const AST_CONFIG = Object.freeze({
+  fromScriptProperties: astConfigFromScriptProperties
+});
+
+const __astConfigRoot = typeof globalThis !== 'undefined' ? globalThis : this;
+__astConfigRoot.astConfigFromScriptProperties = astConfigFromScriptProperties;
+__astConfigRoot.AST_CONFIG = AST_CONFIG;
+this.astConfigFromScriptProperties = astConfigFromScriptProperties;
+this.AST_CONFIG = AST_CONFIG;

--- a/apps_script_tools/runtime/Runtime.js
+++ b/apps_script_tools/runtime/Runtime.js
@@ -1,0 +1,423 @@
+const AST_RUNTIME_MODULE_DEFINITIONS = Object.freeze([
+  { name: 'AI', globalName: 'AST_AI' },
+  { name: 'RAG', globalName: 'AST_RAG' },
+  { name: 'Cache', globalName: 'AST_CACHE' },
+  { name: 'Storage', globalName: 'AST_STORAGE' },
+  { name: 'Telemetry', globalName: 'AST_TELEMETRY' },
+  { name: 'Jobs', globalName: 'AST_JOBS' }
+]);
+
+const AST_RUNTIME_MODULE_ALIAS_MAP = Object.freeze({
+  AI: 'AI',
+  ASTAI: 'AI',
+  RAG: 'RAG',
+  ASTRAG: 'RAG',
+  CACHE: 'Cache',
+  ASTCACHE: 'Cache',
+  STORAGE: 'Storage',
+  ASTSTORAGE: 'Storage',
+  TELEMETRY: 'Telemetry',
+  ASTTELEMETRY: 'Telemetry',
+  JOBS: 'Jobs',
+  ASTJOBS: 'Jobs'
+});
+
+function astRuntimeIsPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function astRuntimeNormalizeString(value, fallback = '') {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function astRuntimeNormalizeBoolean(value, fallback = false) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  return fallback;
+}
+
+function astRuntimeNormalizeConfigValue(value, includeEmpty = false) {
+  if (value == null) {
+    return includeEmpty ? '' : null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+
+    return includeEmpty ? '' : null;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return null;
+}
+
+function astRuntimeNormalizeKeys(keys) {
+  if (!Array.isArray(keys)) {
+    return null;
+  }
+
+  const output = [];
+  const seen = {};
+
+  for (let idx = 0; idx < keys.length; idx += 1) {
+    const normalized = astRuntimeNormalizeString(keys[idx], '');
+    if (!normalized || seen[normalized]) {
+      continue;
+    }
+
+    seen[normalized] = true;
+    output.push(normalized);
+  }
+
+  return output;
+}
+
+function astRuntimeReadPropertiesMap(options = {}) {
+  const includeEmpty = astRuntimeNormalizeBoolean(options.includeEmpty, false);
+  const requestedKeys = astRuntimeNormalizeKeys(options.keys);
+  const prefix = astRuntimeNormalizeString(options.prefix, '');
+  const stripPrefix = astRuntimeNormalizeBoolean(options.stripPrefix, false);
+  const output = {};
+  let sourceMap = {};
+  const hasRequestedKeys = Array.isArray(requestedKeys);
+
+  if (astRuntimeIsPlainObject(options.properties)) {
+    sourceMap = options.properties;
+  } else if (
+    astRuntimeIsPlainObject(options.scriptProperties)
+    && typeof options.scriptProperties.getProperties !== 'function'
+    && typeof options.scriptProperties.getProperty !== 'function'
+  ) {
+    sourceMap = options.scriptProperties;
+  } else {
+    const scriptProperties = astRuntimeResolveScriptPropertiesHandle(options.scriptProperties);
+    sourceMap = astRuntimeReadScriptPropertiesMap(scriptProperties, requestedKeys);
+  }
+
+  const keys = hasRequestedKeys
+    ? requestedKeys
+    : Object.keys(sourceMap || {}).sort();
+
+  for (let idx = 0; idx < keys.length; idx += 1) {
+    const sourceKey = astRuntimeNormalizeString(keys[idx], '');
+    if (!sourceKey || !Object.prototype.hasOwnProperty.call(sourceMap, sourceKey)) {
+      continue;
+    }
+
+    if (prefix && !sourceKey.startsWith(prefix)) {
+      continue;
+    }
+
+    const nextKey = stripPrefix && prefix
+      ? sourceKey.slice(prefix.length)
+      : sourceKey;
+
+    const normalizedKey = astRuntimeNormalizeString(nextKey, '');
+    if (!normalizedKey) {
+      continue;
+    }
+
+    const normalizedValue = astRuntimeNormalizeConfigValue(sourceMap[sourceKey], includeEmpty);
+    if (normalizedValue == null) {
+      continue;
+    }
+
+    output[normalizedKey] = normalizedValue;
+  }
+
+  return output;
+}
+
+function astRuntimeResolveScriptPropertiesHandle(scriptProperties) {
+  if (
+    scriptProperties
+    && (
+      typeof scriptProperties.getProperties === 'function'
+      || typeof scriptProperties.getProperty === 'function'
+    )
+  ) {
+    return scriptProperties;
+  }
+
+  try {
+    if (
+      typeof PropertiesService !== 'undefined'
+      && PropertiesService
+      && typeof PropertiesService.getScriptProperties === 'function'
+    ) {
+      return PropertiesService.getScriptProperties();
+    }
+  } catch (_error) {
+    // Ignore script property resolution errors.
+  }
+
+  return null;
+}
+
+function astRuntimeReadScriptPropertiesMap(scriptProperties, requestedKeys = null) {
+  if (!scriptProperties) {
+    return {};
+  }
+
+  const output = {};
+  const hasRequestedKeys = Array.isArray(requestedKeys);
+
+  if (typeof scriptProperties.getProperties === 'function') {
+    const entries = scriptProperties.getProperties();
+    if (astRuntimeIsPlainObject(entries)) {
+      const keys = hasRequestedKeys ? requestedKeys : Object.keys(entries);
+
+      for (let idx = 0; idx < keys.length; idx += 1) {
+        const key = keys[idx];
+        if (Object.prototype.hasOwnProperty.call(entries, key)) {
+          output[key] = entries[key];
+        }
+      }
+    }
+  }
+
+  if (hasRequestedKeys && typeof scriptProperties.getProperty === 'function') {
+    for (let idx = 0; idx < requestedKeys.length; idx += 1) {
+      const key = requestedKeys[idx];
+      if (Object.prototype.hasOwnProperty.call(output, key)) {
+        continue;
+      }
+
+      const value = scriptProperties.getProperty(key);
+      if (typeof value !== 'undefined') {
+        output[key] = value;
+      }
+    }
+  }
+
+  return output;
+}
+
+function astRuntimeResolveConfigReader() {
+  const root = typeof globalThis !== 'undefined' ? globalThis : this;
+
+  if (typeof astConfigFromScriptProperties === 'function') {
+    return astConfigFromScriptProperties;
+  }
+
+  if (root && root.AST_CONFIG && typeof root.AST_CONFIG.fromScriptProperties === 'function') {
+    return root.AST_CONFIG.fromScriptProperties;
+  }
+
+  return astRuntimeReadPropertiesMap;
+}
+
+function astRuntimeResolveProperties(options = {}) {
+  const reader = astRuntimeResolveConfigReader();
+  const rawProperties = reader({
+    properties: options.properties,
+    scriptProperties: options.scriptProperties,
+    keys: options.keys,
+    prefix: options.prefix,
+    stripPrefix: options.stripPrefix,
+    includeEmpty: options.includeEmpty
+  });
+
+  if (!astRuntimeIsPlainObject(rawProperties)) {
+    return {};
+  }
+
+  const includeEmpty = astRuntimeNormalizeBoolean(options.includeEmpty, false);
+  const output = {};
+
+  Object.keys(rawProperties).forEach(key => {
+    const normalizedKey = astRuntimeNormalizeString(key, '');
+    if (!normalizedKey) {
+      return;
+    }
+
+    const normalizedValue = astRuntimeNormalizeConfigValue(rawProperties[key], includeEmpty);
+    if (normalizedValue == null) {
+      return;
+    }
+
+    output[normalizedKey] = normalizedValue;
+  });
+
+  return output;
+}
+
+function astRuntimeListModules() {
+  return AST_RUNTIME_MODULE_DEFINITIONS.map(definition => definition.name);
+}
+
+function astRuntimeResolveModuleName(moduleName) {
+  const normalized = astRuntimeNormalizeString(moduleName, '')
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '');
+
+  return AST_RUNTIME_MODULE_ALIAS_MAP[normalized] || null;
+}
+
+function astRuntimeResolveRequestedModules(modules) {
+  if (typeof modules === 'undefined' || modules == null) {
+    return astRuntimeListModules();
+  }
+
+  const requested = Array.isArray(modules) ? modules : [modules];
+  const output = [];
+  const seen = {};
+
+  for (let idx = 0; idx < requested.length; idx += 1) {
+    const resolvedName = astRuntimeResolveModuleName(requested[idx]);
+    if (!resolvedName) {
+      throw new Error(`AST.Runtime.configureFromProps received unsupported module '${requested[idx]}'`);
+    }
+
+    if (seen[resolvedName]) {
+      continue;
+    }
+
+    seen[resolvedName] = true;
+    output.push(resolvedName);
+  }
+
+  return output;
+}
+
+function astRuntimeResolveModuleApi(moduleName) {
+  const root = typeof globalThis !== 'undefined' ? globalThis : this;
+  const definition = AST_RUNTIME_MODULE_DEFINITIONS.find(entry => entry.name === moduleName);
+  if (!definition) {
+    return null;
+  }
+
+  const fromGlobal = root ? root[definition.globalName] : null;
+  if (fromGlobal && typeof fromGlobal.configure === 'function') {
+    return fromGlobal;
+  }
+
+  const astNamespace = root && root.AST ? root.AST : null;
+  if (astNamespace && astNamespace[moduleName] && typeof astNamespace[moduleName].configure === 'function') {
+    return astNamespace[moduleName];
+  }
+
+  return null;
+}
+
+function astRuntimeNormalizeError(error) {
+  if (error && typeof error === 'object') {
+    return {
+      name: astRuntimeNormalizeString(error.name, 'Error'),
+      message: astRuntimeNormalizeString(error.message, 'Unknown runtime configure error')
+    };
+  }
+
+  return {
+    name: 'Error',
+    message: String(error)
+  };
+}
+
+function astRuntimeConfigureFromProps(options = {}) {
+  if (!astRuntimeIsPlainObject(options)) {
+    throw new Error('AST.Runtime.configureFromProps options must be an object');
+  }
+
+  const properties = astRuntimeResolveProperties(options);
+  const requestedModules = astRuntimeResolveRequestedModules(options.modules);
+  const merge = astRuntimeNormalizeBoolean(options.merge, true);
+  const clearBeforeConfigure = astRuntimeNormalizeBoolean(options.clearBeforeConfigure, false);
+  const throwOnError = options.throwOnError !== false;
+  const summary = {
+    propertyCount: Object.keys(properties).length,
+    modulesRequested: requestedModules.slice(),
+    configuredModules: [],
+    skippedModules: [],
+    failedModules: [],
+    moduleResults: {}
+  };
+
+  for (let idx = 0; idx < requestedModules.length; idx += 1) {
+    const moduleName = requestedModules[idx];
+    const moduleApi = astRuntimeResolveModuleApi(moduleName);
+
+    if (!moduleApi) {
+      const skipped = {
+        module: moduleName,
+        reason: 'module_unavailable'
+      };
+      summary.skippedModules.push(skipped);
+      summary.moduleResults[moduleName] = {
+        status: 'skipped',
+        reason: skipped.reason
+      };
+      continue;
+    }
+
+    try {
+      const cleared = clearBeforeConfigure && typeof moduleApi.clearConfig === 'function';
+      if (cleared) {
+        moduleApi.clearConfig();
+      }
+
+      moduleApi.configure(properties, { merge });
+      summary.configuredModules.push(moduleName);
+      summary.moduleResults[moduleName] = {
+        status: 'configured',
+        merge,
+        cleared,
+        propertyCount: summary.propertyCount
+      };
+    } catch (error) {
+      const normalizedError = astRuntimeNormalizeError(error);
+      const failed = {
+        module: moduleName,
+        error: normalizedError
+      };
+
+      summary.failedModules.push(failed);
+      summary.moduleResults[moduleName] = {
+        status: 'error',
+        error: normalizedError
+      };
+
+      if (throwOnError) {
+        const runtimeError = new Error(
+          `AST.Runtime.configureFromProps failed for module '${moduleName}': ${normalizedError.message}`
+        );
+        runtimeError.name = 'AstRuntimeError';
+        runtimeError.details = {
+          module: moduleName,
+          configuredModules: summary.configuredModules.slice(),
+          failedModules: summary.failedModules.slice()
+        };
+        runtimeError.cause = error;
+        throw runtimeError;
+      }
+    }
+  }
+
+  return summary;
+}
+
+const AST_RUNTIME = Object.freeze({
+  configureFromProps: astRuntimeConfigureFromProps,
+  modules: astRuntimeListModules
+});
+
+const __astRuntimeRoot = typeof globalThis !== 'undefined' ? globalThis : this;
+__astRuntimeRoot.astRuntimeConfigureFromProps = astRuntimeConfigureFromProps;
+__astRuntimeRoot.astRuntimeListModules = astRuntimeListModules;
+__astRuntimeRoot.AST_RUNTIME = AST_RUNTIME;
+this.astRuntimeConfigureFromProps = astRuntimeConfigureFromProps;
+this.astRuntimeListModules = astRuntimeListModules;
+this.AST_RUNTIME = AST_RUNTIME;

--- a/apps_script_tools/telemetry/TelemetryHelpers.js
+++ b/apps_script_tools/telemetry/TelemetryHelpers.js
@@ -1,0 +1,236 @@
+function astTelemetryHelpersIsPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function astTelemetryHelpersNormalizeError(error) {
+  if (error && typeof error === 'object') {
+    return {
+      name: typeof error.name === 'string' && error.name.trim().length > 0 ? error.name.trim() : 'Error',
+      message: typeof error.message === 'string' && error.message.trim().length > 0
+        ? error.message.trim()
+        : 'Unknown error'
+    };
+  }
+
+  return {
+    name: 'Error',
+    message: String(error)
+  };
+}
+
+function astTelemetryHelpersResolveApi() {
+  const root = typeof globalThis !== 'undefined' ? globalThis : this;
+
+  if (typeof AST_TELEMETRY !== 'undefined' && AST_TELEMETRY) {
+    return AST_TELEMETRY;
+  }
+
+  if (root && root.AST_TELEMETRY) {
+    return root.AST_TELEMETRY;
+  }
+
+  if (root && root.AST && root.AST.Telemetry) {
+    return root.AST.Telemetry;
+  }
+
+  return null;
+}
+
+function astTelemetryHelpersStartSpanSafe(name, context = {}, options = {}) {
+  const api = astTelemetryHelpersResolveApi();
+  if (!api || typeof api.startSpan !== 'function') {
+    return null;
+  }
+
+  try {
+    return api.startSpan(name, context, options);
+  } catch (_error) {
+    return null;
+  }
+}
+
+function astTelemetryHelpersEndSpanSafe(spanId, result = {}, options = {}) {
+  if (!spanId) {
+    return null;
+  }
+
+  const api = astTelemetryHelpersResolveApi();
+  if (!api || typeof api.endSpan !== 'function') {
+    return null;
+  }
+
+  try {
+    return api.endSpan(spanId, result, options);
+  } catch (_error) {
+    return null;
+  }
+}
+
+function astTelemetryHelpersRecordEventSafe(event = {}, options = {}) {
+  const api = astTelemetryHelpersResolveApi();
+  if (!api || typeof api.recordEvent !== 'function') {
+    return null;
+  }
+
+  try {
+    return api.recordEvent(event, options);
+  } catch (_error) {
+    return null;
+  }
+}
+
+function astTelemetryHelpersResolveWithSpanArgs(name, contextOrTask, taskOrOptions, maybeOptions) {
+  const spanName = typeof name === 'string' ? name.trim() : '';
+  if (!spanName) {
+    throw new Error('AST.TelemetryHelpers.withSpan requires a non-empty span name');
+  }
+
+  if (typeof contextOrTask === 'function') {
+    return {
+      spanName,
+      context: {},
+      task: contextOrTask,
+      options: astTelemetryHelpersIsPlainObject(taskOrOptions) ? taskOrOptions : {}
+    };
+  }
+
+  if (typeof taskOrOptions !== 'function') {
+    throw new Error('AST.TelemetryHelpers.withSpan requires a task function');
+  }
+
+  return {
+    spanName,
+    context: astTelemetryHelpersIsPlainObject(contextOrTask) ? contextOrTask : {},
+    task: taskOrOptions,
+    options: astTelemetryHelpersIsPlainObject(maybeOptions) ? maybeOptions : {}
+  };
+}
+
+function astTelemetryHelpersBuildSpanResult({ status, startedAtMs, result, error, options }) {
+  const payload = { status };
+  const includeDuration = options.includeDuration !== false;
+
+  if (includeDuration) {
+    payload.durationMs = Math.max(0, new Date().getTime() - startedAtMs);
+  }
+
+  if (status === 'ok' && options.includeResult === true) {
+    payload.result = typeof options.resultMapper === 'function'
+      ? options.resultMapper(result)
+      : result;
+  }
+
+  if (status === 'error') {
+    payload.error = typeof options.errorMapper === 'function'
+      ? options.errorMapper(error)
+      : astTelemetryHelpersNormalizeError(error);
+  }
+
+  return payload;
+}
+
+function astTelemetryHelpersWithSpan(name, contextOrTask, taskOrOptions, maybeOptions) {
+  const resolved = astTelemetryHelpersResolveWithSpanArgs(name, contextOrTask, taskOrOptions, maybeOptions);
+  const endOptions = astTelemetryHelpersIsPlainObject(resolved.options.endOptions)
+    ? resolved.options.endOptions
+    : {};
+  const startedAtMs = new Date().getTime();
+  const spanId = astTelemetryHelpersStartSpanSafe(
+    resolved.spanName,
+    resolved.context,
+    astTelemetryHelpersIsPlainObject(resolved.options.startOptions) ? resolved.options.startOptions : {}
+  );
+
+  try {
+    const output = resolved.task();
+
+    if (output && typeof output.then === 'function') {
+      return output
+        .then(value => {
+          const endPayload = astTelemetryHelpersBuildSpanResult({
+            status: 'ok',
+            startedAtMs,
+            result: value,
+            options: resolved.options
+          });
+          astTelemetryHelpersEndSpanSafe(spanId, endPayload, endOptions);
+          return value;
+        })
+        .catch(error => {
+          const endPayload = astTelemetryHelpersBuildSpanResult({
+            status: 'error',
+            startedAtMs,
+            error,
+            options: resolved.options
+          });
+          astTelemetryHelpersEndSpanSafe(spanId, endPayload, endOptions);
+          throw error;
+        });
+    }
+
+    const endPayload = astTelemetryHelpersBuildSpanResult({
+      status: 'ok',
+      startedAtMs,
+      result: output,
+      options: resolved.options
+    });
+    astTelemetryHelpersEndSpanSafe(spanId, endPayload, endOptions);
+    return output;
+  } catch (error) {
+    const endPayload = astTelemetryHelpersBuildSpanResult({
+      status: 'error',
+      startedAtMs,
+      error,
+      options: resolved.options
+    });
+    astTelemetryHelpersEndSpanSafe(spanId, endPayload, endOptions);
+    throw error;
+  }
+}
+
+function astTelemetryHelpersWrap(name, task, options = {}) {
+  if (typeof task !== 'function') {
+    throw new Error('AST.TelemetryHelpers.wrap requires a task function');
+  }
+
+  const normalizedOptions = astTelemetryHelpersIsPlainObject(options) ? options : {};
+
+  return function wrappedTelemetryTask(...args) {
+    const context = typeof normalizedOptions.contextFactory === 'function'
+      ? normalizedOptions.contextFactory(args, this)
+      : normalizedOptions.context;
+    const contextObject = astTelemetryHelpersIsPlainObject(context) ? context : {};
+    const withSpanOptions = Object.assign({}, normalizedOptions);
+    delete withSpanOptions.context;
+    delete withSpanOptions.contextFactory;
+
+    return astTelemetryHelpersWithSpan(
+      name,
+      contextObject,
+      () => task.apply(this, args),
+      withSpanOptions
+    );
+  };
+}
+
+const AST_TELEMETRY_HELPERS = Object.freeze({
+  startSpanSafe: astTelemetryHelpersStartSpanSafe,
+  endSpanSafe: astTelemetryHelpersEndSpanSafe,
+  recordEventSafe: astTelemetryHelpersRecordEventSafe,
+  withSpan: astTelemetryHelpersWithSpan,
+  wrap: astTelemetryHelpersWrap
+});
+
+const __astTelemetryHelpersApiRoot = typeof globalThis !== 'undefined' ? globalThis : this;
+__astTelemetryHelpersApiRoot.astTelemetryHelpersStartSpanSafe = astTelemetryHelpersStartSpanSafe;
+__astTelemetryHelpersApiRoot.astTelemetryHelpersEndSpanSafe = astTelemetryHelpersEndSpanSafe;
+__astTelemetryHelpersApiRoot.astTelemetryHelpersRecordEventSafe = astTelemetryHelpersRecordEventSafe;
+__astTelemetryHelpersApiRoot.astTelemetryHelpersWithSpan = astTelemetryHelpersWithSpan;
+__astTelemetryHelpersApiRoot.astTelemetryHelpersWrap = astTelemetryHelpersWrap;
+__astTelemetryHelpersApiRoot.AST_TELEMETRY_HELPERS = AST_TELEMETRY_HELPERS;
+this.astTelemetryHelpersStartSpanSafe = astTelemetryHelpersStartSpanSafe;
+this.astTelemetryHelpersEndSpanSafe = astTelemetryHelpersEndSpanSafe;
+this.astTelemetryHelpersRecordEventSafe = astTelemetryHelpersRecordEventSafe;
+this.astTelemetryHelpersWithSpan = astTelemetryHelpersWithSpan;
+this.astTelemetryHelpersWrap = astTelemetryHelpersWrap;
+this.AST_TELEMETRY_HELPERS = AST_TELEMETRY_HELPERS;

--- a/apps_script_tools/testing/ast/astUtils.js
+++ b/apps_script_tools/testing/ast/astUtils.js
@@ -57,6 +57,44 @@ AST_UTILS_TESTS = [
     }
   },
   {
+    description: 'AST namespace should expose Config and Runtime helper surfaces',
+    test: () => {
+      if (!AST || !AST.Config || !AST.Runtime) {
+        throw new Error('AST.Config or AST.Runtime is not available');
+      }
+
+      if (typeof AST.Config.fromScriptProperties !== 'function') {
+        throw new Error('AST.Config.fromScriptProperties is not available');
+      }
+
+      if (typeof AST.Runtime.configureFromProps !== 'function') {
+        throw new Error('AST.Runtime.configureFromProps is not available');
+      }
+    }
+  },
+  {
+    description: 'AST namespace should expose TelemetryHelpers helper surface',
+    test: () => {
+      if (!AST || !AST.TelemetryHelpers) {
+        throw new Error('AST.TelemetryHelpers is not available');
+      }
+
+      const requiredMethods = [
+        'startSpanSafe',
+        'endSpanSafe',
+        'recordEventSafe',
+        'withSpan',
+        'wrap'
+      ];
+
+      requiredMethods.forEach(method => {
+        if (typeof AST.TelemetryHelpers[method] !== 'function') {
+          throw new Error(`AST.TelemetryHelpers.${method} is not available`);
+        }
+      });
+    }
+  },
+  {
     description: 'AST namespace should expose SQL runtime helper surface',
     test: () => {
       if (!AST || !AST.Sql) {

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -21,7 +21,10 @@ ASTX.AI
 ASTX.RAG
 ASTX.Cache
 ASTX.Storage
+ASTX.Config
+ASTX.Runtime
 ASTX.Telemetry
+ASTX.TelemetryHelpers
 ASTX.Jobs
 ASTX.Sql
 ASTX.Utils
@@ -182,6 +185,19 @@ ASTX.Cache.clearConfig()
 ASTX.Cache.clear(options)
 ```
 
+## `Config` essentials
+
+```javascript
+ASTX.Config.fromScriptProperties(options)
+```
+
+## `Runtime` essentials
+
+```javascript
+ASTX.Runtime.configureFromProps(options)
+ASTX.Runtime.modules()
+```
+
 ## `Telemetry` essentials
 
 ```javascript
@@ -193,6 +209,16 @@ ASTX.Telemetry.endSpan(spanId, result)
 ASTX.Telemetry.recordEvent(event)
 ASTX.Telemetry.getTrace(traceId)
 ASTX.Telemetry.flush(options)
+```
+
+## `TelemetryHelpers` essentials
+
+```javascript
+ASTX.TelemetryHelpers.startSpanSafe(name, context, options)
+ASTX.TelemetryHelpers.endSpanSafe(spanId, result, options)
+ASTX.TelemetryHelpers.recordEventSafe(event, options)
+ASTX.TelemetryHelpers.withSpan(name, context, task, options)
+ASTX.TelemetryHelpers.wrap(name, task, options)
 ```
 
 ## `Jobs` essentials
@@ -243,5 +269,8 @@ ASTX.Jobs.clearConfig()
 - Storage `exists` returns `output.exists.exists` instead of throwing on not-found.
 - Storage `copy/move` require same-provider source and destination in this release.
 - Telemetry records redact secrets by default and can emit to `logger`, Drive NDJSON (`drive_json`), or storage NDJSON batches (`storage_json`).
+- `ASTX.Config.fromScriptProperties(...)` supports `keys`, `prefix`, and `stripPrefix` for deterministic property snapshots.
+- `ASTX.Runtime.configureFromProps(...)` applies script/runtime config to selected modules (`AI`, `RAG`, `Cache`, `Storage`, `Telemetry`, `Jobs`).
+- `ASTX.TelemetryHelpers.withSpan(...)` safely closes spans on success/error and rethrows task errors.
 - Jobs step handlers must be globally resolvable named functions and return JSON-serializable values.
 - Jobs checkpoint storage currently supports `checkpointStore='properties'` only.

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -302,6 +302,50 @@ See:
 - [Storage Providers](storage-providers.md)
 - [Storage Security](../operations/storage-security.md)
 
+## `ASTX.Config`
+
+Script property extraction helpers for deterministic runtime bootstrap.
+
+Primary methods:
+
+- `ASTX.Config.fromScriptProperties(options)` to read and normalize script properties.
+
+High-signal behavior:
+
+- values are normalized to trimmed strings.
+- supports `keys` filtering and prefix filtering (`prefix`, `stripPrefix`).
+- gracefully returns `{}` when script properties are unavailable.
+
+```javascript
+const props = ASTX.Config.fromScriptProperties({
+  prefix: 'OPENAI_',
+  stripPrefix: true
+});
+```
+
+## `ASTX.Runtime`
+
+One-shot runtime configuration hydration across module namespaces.
+
+Primary methods:
+
+- `ASTX.Runtime.configureFromProps(options)` to apply script properties to module `configure(...)` hooks.
+- `ASTX.Runtime.modules()` to list supported runtime-configurable module names.
+
+High-signal behavior:
+
+- default target modules: `AI`, `RAG`, `Cache`, `Storage`, `Telemetry`, `Jobs`.
+- configuration merge policy is controlled by `options.merge` (default `true`).
+- supports scoped application with `options.modules` (for example `['AI', 'RAG']`).
+
+```javascript
+const summary = ASTX.Runtime.configureFromProps({
+  modules: ['AI', 'RAG', 'Storage']
+});
+
+Logger.log(summary.configuredModules);
+```
+
 ## `ASTX.Telemetry`
 
 Observability foundation for request traces and operational diagnostics.
@@ -354,6 +398,33 @@ See:
 
 - [Telemetry Contracts](telemetry-contracts.md)
 - [Telemetry Operations](../operations/telemetry.md)
+
+## `ASTX.TelemetryHelpers`
+
+Safe wrappers around span/event operations for app-level workflows.
+
+Primary methods:
+
+- `ASTX.TelemetryHelpers.startSpanSafe(name, context, options)`
+- `ASTX.TelemetryHelpers.endSpanSafe(spanId, result, options)`
+- `ASTX.TelemetryHelpers.recordEventSafe(event, options)`
+- `ASTX.TelemetryHelpers.withSpan(name, context, task, options)`
+- `ASTX.TelemetryHelpers.wrap(name, task, options)`
+
+High-signal behavior:
+
+- never throws from telemetry API failures.
+- `withSpan(...)` always attempts to close the span on both success and error.
+- task errors are re-thrown after telemetry finalization.
+
+```javascript
+const sum = ASTX.TelemetryHelpers.withSpan(
+  'app.compute.sum',
+  { requestId: 'req_1' },
+  () => ASTX.Utils.arraySum([1, 2, 3, 4]),
+  { includeResult: true }
+);
+```
 
 ## `ASTX.Jobs`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,10 @@
 - `AST.RAG`: Drive-backed indexing, retrieval, and grounded answering with citations.
 - `AST.Storage`: cross-provider object storage for GCS, S3, and DBFS.
 - `AST.Cache`: backend-agnostic cache layer for repeated computations and API responses (single + bulk ops).
+- `AST.Config`: script-properties snapshot helpers for configuration bootstrap.
+- `AST.Runtime`: runtime configuration hydration across AST namespaces.
 - `AST.Telemetry`: request-level tracing spans/events with redaction and sink controls.
+- `AST.TelemetryHelpers`: safe wrappers for span lifecycle orchestration.
 - `AST.Jobs`: storage-backed multi-step job runner with retry/resume, polling, and status controls.
 - `AST.Sql`: validated SQL execution for Databricks and BigQuery.
 - `AST.Utils`: utility helpers (`arraySum`, `dateAdd`, `toSnakeCase`, and others).
@@ -38,7 +41,9 @@ flowchart LR
     B --> K[AST.RAG]
     B --> M[AST.Storage]
     B --> Q[AST.Cache]
+    B --> S[AST.Config / AST.Runtime]
     B --> O[AST.Telemetry]
+    B --> V[AST.TelemetryHelpers]
     B --> T[AST.Jobs]
     D --> F[BigQuery]
     D --> G[Databricks SQL API]
@@ -67,6 +72,8 @@ flowchart LR
 - `AST.Storage` unified CRUD contracts (`list`, `head`, `read`, `write`, `delete`) for `gcs`, `s3`, and `dbfs`.
 - `AST.Cache` cache contracts (`get`, `set`, `delete`, `getMany`, `setMany`, `deleteMany`, `invalidateByTag`, `stats`) for `memory`, `drive_json`, `script_properties`, and `storage_json` (`gcs://`, `s3://`, `dbfs:/`).
 - `AST.Telemetry` observability foundation (`startSpan`, `endSpan`, `recordEvent`, `getTrace`, `flush`) with redaction and sink control.
+- `AST.Config.fromScriptProperties(...)` + `AST.Runtime.configureFromProps(...)` to bootstrap module runtime config from Script Properties.
+- `AST.TelemetryHelpers` wrappers (`withSpan`, `wrap`, safe start/end/event helpers) for non-blocking app instrumentation.
 - RAG hot-path cache controls for embedding/search/answer reuse across repeated queries.
 - `AST.Jobs` orchestration contracts (`run`, `enqueue`, `resume`, `status`, `list`, `cancel`, `pollAndRun`) with storage-backed checkpoint state and worker leases.
 

--- a/tests/local/config-runtime-telemetry-helpers.test.mjs
+++ b/tests/local/config-runtime-telemetry-helpers.test.mjs
@@ -1,0 +1,148 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createGasContext, loadScripts, listScriptFiles } from './helpers.mjs';
+import { loadAiScripts } from './ai-helpers.mjs';
+import { loadTelemetryScripts } from './telemetry-helpers.mjs';
+
+test('AST exposes Config, Runtime, and TelemetryHelpers helper namespaces', () => {
+  const context = createGasContext();
+  loadScripts(context, [
+    'apps_script_tools/config/Config.js',
+    'apps_script_tools/runtime/Runtime.js',
+    ...listScriptFiles('apps_script_tools/telemetry/general'),
+    'apps_script_tools/telemetry/Telemetry.js',
+    'apps_script_tools/telemetry/TelemetryHelpers.js',
+    'apps_script_tools/AST.js'
+  ]);
+
+  assert.equal(typeof context.AST.Config.fromScriptProperties, 'function');
+  assert.equal(typeof context.AST.Runtime.configureFromProps, 'function');
+  assert.equal(typeof context.AST.Runtime.modules, 'function');
+  assert.equal(typeof context.AST.TelemetryHelpers.withSpan, 'function');
+  assert.equal(typeof context.AST.TelemetryHelpers.startSpanSafe, 'function');
+});
+
+test('AST.Config.fromScriptProperties supports key/prefix normalization', () => {
+  const context = createGasContext({
+    PropertiesService: {
+      getScriptProperties: () => ({
+        getProperties: () => ({
+          OPENAI_API_KEY: '  key-123  ',
+          OPENAI_MODEL: 'gpt-test',
+          AST_APP_NAME: '  demo app ',
+          EMPTY_VALUE: '   '
+        })
+      })
+    }
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/config/Config.js',
+    'apps_script_tools/AST.js'
+  ]);
+
+  const openAiOnly = context.AST.Config.fromScriptProperties({
+    prefix: 'OPENAI_',
+    stripPrefix: true
+  });
+
+  assert.equal(
+    JSON.stringify(openAiOnly),
+    JSON.stringify({
+      API_KEY: 'key-123',
+      MODEL: 'gpt-test'
+    })
+  );
+
+  const selected = context.AST.Config.fromScriptProperties({
+    keys: ['AST_APP_NAME', 'EMPTY_VALUE'],
+    includeEmpty: true
+  });
+
+  assert.equal(
+    JSON.stringify(selected),
+    JSON.stringify({
+      AST_APP_NAME: 'demo app',
+      EMPTY_VALUE: ''
+    })
+  );
+});
+
+test('AST.Runtime.configureFromProps configures selected modules from script properties', () => {
+  const context = createGasContext({
+    PropertiesService: {
+      getScriptProperties: () => ({
+        getProperties: () => ({
+          OPENAI_API_KEY: 'runtime-key',
+          OPENAI_MODEL: 'runtime-model'
+        })
+      })
+    }
+  });
+
+  loadAiScripts(context);
+  loadScripts(context, [
+    'apps_script_tools/config/Config.js',
+    'apps_script_tools/runtime/Runtime.js',
+    'apps_script_tools/AST.js'
+  ]);
+
+  context.AST.AI.clearConfig();
+
+  const summary = context.AST.Runtime.configureFromProps({
+    modules: ['AI'],
+    keys: ['OPENAI_API_KEY', 'OPENAI_MODEL']
+  });
+
+  assert.equal(JSON.stringify(summary.modulesRequested), JSON.stringify(['AI']));
+  assert.equal(JSON.stringify(summary.configuredModules), JSON.stringify(['AI']));
+  assert.equal(summary.failedModules.length, 0);
+  assert.equal(summary.propertyCount, 2);
+  assert.equal(
+    JSON.stringify(context.AST.AI.getConfig()),
+    JSON.stringify({
+      OPENAI_API_KEY: 'runtime-key',
+      OPENAI_MODEL: 'runtime-model'
+    })
+  );
+});
+
+test('AST.TelemetryHelpers.withSpan records success and failure paths', () => {
+  const context = createGasContext();
+  loadTelemetryScripts(context, { includeAst: false });
+  loadScripts(context, ['apps_script_tools/AST.js']);
+
+  context.AST.Telemetry._reset();
+  context.AST.Telemetry.clearConfig();
+  context.AST.Telemetry.configure({ sink: 'logger' });
+
+  const ok = context.AST.TelemetryHelpers.withSpan(
+    'telemetry.helpers.ok',
+    { traceId: 'trace_helpers_ok' },
+    () => 42,
+    { includeResult: true }
+  );
+  assert.equal(ok, 42);
+
+  const okTrace = context.AST.Telemetry.getTrace('trace_helpers_ok');
+  assert.equal(okTrace.spans.length, 1);
+  assert.equal(okTrace.spans[0].status, 'ok');
+  assert.equal(okTrace.spans[0].result.result, 42);
+
+  assert.throws(
+    () => context.AST.TelemetryHelpers.withSpan(
+      'telemetry.helpers.error',
+      { traceId: 'trace_helpers_error' },
+      () => {
+        throw new Error('boom');
+      }
+    ),
+    /boom/
+  );
+
+  const errorTrace = context.AST.Telemetry.getTrace('trace_helpers_error');
+  assert.equal(errorTrace.spans.length, 1);
+  assert.equal(errorTrace.spans[0].status, 'error');
+  assert.equal(errorTrace.spans[0].error.message, 'boom');
+});

--- a/tests/local/telemetry-helpers.mjs
+++ b/tests/local/telemetry-helpers.mjs
@@ -4,7 +4,10 @@ export function loadTelemetryScripts(context, { includeAst = false } = {}) {
   const paths = [];
 
   paths.push(...listScriptFiles('apps_script_tools/telemetry/general'));
-  paths.push('apps_script_tools/telemetry/Telemetry.js');
+  paths.push(
+    'apps_script_tools/telemetry/Telemetry.js',
+    'apps_script_tools/telemetry/TelemetryHelpers.js'
+  );
 
   if (includeAst) {
     paths.push('apps_script_tools/AST.js');


### PR DESCRIPTION
## Summary
- add `AST.Config.fromScriptProperties(...)` for normalized script-property snapshots with key/prefix filtering
- add `AST.Runtime.configureFromProps(...)` + `AST.Runtime.modules()` for one-shot module runtime bootstrap
- add `AST.TelemetryHelpers` safe wrappers (`startSpanSafe`, `endSpanSafe`, `recordEventSafe`, `withSpan`, `wrap`)
- expose new namespaces via `AST` root and add GAS namespace coverage
- add local tests for config/runtime/telemetry helper contracts and update docs/changelog

## Validation
- `npm run lint`
- `npm run test:local`
- `npm run test:perf:check`
- `mkdocs build --strict`