### PR TITLE
perf(config): memoize script-properties snapshots on hot paths

### DIFF
--- a/apps_script_tools/cache/general/config.js
+++ b/apps_script_tools/cache/general/config.js
@@ -26,6 +26,12 @@ const AST_CACHE_CONFIG_KEYS = Object.freeze([
 
 let AST_CACHE_RUNTIME_CONFIG = {};
 
+function astCacheInvalidateScriptPropertiesSnapshotCache() {
+  if (typeof astConfigInvalidateScriptPropertiesSnapshotMemoized === 'function') {
+    astConfigInvalidateScriptPropertiesSnapshotMemoized();
+  }
+}
+
 function astCacheNormalizeConfigValue(value) {
   if (value == null) {
     return null;
@@ -76,15 +82,23 @@ function astCacheSetRuntimeConfig(config = {}, options = {}) {
   }
 
   AST_CACHE_RUNTIME_CONFIG = next;
+  astCacheInvalidateScriptPropertiesSnapshotCache();
   return astCacheGetRuntimeConfig();
 }
 
 function astCacheClearRuntimeConfig() {
   AST_CACHE_RUNTIME_CONFIG = {};
+  astCacheInvalidateScriptPropertiesSnapshotCache();
   return {};
 }
 
 function astCacheGetScriptPropertiesSnapshot() {
+  if (typeof astConfigGetScriptPropertiesSnapshotMemoized === 'function') {
+    return astConfigGetScriptPropertiesSnapshotMemoized({
+      keys: AST_CACHE_CONFIG_KEYS
+    });
+  }
+
   const output = {};
 
   try {

--- a/apps_script_tools/config/Config.js
+++ b/apps_script_tools/config/Config.js
@@ -61,6 +61,49 @@ function astConfigNormalizeValue(value, includeEmpty = false) {
   return null;
 }
 
+let AST_CONFIG_SCRIPT_PROPERTIES_CACHE = {
+  byKey: {}
+};
+
+function astConfigCloneEntries(entries) {
+  if (!astConfigIsPlainObject(entries)) {
+    return {};
+  }
+  return Object.assign({}, entries);
+}
+
+function astConfigBuildSnapshotCacheKey(keys) {
+  const normalizedKeys = astConfigNormalizeKeys(keys);
+  if (!Array.isArray(normalizedKeys) || normalizedKeys.length === 0) {
+    return '*';
+  }
+  return normalizedKeys.slice().sort().join('\u0001');
+}
+
+function astConfigProjectEntriesForKeys(entries, requestedKeys) {
+  if (!Array.isArray(requestedKeys)) {
+    return astConfigCloneEntries(entries);
+  }
+
+  const output = {};
+  for (let idx = 0; idx < requestedKeys.length; idx += 1) {
+    const key = requestedKeys[idx];
+    if (!Object.prototype.hasOwnProperty.call(entries, key)) {
+      continue;
+    }
+    output[key] = entries[key];
+  }
+
+  return output;
+}
+
+function astConfigInvalidateScriptPropertiesSnapshotMemoized() {
+  AST_CONFIG_SCRIPT_PROPERTIES_CACHE = {
+    byKey: {}
+  };
+  return true;
+}
+
 function astConfigResolveScriptPropertiesHandle(options = {}) {
   const providedHandle = options.scriptProperties;
   if (
@@ -127,6 +170,43 @@ function astConfigReadEntriesFromHandle(handle, requestedKeys = null) {
   return output;
 }
 
+function astConfigReadEntriesFromHandleMemoized(handle, requestedKeys = null, options = {}) {
+  if (!handle) {
+    return {};
+  }
+
+  const disableCache = astConfigNormalizeBoolean(options.disableCache, false);
+  const forceRefresh = astConfigNormalizeBoolean(options.forceRefresh, false);
+
+  if (disableCache) {
+    return astConfigReadEntriesFromHandle(handle, requestedKeys);
+  }
+
+  if (forceRefresh) {
+    astConfigInvalidateScriptPropertiesSnapshotMemoized();
+  }
+
+  const cacheKey = astConfigBuildSnapshotCacheKey(requestedKeys);
+  const cache = AST_CONFIG_SCRIPT_PROPERTIES_CACHE;
+
+  if (Object.prototype.hasOwnProperty.call(cache.byKey, cacheKey)) {
+    return astConfigCloneEntries(cache.byKey[cacheKey]);
+  }
+
+  if (
+    cacheKey !== '*'
+    && Object.prototype.hasOwnProperty.call(cache.byKey, '*')
+  ) {
+    const projected = astConfigProjectEntriesForKeys(cache.byKey['*'], requestedKeys);
+    cache.byKey[cacheKey] = astConfigCloneEntries(projected);
+    return projected;
+  }
+
+  const entries = astConfigReadEntriesFromHandle(handle, requestedKeys);
+  cache.byKey[cacheKey] = astConfigCloneEntries(entries);
+  return astConfigCloneEntries(entries);
+}
+
 function astConfigBuildOutput(entries, options = {}) {
   const includeEmpty = astConfigNormalizeBoolean(options.includeEmpty, false);
   const requestedKeys = astConfigNormalizeKeys(options.keys);
@@ -169,9 +249,9 @@ function astConfigBuildOutput(entries, options = {}) {
   return output;
 }
 
-function astConfigFromScriptProperties(options = {}) {
+function astConfigGetScriptPropertiesSnapshotMemoized(options = {}) {
   if (!astConfigIsPlainObject(options)) {
-    throw new Error('AST.Config.fromScriptProperties options must be an object');
+    throw new Error('Script properties snapshot options must be an object');
   }
 
   const requestedKeys = astConfigNormalizeKeys(options.keys);
@@ -193,10 +273,18 @@ function astConfigFromScriptProperties(options = {}) {
   }
 
   const scriptProperties = astConfigResolveScriptPropertiesHandle(options);
-  const entries = astConfigReadEntriesFromHandle(scriptProperties, requestedKeys);
+  const entries = astConfigReadEntriesFromHandleMemoized(scriptProperties, requestedKeys, options);
   return astConfigBuildOutput(entries, Object.assign({}, options, {
     keys: requestedKeys
   }));
+}
+
+function astConfigFromScriptProperties(options = {}) {
+  if (!astConfigIsPlainObject(options)) {
+    throw new Error('AST.Config.fromScriptProperties options must be an object');
+  }
+
+  return astConfigGetScriptPropertiesSnapshotMemoized(options);
 }
 
 const AST_CONFIG = Object.freeze({
@@ -205,6 +293,10 @@ const AST_CONFIG = Object.freeze({
 
 const __astConfigRoot = typeof globalThis !== 'undefined' ? globalThis : this;
 __astConfigRoot.astConfigFromScriptProperties = astConfigFromScriptProperties;
+__astConfigRoot.astConfigGetScriptPropertiesSnapshotMemoized = astConfigGetScriptPropertiesSnapshotMemoized;
+__astConfigRoot.astConfigInvalidateScriptPropertiesSnapshotMemoized = astConfigInvalidateScriptPropertiesSnapshotMemoized;
 __astConfigRoot.AST_CONFIG = AST_CONFIG;
 this.astConfigFromScriptProperties = astConfigFromScriptProperties;
+this.astConfigGetScriptPropertiesSnapshotMemoized = astConfigGetScriptPropertiesSnapshotMemoized;
+this.astConfigInvalidateScriptPropertiesSnapshotMemoized = astConfigInvalidateScriptPropertiesSnapshotMemoized;
 this.AST_CONFIG = AST_CONFIG;

--- a/apps_script_tools/jobs/general/jobStore.js
+++ b/apps_script_tools/jobs/general/jobStore.js
@@ -1,5 +1,11 @@
 let AST_JOBS_RUNTIME_CONFIG = {};
 
+function astJobsInvalidateScriptPropertiesSnapshotCache() {
+  if (typeof astConfigInvalidateScriptPropertiesSnapshotMemoized === 'function') {
+    astConfigInvalidateScriptPropertiesSnapshotMemoized();
+  }
+}
+
 const AST_JOBS_CANONICAL_CONFIG_KEYS = Object.freeze([
   'AST_JOBS_DEFAULT_MAX_RETRIES',
   'AST_JOBS_DEFAULT_MAX_RUNTIME_MS',
@@ -90,11 +96,13 @@ function astJobsSetRuntimeConfig(config = {}, options = {}) {
   });
 
   AST_JOBS_RUNTIME_CONFIG = next;
+  astJobsInvalidateScriptPropertiesSnapshotCache();
   return astJobsGetRuntimeConfig();
 }
 
 function astJobsClearRuntimeConfig() {
   AST_JOBS_RUNTIME_CONFIG = {};
+  astJobsInvalidateScriptPropertiesSnapshotCache();
   return {};
 }
 
@@ -128,9 +136,13 @@ function astJobsReadAllScriptProperties() {
 function astJobsGetScriptConfigSnapshot() {
   const output = {};
   const scriptProperties = astJobsGetScriptPropertiesHandle();
-  const entries = typeof scriptProperties.getProperties === 'function'
-    ? scriptProperties.getProperties()
-    : {};
+  const entries = typeof astConfigGetScriptPropertiesSnapshotMemoized === 'function'
+    ? astConfigGetScriptPropertiesSnapshotMemoized({
+      scriptProperties
+    })
+    : (typeof scriptProperties.getProperties === 'function'
+      ? scriptProperties.getProperties()
+      : {});
 
   if (astJobsIsPlainObject(entries)) {
     Object.keys(entries).forEach(key => {

--- a/apps_script_tools/rag/general/helpers.js
+++ b/apps_script_tools/rag/general/helpers.js
@@ -112,7 +112,16 @@ function astRagTruncate(text, maxChars) {
   return text.slice(0, maxChars);
 }
 
-function astRagToScriptPropertiesSnapshot(allowedKeys) {
+function astRagToScriptPropertiesSnapshot(allowedKeys, options = {}) {
+  const forceRefresh = Boolean(options && options.forceRefresh);
+
+  if (typeof astConfigGetScriptPropertiesSnapshotMemoized === 'function') {
+    return astConfigGetScriptPropertiesSnapshotMemoized({
+      keys: Array.isArray(allowedKeys) ? allowedKeys : [],
+      forceRefresh
+    });
+  }
+
   const output = {};
   const keys = Array.isArray(allowedKeys) ? allowedKeys : [];
 

--- a/apps_script_tools/storage/general/resolveStorageConfig.js
+++ b/apps_script_tools/storage/general/resolveStorageConfig.js
@@ -11,6 +11,12 @@ const AST_STORAGE_CONFIG_KEYS = Object.freeze([
 
 let AST_STORAGE_RUNTIME_CONFIG = {};
 
+function astStorageInvalidateScriptPropertiesSnapshotCache() {
+  if (typeof astConfigInvalidateScriptPropertiesSnapshotMemoized === 'function') {
+    astConfigInvalidateScriptPropertiesSnapshotMemoized();
+  }
+}
+
 function astStorageNormalizeConfigValue(value) {
   if (value == null) {
     return null;
@@ -60,15 +66,23 @@ function astStorageSetRuntimeConfig(config = {}, options = {}) {
   });
 
   AST_STORAGE_RUNTIME_CONFIG = next;
+  astStorageInvalidateScriptPropertiesSnapshotCache();
   return astStorageGetRuntimeConfig();
 }
 
 function astStorageClearRuntimeConfig() {
   AST_STORAGE_RUNTIME_CONFIG = {};
+  astStorageInvalidateScriptPropertiesSnapshotCache();
   return {};
 }
 
 function astStorageGetScriptPropertiesSnapshot() {
+  if (typeof astConfigGetScriptPropertiesSnapshotMemoized === 'function') {
+    return astConfigGetScriptPropertiesSnapshotMemoized({
+      keys: AST_STORAGE_CONFIG_KEYS
+    });
+  }
+
   const output = {};
 
   try {

--- a/tests/local/ai-helpers.mjs
+++ b/tests/local/ai-helpers.mjs
@@ -2,6 +2,7 @@ import { listScriptFiles, loadScripts } from './helpers.mjs';
 
 export function loadAiScripts(context, { includeAst = false } = {}) {
   const shared = [
+    'apps_script_tools/config/Config.js',
     'apps_script_tools/utilities/auth/vertexServiceAccountAuthCore.js'
   ];
   const general = listScriptFiles('apps_script_tools/ai/general');

--- a/tests/local/cache-helpers.mjs
+++ b/tests/local/cache-helpers.mjs
@@ -1,7 +1,9 @@
 import { listScriptFiles, loadScripts } from './helpers.mjs';
 
 export function loadCacheScripts(context, { includeAst = false } = {}) {
-  const paths = [];
+  const paths = [
+    'apps_script_tools/config/Config.js'
+  ];
 
   paths.push(...listScriptFiles('apps_script_tools/cache/general'));
   paths.push(...listScriptFiles('apps_script_tools/cache/backends'));

--- a/tests/local/helpers.mjs
+++ b/tests/local/helpers.mjs
@@ -147,10 +147,19 @@ export function createGasContext(overrides = {}) {
 }
 
 export function loadScripts(context, relativePaths) {
+  if (!context.__loadedScriptFiles || typeof context.__loadedScriptFiles !== 'object') {
+    context.__loadedScriptFiles = {};
+  }
+
   for (const relativePath of relativePaths) {
+    if (context.__loadedScriptFiles[relativePath]) {
+      continue;
+    }
+
     const fullPath = path.join(ROOT, relativePath);
     const source = fs.readFileSync(fullPath, 'utf8');
     vm.runInContext(source, context, { filename: relativePath });
+    context.__loadedScriptFiles[relativePath] = true;
   }
   return context;
 }

--- a/tests/local/jobs-helpers.mjs
+++ b/tests/local/jobs-helpers.mjs
@@ -1,7 +1,9 @@
 import { listScriptFiles, loadScripts } from './helpers.mjs';
 
 export function loadJobsScripts(context, { includeAst = false } = {}) {
-  const paths = [];
+  const paths = [
+    'apps_script_tools/config/Config.js'
+  ];
 
   paths.push(...listScriptFiles('apps_script_tools/jobs/general'));
   paths.push('apps_script_tools/jobs/Jobs.js');

--- a/tests/local/rag-helpers.mjs
+++ b/tests/local/rag-helpers.mjs
@@ -9,6 +9,7 @@ export function loadRagScripts(
   } = {}
 ) {
   const paths = [];
+  paths.push('apps_script_tools/config/Config.js');
 
   if (includeUtilities) {
     paths.push(...listScriptFiles('apps_script_tools/utilities'));

--- a/tests/local/storage-helpers.mjs
+++ b/tests/local/storage-helpers.mjs
@@ -1,7 +1,9 @@
 import { listScriptFiles, loadScripts } from './helpers.mjs';
 
 export function loadStorageScripts(context, { includeAst = false } = {}) {
-  const paths = [];
+  const paths = [
+    'apps_script_tools/config/Config.js'
+  ];
 
   paths.push(...listScriptFiles('apps_script_tools/storage/general'));
   paths.push(


### PR DESCRIPTION
## Summary
- add shared per-execution script-properties snapshot memoization in AST.Config
- wire AI/Storage/Cache/Jobs/RAG hot-path config readers to the shared memoized snapshot helper
- add explicit snapshot cache invalidation hooks in module configure/clearConfig runtime config paths
- preserve vertex service-account key-rotation behavior by force-refreshing script config in vertex resolution paths
- dedupe local test script loading to avoid duplicate declaration collisions when helper loaders include shared config module

## Tests
- npm run lint
- npm run test:local
- npm run test:perf:check
- mkdocs build --strict
- clasp run runAllTests

Closes #84