### PR TITLE
feat(rag): add lexical-only retrieval mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
   - `AST.RAG.Citations.normalizeInline/extractInlineIds/filterForAnswer/toUrl`
   - `AST.RAG.Fallback.fromCitations(...)` deterministic citation-only fallback builder
 - `AST.RAG.answer(...)` now supports retrieval recovery controls (`retrieval.recovery`) and deterministic fallback policy controls (`fallback.onRetrievalError`, `fallback.onRetrievalEmpty`).
-- `AST.RAG.answer(...)` responses now include stable retrieval/generation diagnostics (`diagnostics.totalMs`, `pipelinePath`, per-phase timing/status fields).
+- `AST.RAG.answer(...)` supports stable retrieval/generation diagnostics (`diagnostics.totalMs`, `pipelinePath`, per-phase timing/status fields) when enabled via `options.diagnostics` or `RAG_DIAGNOSTICS_ENABLED`.
 - Drive-only source ingestion for:
   - plain text (`text/plain`)
   - PDF (`application/pdf`)
@@ -82,6 +82,7 @@
 - Embedding provider registry with built-ins (`openai`, `gemini`, `vertex_gemini`, `openrouter`, `perplexity`) plus runtime custom provider registration.
 - Grounded answer orchestration with citation IDs (`S1..Sn`) and abstention behavior (`status=insufficient_context`).
 - Hybrid RAG retrieval mode (`mode=hybrid`) with weighted vector + lexical score fusion.
+- Lexical-only RAG retrieval mode (`mode=lexical`) for no-embedding low-latency retrieval paths.
 - Optional RAG reranking (`retrieval.rerank`) for top-N post-rank refinement.
 - RAG access-control contract for retrieval and answer flows (`retrieval.access`) with enforceable source/citation boundaries.
 - Search/answer retrieval responses now expose explainability fields: `vectorScore`, `lexicalScore`, `finalScore`, and `rerankScore` (when enabled).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Current release state:
 - Drive JSON index lifecycle APIs: `buildIndex`, `syncIndex`, `search`, `previewSources`, `answer`, `inspectIndex`.
 - RAG retrieval payload interop APIs for preview-to-answer reuse: `buildRetrievalCacheKey`, `putRetrievalPayload`, `getRetrievalPayload`, `deleteRetrievalPayload`.
 - RAG index orchestration wrapper: `AST.RAG.IndexManager.create(...).ensure/sync/fastState`.
-- Hybrid retrieval + reranking support in `RAG.search(...)` / `RAG.answer(...)` with explainable score fields (`vectorScore`, `lexicalScore`, `finalScore`).
+- Retrieval mode support in `RAG.search(...)` / `RAG.answer(...)` for `vector`, `hybrid`, and `lexical` (no-embedding) paths, plus optional reranking with explainable score fields (`vectorScore`, `lexicalScore`, `finalScore`).
 - RAG retrieval access-control (`retrieval.access`) and citation/source policy enforcement (`options.enforceAccessControl`).
 - New `AST.Storage` module with unified URI contracts and CRUD operations across `gcs`, `s3`, and `dbfs`.
 - Storage advanced ops: `exists`, `copy`, `move`, `signedUrl`, and `multipartWrite` for production object workflows.

--- a/apps_script_tools/rag/general/retrievalEngine.js
+++ b/apps_script_tools/rag/general/retrievalEngine.js
@@ -38,12 +38,14 @@ function astRagRetrieveRankedChunks(indexDocument, query, queryVector, retrieval
     return [];
   }
 
