### PR TITLE
docs: align Cache/Jobs contracts with runtime exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@
 - `AST.GroupBy`: grouped aggregation/apply workflows
 - `AST.Sheets` + `AST.Drive`: workspace helpers
 - `AST.Storage`: object storage CRUD for GCS, S3, and DBFS
-- `AST.Cache`: backend-agnostic caching (memory, Drive JSON, script properties, Storage URI) with single + bulk operations
+- `AST.Cache`: backend-agnostic caching (memory, Drive JSON, script properties, Storage URI) with single-key ops, tag invalidation, and stats
 - `AST.Config`: script-properties snapshot helpers for runtime bootstrap
 - `AST.Runtime`: one-shot runtime config hydration across namespaces
 - `AST.Telemetry`: trace spans/events with redaction and sink controls
 - `AST.TelemetryHelpers`: safe span/event wrappers for app workflows
-- `AST.Jobs`: storage-backed multi-step job orchestration with retry/resume/poll semantics
+- `AST.Jobs`: script-properties checkpointed multi-step job orchestration with retry/resume semantics
 - `AST.Chat`: durable user-scoped thread state store for chat apps
 - `AST.AI`: unified AI providers, structured outputs, tools, and image flows
 - `AST.RAG`: Drive indexing, retrieval, and grounded Q&A with citations
@@ -63,13 +63,13 @@ Current release state:
 - New `AST.Storage` module with unified URI contracts and CRUD operations across `gcs`, `s3`, and `dbfs`.
 - Storage advanced ops: `exists`, `copy`, `move`, `signedUrl`, and `multipartWrite` for production object workflows.
 - SQL ergonomics: `prepare`, `executePrepared`, `status`, and `cancel` on top of provider-routed `run`.
-- New `AST.Cache` module with deterministic TTL semantics, tag invalidation, backend selection, and bulk helpers (`getMany`, `setMany`, `deleteMany`).
+- New `AST.Cache` module with deterministic TTL semantics, tag invalidation, backend selection, and namespace stats/clear helpers.
 - Cache backend posture for production: prefer `storage_json`; use `drive_json` and `script_properties` only for low-scale paths.
 - New `AST.Telemetry` module with typed spans/events, secret redaction, and `logger`/Drive/storage NDJSON sinks (including batched `storage_json` + `flush`).
 - New bootstrap helpers: `AST.Config.fromScriptProperties(...)` and `AST.Runtime.configureFromProps(...)`.
 - New `AST.TelemetryHelpers` wrappers for safe instrumented execution (`withSpan`, `wrap`, `startSpanSafe`, `endSpanSafe`).
 - RAG request-level cache controls for embedding/search/answer hot paths with backend overrides.
