### PR TITLE
feat(rag): add opt-in diagnostics for search/preview/answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Current release state:
 - `AST.AI.OutputRepair.continueIfTruncated(...)` helper for bounded continuation of truncated outputs.
 - `AST.RAG.Citations.*` utility helpers for inline normalization, filtering, and source-link mapping.
 - `AST.RAG.Fallback.fromCitations(...)` deterministic citation-only fallback synthesis.
-- `AST.RAG.answer(...)` recovery controls (`retrieval.recovery`) and stable per-phase diagnostics.
+- `AST.RAG.answer(...)` recovery controls (`retrieval.recovery`) and optional per-phase diagnostics (`options.diagnostics` or `RAG_DIAGNOSTICS_ENABLED`).
 - `AST.RAG.answer(...)` fallback controls for retrieval error/empty paths (`fallback.onRetrievalError`, `fallback.onRetrievalEmpty`).
 
 ## Install As Apps Script Library

--- a/apps_script_tools/rag/general/driveIndexStore.js
+++ b/apps_script_tools/rag/general/driveIndexStore.js
@@ -89,6 +89,7 @@ function astRagLoadIndexDocument(indexFileId, options = {}) {
       indexFileId,
       fileName,
       versionToken,
+      cacheHit: true,
       document: cached.document
     };
   }
@@ -125,6 +126,7 @@ function astRagLoadIndexDocument(indexFileId, options = {}) {
     indexFileId,
     fileName,
     versionToken,
+    cacheHit: false,
     document: json
   };
 }

--- a/apps_script_tools/rag/general/resolveRagConfig.js
+++ b/apps_script_tools/rag/general/resolveRagConfig.js
@@ -22,6 +22,7 @@ const AST_RAG_CONFIG_KEYS = Object.freeze([
   'RAG_DEFAULT_INDEX_FOLDER_ID',
   'RAG_DEFAULT_TOP_K',
   'RAG_DEFAULT_MIN_SCORE',
+  'RAG_DIAGNOSTICS_ENABLED',
   'RAG_CACHE_ENABLED',
   'RAG_CACHE_BACKEND',
   'RAG_CACHE_NAMESPACE',
@@ -423,4 +424,25 @@ function astRagResolveCacheConfig(overrides = {}) {
     lockTimeoutMs,
     updateStatsOnGet
   };
+}
+
+function astRagResolveDiagnosticsEnabledDefault() {
+  const snapshot = astRagResolveConfigSnapshot();
+  const value = snapshot.RAG_DIAGNOSTICS_ENABLED;
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const token = value.trim().toLowerCase();
+    if (token === 'true' || token === '1' || token === 'yes') {
+      return true;
+    }
+    if (token === 'false' || token === '0' || token === 'no') {
+      return false;
+    }
+  }
+
+  return false;
 }

--- a/apps_script_tools/rag/general/validateRagRequest.js
+++ b/apps_script_tools/rag/general/validateRagRequest.js
@@ -87,8 +87,13 @@ function astRagNormalizeSearchOptions(options = {}) {
     throw new AstRagValidationError('search.options must be an object when provided');
   }
 
+  const diagnosticsDefault = typeof astRagResolveDiagnosticsEnabledDefault === 'function'
+    ? astRagResolveDiagnosticsEnabledDefault()
+    : false;
+
   return {
-    enforceAccessControl: astRagNormalizeBoolean(options.enforceAccessControl, true)
+    enforceAccessControl: astRagNormalizeBoolean(options.enforceAccessControl, true),
+    diagnostics: astRagNormalizeBoolean(options.diagnostics, diagnosticsDefault)
   };
 }
 
@@ -151,11 +156,16 @@ function astRagNormalizeAnswerOptions(options = {}) {
     throw new AstRagValidationError('answer.options must be an object when provided');
   }
 
+  const diagnosticsDefault = typeof astRagResolveDiagnosticsEnabledDefault === 'function'
+    ? astRagResolveDiagnosticsEnabledDefault()
+    : false;
+
   return {
     requireCitations: typeof options.requireCitations === 'boolean'
       ? options.requireCitations
       : true,
     enforceAccessControl: astRagNormalizeBoolean(options.enforceAccessControl, true),
+    diagnostics: astRagNormalizeBoolean(options.diagnostics, diagnosticsDefault),
     insufficientEvidenceMessage: astRagNormalizeString(
       options.insufficientEvidenceMessage,
       'I do not have enough grounded context to answer that.'

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -291,7 +291,7 @@ store.buildHistory({ userKey: 'user-1' }, { maxPairs: 10, systemMessage: 'You ar
 - `ASTX.AI.OutputRepair.continueIfTruncated(...)` can continue truncated answers with bounded follow-up passes.
 - `RAG.answer(...)` supports retrieval recovery policy (`retrieval.recovery.*`) before generation.
 - `RAG.answer(...)` supports deterministic fallback controls (`fallback.onRetrievalError`, `fallback.onRetrievalEmpty`).
-- `RAG.answer(...)` always returns `diagnostics` with retrieval/generation timings and pipeline path metadata.
+- `RAG.answer(...)` includes `diagnostics` only when enabled via `options.diagnostics=true` (or `RAG_DIAGNOSTICS_ENABLED=true`).
 - `ASTX.Chat.ThreadStore` persists per-user thread state with lock-aware writes and deterministic thread/turn caps.
 - `ASTX.AI.*` accepts optional `routing` candidates for priority/latency/cost-based provider fallback with per-attempt trace metadata.
 - `ASTX.AI.structured(...)` includes a bounded reliability layer (`options.reliability`) for schema retries and optional repair (`json_repair`/`llm_repair`).

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -654,7 +654,7 @@ High-signal behavior:
 - `answer(...)` supports retrieval recovery controls (`retrieval.recovery`) before generation.
 - `answer(...)` supports deterministic fallback policy controls (`fallback.onRetrievalError`, `fallback.onRetrievalEmpty`).
 - `IndexManager.ensure(...)` can optionally fallback unsupported MIME requests to supported MIME sets with diagnostics.
-- `answer(...)` returns stable `diagnostics` for retrieval/generation phase timing + pipeline path.
+- `answer(...)` can return stable `diagnostics` for retrieval/generation phase timing + pipeline path when `options.diagnostics=true` (or `RAG_DIAGNOSTICS_ENABLED=true`).
 
 See:
 


### PR DESCRIPTION
## Summary
- add opt-in diagnostics controls for RAG search/preview/answer via request options and config default
- add cache-hit and phase-timing diagnostics metadata for search/preview/answer paths
- return cache-safe responses by stripping diagnostics from cached payloads and rehydrating per call
- remove duplicate index load in previewSources by reusing search versionToken
- align docs to reflect diagnostics opt-in behavior and config key support

## Validation
- npm run -s lint
- npm run -s test:local
- npm run -s test:perf:check
- mkdocs build --strict
- clasp run runAllTests