-  const lexical = retrieval.mode === 'hybrid'
+  const lexical = (retrieval.mode === 'hybrid' || retrieval.mode === 'lexical')
     ? astRagComputeLexicalScores(query, chunks)
     : { scores: {} };
 
   const scored = chunks.map(chunk => {
-    const vectorScore = astRagCosineSimilarity(queryVector, chunk.embedding);
+    const vectorScore = retrieval.mode === 'lexical'
+      ? null
+      : astRagCosineSimilarity(queryVector, chunk.embedding);
     const lexicalScore = lexical.scores[chunk.chunkId] || 0;
 
     return Object.assign(

--- a/apps_script_tools/rag/general/validateRagRequest.js
+++ b/apps_script_tools/rag/general/validateRagRequest.js
@@ -274,8 +274,8 @@ function astRagNormalizeEmbeddingRequest(embedding = {}) {
 
 function astRagNormalizeRetrievalMode(mode, fieldPath) {
   const normalized = astRagNormalizeString(mode, AST_RAG_DEFAULT_RETRIEVAL.mode);
-  if (!['vector', 'hybrid'].includes(normalized)) {
-    throw new AstRagValidationError(`${fieldPath} must be one of: vector, hybrid`);
+  if (!['vector', 'hybrid', 'lexical'].includes(normalized)) {
+    throw new AstRagValidationError(`${fieldPath} must be one of: vector, hybrid, lexical`);
   }
   return normalized;
 }

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -296,7 +296,7 @@ store.buildHistory({ userKey: 'user-1' }, { maxPairs: 10, systemMessage: 'You ar
 - `ASTX.AI.*` accepts optional `routing` candidates for priority/latency/cost-based provider fallback with per-attempt trace metadata.
 - `ASTX.AI.structured(...)` includes a bounded reliability layer (`options.reliability`) for schema retries and optional repair (`json_repair`/`llm_repair`).
 - RAG answer generation is grounded against retrieved chunks with citation IDs (`S1..Sn`).
-- RAG retrieval supports `vector` (default) and `hybrid` (vector + lexical fusion) modes.
+- RAG retrieval supports `vector` (default), `hybrid` (vector + lexical fusion), and `lexical` (no embedding call) modes.
 - RAG retrieval supports optional reranking on top-N chunks via `retrieval.rerank`.
 - RAG retrieval supports access constraints via `retrieval.access` (`allowedFileIds`, `deniedFileIds`, `allowedMimeTypes`, `deniedMimeTypes`).
 - `RAG.answer(...)` can enforce citation/source boundaries with `options.enforceAccessControl=true`.

--- a/docs/api/rag-contracts.md
+++ b/docs/api/rag-contracts.md
@@ -86,7 +86,7 @@ ASTX.RAG.unregisterEmbeddingProvider(name)
   retrieval: {
     topK: 8,
     minScore: 0.2,
-    mode: 'vector' | 'hybrid',
+    mode: 'vector' | 'hybrid' | 'lexical',
     vectorWeight: 0.65, // hybrid only
     lexicalWeight: 0.35, // hybrid only
     recovery: {
@@ -144,7 +144,7 @@ ASTX.RAG.unregisterEmbeddingProvider(name)
   retrieval: {
     topK: 8,
     minScore: 0.2,
-    mode: 'vector' | 'hybrid',
+    mode: 'vector' | 'hybrid' | 'lexical',
     vectorWeight: 0.65, // hybrid only
     lexicalWeight: 0.35, // hybrid only
     rerank: {
@@ -222,7 +222,7 @@ ASTX.RAG.unregisterEmbeddingProvider(name)
   retrieval: {
     topK: 8,
     minScore: 0.2,
-    mode: 'vector' | 'hybrid'
+    mode: 'vector' | 'hybrid' | 'lexical'
   },
   cache: {
     enabled: false,
@@ -352,7 +352,7 @@ Resolution precedence for Vertex service-account JSON:
       page: null | number,
       slide: null | number,
       score,
-      vectorScore,
+      vectorScore, // null in lexical mode
       lexicalScore, // null in vector mode
       finalScore,
       rerankScore, // null unless rerank produced a score
@@ -429,7 +429,7 @@ const fallback = ASTX.RAG.Fallback.fromCitations({
   query: 'string',
   topK: 8,
   minScore: 0.2,
-  mode: 'vector' | 'hybrid',
+  mode: 'vector' | 'hybrid' | 'lexical',
   results: [
     {
       chunkId,
@@ -441,7 +441,7 @@ const fallback = ASTX.RAG.Fallback.fromCitations({
       section,
       text,
       score, // alias of finalScore
-      vectorScore,
+      vectorScore, // null in lexical mode
       lexicalScore, // null in vector mode
       finalScore,
       rerankScore // present when rerank.enabled=true

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -228,6 +228,7 @@ ASTX.Cache.configure({
 
 - `retrieval.mode = 'vector'` (default cosine-only ranking)
 - `retrieval.mode = 'hybrid'` (weighted vector + lexical fusion)
+- `retrieval.mode = 'lexical'` (BM25-only ranking; no embedding call)
 - `retrieval.rerank` for optional top-N reranking
 - `retrieval.access` for source-level allow/deny constraints
 - optional request/runtime cache controls (`cache.enabled`, backend overrides, TTLs)

--- a/tests/local/rag-foundation.test.mjs
+++ b/tests/local/rag-foundation.test.mjs
@@ -688,6 +688,25 @@ test('astRagValidateSearchRequest normalizes hybrid retrieval contract', () => {
   assert.equal(JSON.stringify(normalized.retrieval.filters.mimeTypes), JSON.stringify(['text/plain']));
 });
 
+test('astRagValidateSearchRequest accepts lexical retrieval mode', () => {
+  const context = createGasContext();
+  loadRagScripts(context);
+
+  const normalized = context.astRagValidateSearchRequest({
+    indexFileId: 'idx_lexical',
+    query: 'project risks',
+    retrieval: {
+      mode: 'lexical',
+      topK: 4,
+      minScore: 0.05
+    }
+  });
+
+  assert.equal(normalized.retrieval.mode, 'lexical');
+  assert.equal(normalized.retrieval.topK, 4);
+  assert.equal(normalized.retrieval.minScore, 0.05);
+});
+
 test('astRagValidateSearchRequest rejects invalid retrieval mode and weights', () => {
   const context = createGasContext();
   loadRagScripts(context);
@@ -700,7 +719,7 @@ test('astRagValidateSearchRequest rejects invalid retrieval mode and weights', (
         mode: 'lexical_only'
       }
     }),
-    /must be one of: vector, hybrid/
+    /must be one of: vector, hybrid, lexical/
   );
 
   assert.throws(


### PR DESCRIPTION
## Summary
- add first-class lexical retrieval mode support across RAG.search, RAG.previewSources, and RAG.answer
- skip embedding resolution/calls for lexical mode while preserving existing response contracts
- extend score fusion and retrieval engine for lexical-only ranking (vectorScore=null, lexical/final score metadata retained)
- update docs/contracts/changelog for lexical mode and diagnostics behavior wording
- add local tests for lexical validation/search/preview/answer paths

## Validation
- npm run -s lint
- npm run -s test:local
- npm run -s test:perf:check
- mkdocs build --strict
- clasp run runAllTests