-- New `AST.Jobs` module with storage-backed checkpointing and run/enqueue/resume/status/list/cancel/pollAndRun contracts.
+- New `AST.Jobs` module with script-properties checkpointing and run/enqueue/resume/status/list/cancel contracts.
 - New `AST.Chat` module with `ThreadStore.create(...)` for user-scoped thread persistence, lock-aware writes, and bounded history assembly.
 - DataFrame schema contracts with `validateSchema(...)` reporting and `enforceSchema(...)` strict/coercion pathways.
 - `AST.AI.tools(...)` guardrails for timeout, payload caps, retries, and idempotent replay.

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -310,8 +310,7 @@ store.buildHistory({ userKey: 'user-1' }, { maxPairs: 10, systemMessage: 'You ar
 - `RAG.IndexManager.create(...).ensure/sync/fastState` wraps index lifecycle operations for app-level orchestration.
 - Cache supports deterministic TTL (`ttlSec`) and tag-based invalidation.
 - Cache backend options are `memory`, `drive_json`, `script_properties`, and `storage_json` (`gcs://`, `s3://`, `dbfs:/` via `storageUri`).
-- Cache bulk helpers are available through `getMany`, `setMany`, and `deleteMany`.
-- Cache `updateStatsOnGet` defaults to `false` for scalable storage-backed read paths.
+- Cache `updateStatsOnGet` defaults to `true`; set `updateStatsOnGet: false` to avoid write-on-read for high-throughput reads.
 - Cache production default should be `storage_json`; keep `memory`/`drive_json`/`script_properties` for low-scale or execution-local workloads.
 - Storage `head/read/delete` missing objects throw `AstStorageNotFoundError`.
 - Storage `exists` returns `output.exists.exists` instead of throwing on not-found.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,12 +20,12 @@
 - `AST.AI`: multi-provider text, structured output, tool calling, and image generation.
 - `AST.RAG`: Drive-backed indexing, retrieval, and grounded answering with citations.
 - `AST.Storage`: cross-provider object storage for GCS, S3, and DBFS.
-- `AST.Cache`: backend-agnostic cache layer for repeated computations and API responses (single + bulk ops).
+- `AST.Cache`: backend-agnostic cache layer for repeated computations and API responses (single-key ops + invalidation/stats).
 - `AST.Config`: script-properties snapshot helpers for configuration bootstrap.
 - `AST.Runtime`: runtime configuration hydration across AST namespaces.
 - `AST.Telemetry`: request-level tracing spans/events with redaction and sink controls.
 - `AST.TelemetryHelpers`: safe wrappers for span lifecycle orchestration.
-- `AST.Jobs`: storage-backed multi-step job runner with retry/resume, polling, and status controls.
+- `AST.Jobs`: script-properties checkpointed multi-step job runner with retry/resume and status controls.
 - `AST.Sql`: validated SQL execution for Databricks and BigQuery.
 - `AST.Utils`: utility helpers (`arraySum`, `dateAdd`, `toSnakeCase`, and others).
 
@@ -52,7 +52,7 @@ flowchart LR
     M --> N[GCS / S3 / DBFS APIs]
     Q --> R["Memory / Drive JSON / Script Properties / Storage JSON"]
     O --> P[Logger / Drive NDJSON / Storage NDJSON]
-    T --> U["Storage URI Checkpoints (gcs/s3/dbfs)"]
+    T --> U["Script Properties Checkpoints"]
     C --> H[Records / Arrays / Sheets]
 ```
 
@@ -70,12 +70,12 @@ flowchart LR
 - Grounded answering with strict citation mapping and deterministic abstention behavior.
 - Drive JSON index lifecycle APIs (`buildIndex`, `syncIndex`, `inspectIndex`, `search`, `answer`).
 - `AST.Storage` unified CRUD contracts (`list`, `head`, `read`, `write`, `delete`) for `gcs`, `s3`, and `dbfs`.
-- `AST.Cache` cache contracts (`get`, `set`, `delete`, `getMany`, `setMany`, `deleteMany`, `invalidateByTag`, `stats`) for `memory`, `drive_json`, `script_properties`, and `storage_json` (`gcs://`, `s3://`, `dbfs:/`).
+- `AST.Cache` cache contracts (`get`, `set`, `delete`, `invalidateByTag`, `stats`, `clear`) for `memory`, `drive_json`, `script_properties`, and `storage_json` (`gcs://`, `s3://`, `dbfs:/`).
 - `AST.Telemetry` observability foundation (`startSpan`, `endSpan`, `recordEvent`, `getTrace`, `flush`) with redaction and sink control.
 - `AST.Config.fromScriptProperties(...)` + `AST.Runtime.configureFromProps(...)` to bootstrap module runtime config from Script Properties.
 - `AST.TelemetryHelpers` wrappers (`withSpan`, `wrap`, safe start/end/event helpers) for non-blocking app instrumentation.
 - RAG hot-path cache controls for embedding/search/answer reuse across repeated queries.
-- `AST.Jobs` orchestration contracts (`run`, `enqueue`, `resume`, `status`, `list`, `cancel`, `pollAndRun`) with storage-backed checkpoint state and worker leases.
+- `AST.Jobs` orchestration contracts (`run`, `enqueue`, `resume`, `status`, `list`, `cancel`) with script-properties checkpoint state.
 
 ## Import pattern
 


### PR DESCRIPTION
## Summary
- align README and docs with actual AST.Cache and AST.Jobs runtime exports
- remove stale references to unsupported methods (getMany, setMany, deleteMany, pollAndRun)
- correct cache behavior note: updateStatsOnGet default is true
- add lint-time docs/API contract guard to prevent future drift

## Details
- updated README.md wording for Cache/Jobs capabilities
- updated docs/index.md architecture and release-scope bullets to match current runtime
- updated docs/api/quick-reference.md high-signal notes for cache behavior
- extended scripts/lint.mjs with:
  - top-level AST namespace export parity check vs quick-reference
  - Cache/Jobs method parity check vs quick-reference
  - stale-claim detection in README/docs for unsupported methods

## Validation
- npm run lint
- npm run test:local
- mkdocs build --strict
- clasp run runAllTests (1496/1496 passed)

Closes #83