### PR TITLE
Breaking: enforce strict internal naming convention (remove legacy allowlist)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
 ### Changed
 
 - `AST.VERSION` and package version moved to `0.0.4` development line.
+- Breaking: internal non-`AST` top-level functions are now strictly internalized (`ast*` / `__ast*` / `*_` naming). Downstream consumers must use documented `AST` namespace APIs instead of direct global helper/function names.
 - `AST` namespace now exposes `AST.RAG`.
 - `AST` namespace now exposes `AST.Cache`.
 - `AST` namespace now exposes `AST.Storage`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,17 @@ Before opening a PR:
 - Prefer explicit validation for public request objects.
 - Keep Apps Script service usage least-privilege and documented.
 
+## Naming Convention (Top-Level Functions)
+
+- Public top-level functions must be explicitly exposed:
+  - via `AST` bindings in `apps_script_tools/AST.js`, or
+  - via explicit global assignment (`this.<name> = ...` / `globalThis.<name> = ...`).
+- Internal-only top-level functions must be clearly marked with one of:
+  - prefix `ast` (for example `astResolveCacheConfig`)
+  - prefix `__ast` (private test/debug hooks)
+  - suffix `_` (entrypoint/helpers intentionally scoped as internal scripts)
+- Non-compliant top-level function names are blocked by `npm run lint` (no legacy exceptions).
+
 ## Test Expectations
 
 - Add regression tests for every bug fix.

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Notes:
 - Docs check: `mkdocs build --strict`
 - Apps Script integration checks: `.github/workflows/integration-gas.yml`
 - Optional live AI smoke checks: `.github/workflows/integration-ai-live.yml`
+- Naming convention and contribution rules: `CONTRIBUTING.md`
 
 ## Release
 

--- a/apps_script_tools/AST.js
+++ b/apps_script_tools/AST.js
@@ -76,7 +76,7 @@ const AST_UTILITY_NAMES = Object.freeze([
 ]);
 const AST_UTILS = {};
 
-function resolveAstBinding(name, lexicalResolver) {
+function astResolveAstBinding(name, lexicalResolver) {
   if (typeof lexicalResolver === 'function') {
     const lexicalValue = lexicalResolver();
     if (typeof lexicalValue !== 'undefined') {
@@ -88,7 +88,7 @@ function resolveAstBinding(name, lexicalResolver) {
 
 AST_UTILITY_NAMES.forEach(name => {
   Object.defineProperty(AST_UTILS, name, {
-    get: () => resolveAstBinding(name, () => AST_GLOBAL[name]),
+    get: () => astResolveAstBinding(name, () => AST_GLOBAL[name]),
     enumerable: true
   });
 });
@@ -101,83 +101,83 @@ Object.defineProperties(AST, {
     enumerable: true
   },
   Series: {
-    get: () => resolveAstBinding('Series', () => (typeof Series === 'undefined' ? undefined : Series)),
+    get: () => astResolveAstBinding('Series', () => (typeof Series === 'undefined' ? undefined : Series)),
     enumerable: true
   },
   DataFrame: {
-    get: () => resolveAstBinding('DataFrame', () => (typeof DataFrame === 'undefined' ? undefined : DataFrame)),
+    get: () => astResolveAstBinding('DataFrame', () => (typeof DataFrame === 'undefined' ? undefined : DataFrame)),
     enumerable: true
   },
   GroupBy: {
-    get: () => resolveAstBinding('GroupBy', () => (typeof GroupBy === 'undefined' ? undefined : GroupBy)),
+    get: () => astResolveAstBinding('GroupBy', () => (typeof GroupBy === 'undefined' ? undefined : GroupBy)),
     enumerable: true
   },
   Sheets: {
     get: () => ({
-      openById: resolveAstBinding('openSpreadsheetById', () => (typeof openSpreadsheetById === 'undefined' ? undefined : openSpreadsheetById)),
-      openByUrl: resolveAstBinding('openSpreadsheetByUrl', () => (typeof openSpreadsheetByUrl === 'undefined' ? undefined : openSpreadsheetByUrl)),
-      EnhancedSheet: resolveAstBinding('EnhancedSheet', () => (typeof EnhancedSheet === 'undefined' ? undefined : EnhancedSheet)),
-      EnhancedSpreadsheet: resolveAstBinding('EnhancedSpreadsheet', () => (typeof EnhancedSpreadsheet === 'undefined' ? undefined : EnhancedSpreadsheet)),
-      numberToSheetRangeNotation: resolveAstBinding('numberToSheetRangeNotation', () => (typeof numberToSheetRangeNotation === 'undefined' ? undefined : numberToSheetRangeNotation))
+      openById: astResolveAstBinding('openSpreadsheetById', () => (typeof openSpreadsheetById === 'undefined' ? undefined : openSpreadsheetById)),
+      openByUrl: astResolveAstBinding('openSpreadsheetByUrl', () => (typeof openSpreadsheetByUrl === 'undefined' ? undefined : openSpreadsheetByUrl)),
+      EnhancedSheet: astResolveAstBinding('EnhancedSheet', () => (typeof EnhancedSheet === 'undefined' ? undefined : EnhancedSheet)),
+      EnhancedSpreadsheet: astResolveAstBinding('EnhancedSpreadsheet', () => (typeof EnhancedSpreadsheet === 'undefined' ? undefined : EnhancedSpreadsheet)),
+      numberToSheetRangeNotation: astResolveAstBinding('numberToSheetRangeNotation', () => (typeof numberToSheetRangeNotation === 'undefined' ? undefined : numberToSheetRangeNotation))
     }),
     enumerable: true
   },
   Drive: {
     get: () => ({
-      read: resolveAstBinding('readFileFromDrive', () => (typeof readFileFromDrive === 'undefined' ? undefined : readFileFromDrive)),
-      create: resolveAstBinding('createFileInDrive', () => (typeof createFileInDrive === 'undefined' ? undefined : createFileInDrive))
+      read: astResolveAstBinding('readFileFromDrive', () => (typeof readFileFromDrive === 'undefined' ? undefined : readFileFromDrive)),
+      create: astResolveAstBinding('createFileInDrive', () => (typeof createFileInDrive === 'undefined' ? undefined : createFileInDrive))
     }),
     enumerable: true
   },
   AI: {
-    get: () => resolveAstBinding('AST_AI', () => (typeof AST_AI === 'undefined' ? undefined : AST_AI)),
+    get: () => astResolveAstBinding('AST_AI', () => (typeof AST_AI === 'undefined' ? undefined : AST_AI)),
     enumerable: true
   },
   RAG: {
-    get: () => resolveAstBinding('AST_RAG', () => (typeof AST_RAG === 'undefined' ? undefined : AST_RAG)),
+    get: () => astResolveAstBinding('AST_RAG', () => (typeof AST_RAG === 'undefined' ? undefined : AST_RAG)),
     enumerable: true
   },
   Cache: {
-    get: () => resolveAstBinding('AST_CACHE', () => (typeof AST_CACHE === 'undefined' ? undefined : AST_CACHE)),
+    get: () => astResolveAstBinding('AST_CACHE', () => (typeof AST_CACHE === 'undefined' ? undefined : AST_CACHE)),
     enumerable: true
   },
   Storage: {
-    get: () => resolveAstBinding('AST_STORAGE', () => (typeof AST_STORAGE === 'undefined' ? undefined : AST_STORAGE)),
+    get: () => astResolveAstBinding('AST_STORAGE', () => (typeof AST_STORAGE === 'undefined' ? undefined : AST_STORAGE)),
     enumerable: true
   },
   Config: {
-    get: () => resolveAstBinding('AST_CONFIG', () => (typeof AST_CONFIG === 'undefined' ? undefined : AST_CONFIG)),
+    get: () => astResolveAstBinding('AST_CONFIG', () => (typeof AST_CONFIG === 'undefined' ? undefined : AST_CONFIG)),
     enumerable: true
   },
   Runtime: {
-    get: () => resolveAstBinding('AST_RUNTIME', () => (typeof AST_RUNTIME === 'undefined' ? undefined : AST_RUNTIME)),
+    get: () => astResolveAstBinding('AST_RUNTIME', () => (typeof AST_RUNTIME === 'undefined' ? undefined : AST_RUNTIME)),
     enumerable: true
   },
   Telemetry: {
-    get: () => resolveAstBinding('AST_TELEMETRY', () => (typeof AST_TELEMETRY === 'undefined' ? undefined : AST_TELEMETRY)),
+    get: () => astResolveAstBinding('AST_TELEMETRY', () => (typeof AST_TELEMETRY === 'undefined' ? undefined : AST_TELEMETRY)),
     enumerable: true
   },
   TelemetryHelpers: {
-    get: () => resolveAstBinding('AST_TELEMETRY_HELPERS', () => (typeof AST_TELEMETRY_HELPERS === 'undefined' ? undefined : AST_TELEMETRY_HELPERS)),
+    get: () => astResolveAstBinding('AST_TELEMETRY_HELPERS', () => (typeof AST_TELEMETRY_HELPERS === 'undefined' ? undefined : AST_TELEMETRY_HELPERS)),
     enumerable: true
   },
   Jobs: {
-    get: () => resolveAstBinding('AST_JOBS', () => (typeof AST_JOBS === 'undefined' ? undefined : AST_JOBS)),
+    get: () => astResolveAstBinding('AST_JOBS', () => (typeof AST_JOBS === 'undefined' ? undefined : AST_JOBS)),
     enumerable: true
   },
   Chat: {
-    get: () => resolveAstBinding('AST_CHAT', () => (typeof AST_CHAT === 'undefined' ? undefined : AST_CHAT)),
+    get: () => astResolveAstBinding('AST_CHAT', () => (typeof AST_CHAT === 'undefined' ? undefined : AST_CHAT)),
     enumerable: true
   },
   Sql: {
     get: () => ({
-      run: resolveAstBinding('runSqlQuery', () => (typeof runSqlQuery === 'undefined' ? undefined : runSqlQuery)),
-      prepare: resolveAstBinding('astSqlPrepare', () => (typeof astSqlPrepare === 'undefined' ? undefined : astSqlPrepare)),
-      executePrepared: resolveAstBinding('astSqlExecutePrepared', () => (typeof astSqlExecutePrepared === 'undefined' ? undefined : astSqlExecutePrepared)),
-      status: resolveAstBinding('astSqlStatus', () => (typeof astSqlStatus === 'undefined' ? undefined : astSqlStatus)),
-      cancel: resolveAstBinding('astSqlCancel', () => (typeof astSqlCancel === 'undefined' ? undefined : astSqlCancel)),
-      providers: resolveAstBinding('astListSqlProviders', () => (typeof astListSqlProviders === 'undefined' ? undefined : astListSqlProviders)),
-      capabilities: resolveAstBinding('astGetSqlProviderCapabilities', () => (typeof astGetSqlProviderCapabilities === 'undefined' ? undefined : astGetSqlProviderCapabilities))
+      run: astResolveAstBinding('runSqlQuery', () => (typeof runSqlQuery === 'undefined' ? undefined : runSqlQuery)),
+      prepare: astResolveAstBinding('astSqlPrepare', () => (typeof astSqlPrepare === 'undefined' ? undefined : astSqlPrepare)),
+      executePrepared: astResolveAstBinding('astSqlExecutePrepared', () => (typeof astSqlExecutePrepared === 'undefined' ? undefined : astSqlExecutePrepared)),
+      status: astResolveAstBinding('astSqlStatus', () => (typeof astSqlStatus === 'undefined' ? undefined : astSqlStatus)),
+      cancel: astResolveAstBinding('astSqlCancel', () => (typeof astSqlCancel === 'undefined' ? undefined : astSqlCancel)),
+      providers: astResolveAstBinding('astListSqlProviders', () => (typeof astListSqlProviders === 'undefined' ? undefined : astListSqlProviders)),
+      capabilities: astResolveAstBinding('astGetSqlProviderCapabilities', () => (typeof astGetSqlProviderCapabilities === 'undefined' ? undefined : astGetSqlProviderCapabilities))
     }),
     enumerable: true
   },

--- a/apps_script_tools/ai/AI.js
+++ b/apps_script_tools/ai/AI.js
@@ -1,25 +1,25 @@
 function astAiRun(request = {}) {
-  return runAiRequest(request);
+  return astRunAiRequest(request);
 }
 
 function astAiText(request = {}) {
-  return runAiRequest(Object.assign({}, request, { operation: 'text' }));
+  return astRunAiRequest(Object.assign({}, request, { operation: 'text' }));
 }
 
 function astAiStructured(request = {}) {
-  return runAiRequest(Object.assign({}, request, { operation: 'structured' }));
+  return astRunAiRequest(Object.assign({}, request, { operation: 'structured' }));
 }
 
 function astAiTools(request = {}) {
-  return runAiRequest(Object.assign({}, request, { operation: 'tools' }));
+  return astRunAiRequest(Object.assign({}, request, { operation: 'tools' }));
 }
 
 function astAiImage(request = {}) {
-  return runAiRequest(Object.assign({}, request, { operation: 'image' }));
+  return astRunAiRequest(Object.assign({}, request, { operation: 'image' }));
 }
 
 function astAiStream(request = {}) {
-  return runAiRequest(Object.assign({}, request, {
+  return astRunAiRequest(Object.assign({}, request, {
     options: Object.assign({}, request.options || {}, { stream: true })
   }));
 }

--- a/apps_script_tools/ai/gemini/runGemini.js
+++ b/apps_script_tools/ai/gemini/runGemini.js
@@ -26,7 +26,7 @@ function astGeminiProviderOptions(providerOptions, omitKeys = []) {
   return output;
 }
 
-function runGemini(request, config) {
+function astRunGemini(request, config) {
   const includeRaw = request.options.includeRaw === true;
   const endpoint = astBuildGeminiEndpoint(config, request.providerOptions);
 
@@ -113,7 +113,7 @@ function runGemini(request, config) {
     });
   }
 
-  return normalizeAiResponse({
+  return astNormalizeAiResponse({
     provider: 'gemini',
     operation: request.operation,
     model: config.model,

--- a/apps_script_tools/ai/general/normalizeAiResponse.js
+++ b/apps_script_tools/ai/general/normalizeAiResponse.js
@@ -67,7 +67,7 @@ function astNormalizeImages(images) {
     .filter(Boolean);
 }
 
-function normalizeAiResponse(payload = {}) {
+function astNormalizeAiResponse(payload = {}) {
   const output = payload.output || {};
   const includeRaw = payload.includeRaw === true;
 

--- a/apps_script_tools/ai/general/outputRepair.js
+++ b/apps_script_tools/ai/general/outputRepair.js
@@ -202,7 +202,7 @@ function astAiContinueIfTruncated(request = {}) {
   for (let pass = 1; pass <= passes; pass += 1) {
     passesUsed = pass;
     const prompt = astAiBuildContinuationPrompt(text, request.question, request.citations);
-    const response = runAiRequest({
+    const response = astRunAiRequest({
       provider,
       operation: 'text',
       model,

--- a/apps_script_tools/ai/general/resolveAiConfig.js
+++ b/apps_script_tools/ai/general/resolveAiConfig.js
@@ -188,9 +188,9 @@ function astResolveConfigString({
   return null;
 }
 
-function resolveAiConfig(request) {
+function astResolveAiConfig(request) {
   if (!request || typeof request !== 'object') {
-    throw new AstAiValidationError('resolveAiConfig expected a normalized AI request object');
+    throw new AstAiValidationError('astResolveAiConfig expected a normalized AI request object');
   }
 
   const auth = request.auth || {};
@@ -379,6 +379,6 @@ function resolveAiConfig(request) {
     }
 
     default:
-      throw new AstAiValidationError('Unknown provider in resolveAiConfig', { provider });
+      throw new AstAiValidationError('Unknown provider in astResolveAiConfig', { provider });
   }
 }

--- a/apps_script_tools/ai/general/runAiRequest.js
+++ b/apps_script_tools/ai/general/runAiRequest.js
@@ -1,15 +1,15 @@
 function astGetAiProviderExecutor(provider) {
   switch (provider) {
     case 'openai':
-      return runOpenAi;
+      return astRunOpenAi;
     case 'gemini':
-      return runGemini;
+      return astRunGemini;
     case 'vertex_gemini':
-      return runVertexGemini;
+      return astRunVertexGemini;
     case 'openrouter':
-      return runOpenRouter;
+      return astRunOpenRouter;
     case 'perplexity':
-      return runPerplexity;
+      return astRunPerplexity;
     default:
       throw new AstAiValidationError('Unsupported AI provider', { provider });
   }
@@ -90,7 +90,7 @@ function astExecuteAiRequestDirect(normalizedRequest) {
   astAssertAiCapability(normalizedRequest.provider, normalizedRequest.operation);
   astAssertAiInputCapabilities(normalizedRequest);
 
-  const config = resolveAiConfig(normalizedRequest);
+  const config = astResolveAiConfig(normalizedRequest);
   const providerExecutor = astGetAiProviderExecutor(normalizedRequest.provider);
 
   if (normalizedRequest.options.stream) {
@@ -118,12 +118,12 @@ function astDispatchAiRequest(normalizedRequest) {
     : astExecuteAiRequestWithReliability(normalizedRequest);
 }
 
-function runAiRequest(request = {}) {
+function astRunAiRequest(request = {}) {
   let normalizedRequest = null;
   const spanId = astAiTelemetryStartSpan(request, null);
 
   try {
-    normalizedRequest = validateAiRequest(request);
+    normalizedRequest = astValidateAiRequest(request);
 
     const response = astDispatchAiRequest(normalizedRequest);
 

--- a/apps_script_tools/ai/general/validateAiRequest.js
+++ b/apps_script_tools/ai/general/validateAiRequest.js
@@ -210,7 +210,7 @@ function astNormalizeAiOptions(options = {}) {
   };
 }
 
-function validateAiRequest(request = {}, forcedOperation) {
+function astValidateAiRequest(request = {}, forcedOperation) {
   if (!astIsPlainObject(request)) {
     throw new AstAiValidationError('AI request must be an object');
   }

--- a/apps_script_tools/ai/openai/runOpenAi.js
+++ b/apps_script_tools/ai/openai/runOpenAi.js
@@ -16,7 +16,7 @@ function astOpenAiCopyProviderOptions(providerOptions = {}, omitKeys = []) {
   return output;
 }
 
-function runOpenAi(request, config) {
+function astRunOpenAi(request, config) {
   const includeRaw = request.options.includeRaw === true;
 
   if (request.operation === 'image') {
@@ -54,7 +54,7 @@ function runOpenAi(request, config) {
       });
     }
 
-    return normalizeAiResponse({
+    return astNormalizeAiResponse({
       provider: 'openai',
       operation: 'image',
       model: config.model,
@@ -131,7 +131,7 @@ function runOpenAi(request, config) {
     structuredJson = astAiSafeJsonParse(text);
   }
 
-  return normalizeAiResponse({
+  return astNormalizeAiResponse({
     provider: 'openai',
     operation: request.operation,
     model: responseJson.model || config.model,

--- a/apps_script_tools/ai/openrouter/runOpenRouter.js
+++ b/apps_script_tools/ai/openrouter/runOpenRouter.js
@@ -26,7 +26,7 @@ function astOpenRouterProviderOptions(providerOptions = {}, omitKeys = []) {
   return output;
 }
 
-function runOpenRouter(request, config) {
+function astRunOpenRouter(request, config) {
   const includeRaw = request.options.includeRaw === true;
 
   if (request.operation === 'image') {
@@ -55,7 +55,7 @@ function runOpenRouter(request, config) {
       });
     }
 
-    return normalizeAiResponse({
+    return astNormalizeAiResponse({
       provider: 'openrouter',
       operation: 'image',
       model: config.model,
@@ -133,7 +133,7 @@ function runOpenRouter(request, config) {
     structuredJson = astAiSafeJsonParse(text);
   }
 
-  return normalizeAiResponse({
+  return astNormalizeAiResponse({
     provider: 'openrouter',
     operation: request.operation,
     model: responseJson.model || config.model,

--- a/apps_script_tools/ai/perplexity/runPerplexity.js
+++ b/apps_script_tools/ai/perplexity/runPerplexity.js
@@ -10,7 +10,7 @@ function astPerplexityProviderOptions(providerOptions = {}, omitKeys = []) {
   return output;
 }
 
-function runPerplexity(request, config) {
+function astRunPerplexity(request, config) {
   const includeRaw = request.options.includeRaw === true;
   const endpoint = request.providerOptions.chatEndpoint || 'https://api.perplexity.ai/chat/completions';
 
@@ -76,7 +76,7 @@ function runPerplexity(request, config) {
       });
     }
 
-    return normalizeAiResponse({
+    return astNormalizeAiResponse({
       provider: 'perplexity',
       operation: 'image',
       model: responseJson.model || config.model,
@@ -104,7 +104,7 @@ function runPerplexity(request, config) {
     structuredJson = astAiSafeJsonParse(text);
   }
 
-  return normalizeAiResponse({
+  return astNormalizeAiResponse({
     provider: 'perplexity',
     operation: request.operation,
     model: responseJson.model || config.model,

--- a/apps_script_tools/ai/vertexGemini/runVertexGemini.js
+++ b/apps_script_tools/ai/vertexGemini/runVertexGemini.js
@@ -18,7 +18,7 @@ function astVertexProviderOptions(providerOptions = {}, omitKeys = []) {
   return output;
 }
 
-function runVertexGemini(request, config) {
+function astRunVertexGemini(request, config) {
   const includeRaw = request.options.includeRaw === true;
   const endpoint = astBuildVertexGeminiEndpoint(config, request.providerOptions);
 
@@ -98,7 +98,7 @@ function runVertexGemini(request, config) {
     structuredJson = astAiSafeJsonParse(parsed.text);
   }
 
-  return normalizeAiResponse({
+  return astNormalizeAiResponse({
     provider: 'vertex_gemini',
     operation: request.operation,
     model: config.model,

--- a/apps_script_tools/cache/backends/storageJson.js
+++ b/apps_script_tools/cache/backends/storageJson.js
@@ -7,12 +7,12 @@ const AST_CACHE_STORAGE_TRIM_BATCH_SIZE = 64;
 const AST_CACHE_STORAGE_HARD_MAX_LIST_ITEMS = 2000000;
 
 function astCacheStorageRequireRunner() {
-  if (typeof runStorageRequest === 'function') {
-    return runStorageRequest;
+  if (typeof astRunStorageRequest === 'function') {
+    return astRunStorageRequest;
   }
 
   throw new AstCacheCapabilityError(
-    'runStorageRequest is required for cache storage_json backend'
+    'astRunStorageRequest is required for cache storage_json backend'
   );
 }
 

--- a/apps_script_tools/cache/general/helpers.js
+++ b/apps_script_tools/cache/general/helpers.js
@@ -11,10 +11,6 @@ function astCacheNormalizeString(value, fallback = '') {
   return normalized.length > 0 ? normalized : fallback;
 }
 
-function astCacheNormalizeBoolean(value, fallback = false) {
-  return typeof value === 'boolean' ? value : fallback;
-}
-
 function astCacheNormalizePositiveInt(value, fallback, minValue = 1, maxValue = 2147483647) {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) {
@@ -31,10 +27,6 @@ function astCacheNormalizePositiveInt(value, fallback, minValue = 1, maxValue = 
 
 function astCacheNowMs() {
   return Date.now();
-}
-
-function astCacheNowIsoString() {
-  return new Date().toISOString();
 }
 
 function astCacheTryOrFallback(task, fallback) {

--- a/apps_script_tools/config/Config.js
+++ b/apps_script_tools/config/Config.js
@@ -109,23 +109,6 @@ function astConfigBuildSnapshotCacheKey(keys) {
   return normalizedKeys.slice().sort().join('\u0001');
 }
 
-function astConfigProjectEntriesForKeys(entries, requestedKeys) {
-  if (!Array.isArray(requestedKeys)) {
-    return astConfigCloneEntries(entries);
-  }
-
-  const output = {};
-  for (let idx = 0; idx < requestedKeys.length; idx += 1) {
-    const key = requestedKeys[idx];
-    if (!Object.prototype.hasOwnProperty.call(entries, key)) {
-      continue;
-    }
-    output[key] = entries[key];
-  }
-
-  return output;
-}
-
 function astConfigInvalidateScriptPropertiesSnapshotMemoized() {
   AST_CONFIG_SCRIPT_PROPERTIES_CACHE = {
     nextHandleId: 1,

--- a/apps_script_tools/dataFrame/DataFrame.js
+++ b/apps_script_tools/dataFrame/DataFrame.js
@@ -1628,10 +1628,10 @@ var DataFrame = class DataFrame {
 
     switch (provider) {
       case 'databricks':
-        loadDatabricksTable(tableConfig);
+        astLoadDatabricksTable(tableConfig);
         return this;
       case 'bigquery':
-        loadBigQueryTable(tableConfig);
+        astLoadBigQueryTable(tableConfig);
         return this;
       default:
         throw new Error('Provider must be one of: databricks, bigquery');

--- a/apps_script_tools/database/general/replacePlaceHoldersInQuery.js
+++ b/apps_script_tools/database/general/replacePlaceHoldersInQuery.js
@@ -1,5 +1,5 @@
 /**
- * @function replacePlaceHoldersInQuery
+ * @function astReplacePlaceHoldersInQuery
  * @description Replaces placeholders in a SQL query with provided values. Placeholders are specified in 
  *              the format `{{key}}` and are replaced with their corresponding values. String values are 
  *              automatically wrapped in single quotes.
@@ -12,7 +12,7 @@
  * const query = "SELECT * FROM users WHERE region = {{region}} AND age > {{minAge}}";
  * const placeholders = { region: "North", minAge: 25 };
  * 
- * const finalQuery = replacePlaceHoldersInQuery(query, placeholders);
+ * const finalQuery = astReplacePlaceHoldersInQuery(query, placeholders);
  * console.log(finalQuery);
  * // Output: "SELECT * FROM users WHERE region = 'North' AND age > 25"
  * 
@@ -28,7 +28,7 @@ function astEscapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function replacePlaceHoldersInQuery(query, placeholders) {
+function astReplacePlaceHoldersInQuery(query, placeholders) {
   if (typeof query !== 'string') {
     throw new Error('Query must be a string');
   }

--- a/apps_script_tools/database/general/runSqlQuery.js
+++ b/apps_script_tools/database/general/runSqlQuery.js
@@ -429,7 +429,7 @@ function astSqlExecutePrepared(request = {}) {
     astSqlIsPlainObject(request.options) ? request.options : {}
   );
 
-  const normalizedRequest = validateSqlRequest({
+  const normalizedRequest = astValidateSqlRequest({
     provider: prepared.provider,
     sql: renderedSql,
     parameters: mergedParameters,
@@ -551,7 +551,7 @@ function astSqlCancel(request = {}) {
 }
 
 function runSqlQuery(request = {}) {
-  const normalizedRequest = validateSqlRequest(request);
+  const normalizedRequest = astValidateSqlRequest(request);
   const adapter = astGetSqlProviderAdapter(normalizedRequest.provider);
 
   try {

--- a/apps_script_tools/database/general/sqlProviderAdapters.js
+++ b/apps_script_tools/database/general/sqlProviderAdapters.js
@@ -1,4 +1,4 @@
-function buildSqlProviderValidationError(message, details = {}, cause = null) {
+function astBuildSqlProviderValidationError(message, details = {}, cause = null) {
   const error = new Error(message);
   error.name = 'SqlProviderValidationError';
   error.provider = details.provider || 'sql_router';
@@ -22,7 +22,7 @@ function astCreateBigQuerySqlAdapter() {
     },
     validateRequest: request => request,
     executeQuery: request => {
-      return runBigQuerySql(
+      return astRunBigQuerySql(
         request.sql,
         request.parameters,
         request.placeholders,
@@ -30,8 +30,8 @@ function astCreateBigQuerySqlAdapter() {
       );
     },
     executePrepared: request => {
-      if (typeof executeBigQuerySqlDetailed === 'function') {
-        return executeBigQuerySqlDetailed(
+      if (typeof astExecuteBigQuerySqlDetailed === 'function') {
+        return astExecuteBigQuerySqlDetailed(
           request.sql,
           request.parameters,
           request.placeholders || {},
@@ -40,7 +40,7 @@ function astCreateBigQuerySqlAdapter() {
       }
 
       return {
-        dataFrame: runBigQuerySql(
+        dataFrame: astRunBigQuerySql(
           request.sql,
           request.parameters,
           request.placeholders || {},
@@ -50,25 +50,25 @@ function astCreateBigQuerySqlAdapter() {
       };
     },
     getStatus: request => {
-      if (typeof getBigQuerySqlStatus !== 'function') {
-        throw buildSqlProviderValidationError('BigQuery status helper is not available', {
+      if (typeof astGetBigQuerySqlStatus !== 'function') {
+        throw astBuildSqlProviderValidationError('BigQuery status helper is not available', {
           provider: 'bigquery'
         });
       }
 
-      return getBigQuerySqlStatus(
+      return astGetBigQuerySqlStatus(
         request.parameters,
         request.jobId || request.executionId
       );
     },
     cancelExecution: request => {
-      if (typeof cancelBigQuerySql !== 'function') {
-        throw buildSqlProviderValidationError('BigQuery cancel helper is not available', {
+      if (typeof astCancelBigQuerySql !== 'function') {
+        throw astBuildSqlProviderValidationError('BigQuery cancel helper is not available', {
           provider: 'bigquery'
         });
       }
 
-      return cancelBigQuerySql(
+      return astCancelBigQuerySql(
         request.parameters,
         request.jobId || request.executionId
       );
@@ -90,7 +90,7 @@ function astCreateDatabricksSqlAdapter() {
     },
     validateRequest: request => request,
     executeQuery: request => {
-      return runDatabricksSql(
+      return astRunDatabricksSql(
         request.sql,
         request.parameters,
         request.placeholders,
@@ -98,8 +98,8 @@ function astCreateDatabricksSqlAdapter() {
       );
     },
     executePrepared: request => {
-      if (typeof executeDatabricksSqlDetailed === 'function') {
-        return executeDatabricksSqlDetailed(
+      if (typeof astExecuteDatabricksSqlDetailed === 'function') {
+        return astExecuteDatabricksSqlDetailed(
           request.sql,
           request.parameters,
           request.placeholders || {},
@@ -108,7 +108,7 @@ function astCreateDatabricksSqlAdapter() {
       }
 
       return {
-        dataFrame: runDatabricksSql(
+        dataFrame: astRunDatabricksSql(
           request.sql,
           request.parameters,
           request.placeholders || {},
@@ -118,25 +118,25 @@ function astCreateDatabricksSqlAdapter() {
       };
     },
     getStatus: request => {
-      if (typeof getDatabricksSqlStatus !== 'function') {
-        throw buildSqlProviderValidationError('Databricks status helper is not available', {
+      if (typeof astGetDatabricksSqlStatus !== 'function') {
+        throw astBuildSqlProviderValidationError('Databricks status helper is not available', {
           provider: 'databricks'
         });
       }
 
-      return getDatabricksSqlStatus(
+      return astGetDatabricksSqlStatus(
         request.parameters,
         request.statementId || request.executionId
       );
     },
     cancelExecution: request => {
-      if (typeof cancelDatabricksSql !== 'function') {
-        throw buildSqlProviderValidationError('Databricks cancel helper is not available', {
+      if (typeof astCancelDatabricksSql !== 'function') {
+        throw astBuildSqlProviderValidationError('Databricks cancel helper is not available', {
           provider: 'databricks'
         });
       }
 
-      return cancelDatabricksSql(
+      return astCancelDatabricksSql(
         request.parameters,
         request.statementId || request.executionId
       );
@@ -154,7 +154,7 @@ function astGetSqlProviderAdapter(provider) {
   const adapter = AST_SQL_PROVIDER_ADAPTERS[provider];
 
   if (!adapter) {
-    throw buildSqlProviderValidationError(
+    throw astBuildSqlProviderValidationError(
       'Provider must be one of: databricks, bigquery',
       {
         provider,

--- a/apps_script_tools/database/general/validateSqlRequest.js
+++ b/apps_script_tools/database/general/validateSqlRequest.js
@@ -1,5 +1,5 @@
 /**
- * @function validateSqlRequest
+ * @function astValidateSqlRequest
  * @description Validates and normalizes a SQL request object used by `runSqlQuery`.
  *              Placeholder interpolation is disabled by default for security.
  * @param {Object} request - SQL execution request.
@@ -13,7 +13,7 @@
  * @param {Number} [request.options.pollIntervalMs=500] - Poll interval for providers that support it.
  * @returns {Object} Normalized SQL request.
  */
-function validateSqlRequest(request = {}) {
+function astValidateSqlRequest(request = {}) {
   if (request == null || typeof request !== 'object' || Array.isArray(request)) {
     throw new Error('SQL request must be an object');
   }

--- a/apps_script_tools/rag/general/answerWithRag.js
+++ b/apps_script_tools/rag/general/answerWithRag.js
@@ -831,8 +831,8 @@ function astRagAnswerCore(request = {}) {
       return preparedInsufficient;
     }
 
-    if (typeof runAiRequest !== 'function') {
-      throw new AstRagGroundingError('runAiRequest is not available; AST.AI runtime is required for RAG.answer');
+    if (typeof astRunAiRequest !== 'function') {
+      throw new AstRagGroundingError('astRunAiRequest is not available; AST.AI runtime is required for RAG.answer');
     }
 
     diagnostics.generation.status = 'started';
@@ -855,7 +855,7 @@ function astRagAnswerCore(request = {}) {
         diagnostics.retrieval.contextBudget = astRagCloneObject(prompt.contextStats);
       }
 
-      const aiResponse = runAiRequest({
+      const aiResponse = astRunAiRequest({
         provider: normalizedRequest.generation.provider,
         operation: 'structured',
         model: normalizedRequest.generation.model,

--- a/apps_script_tools/rag/general/citations.js
+++ b/apps_script_tools/rag/general/citations.js
@@ -133,10 +133,3 @@ function astRagCitationToUrl(citation = {}) {
 
   return normalized.url;
 }
-
-const AST_RAG_CITATIONS = Object.freeze({
-  normalizeInline: astRagCitationNormalizeInline,
-  extractInlineIds: astRagCitationExtractIds,
-  filterForAnswer: astRagCitationFilterForAnswer,
-  toUrl: astRagCitationToUrl
-});

--- a/apps_script_tools/rag/general/fallback.js
+++ b/apps_script_tools/rag/general/fallback.js
@@ -6,25 +6,6 @@ function astRagFallbackNormalizeIntent(value, fallback = AST_RAG_DEFAULT_FALLBAC
   return normalized;
 }
 
-function astRagFallbackNormalizePolicy(policy = {}) {
-  if (!astRagIsPlainObject(policy)) {
-    return astRagCloneObject(AST_RAG_DEFAULT_FALLBACK);
-  }
-
-  return {
-    onRetrievalError: astRagNormalizeBoolean(
-      policy.onRetrievalError,
-      AST_RAG_DEFAULT_FALLBACK.onRetrievalError
-    ),
-    onRetrievalEmpty: astRagNormalizeBoolean(
-      policy.onRetrievalEmpty,
-      AST_RAG_DEFAULT_FALLBACK.onRetrievalEmpty
-    ),
-    intent: astRagFallbackNormalizeIntent(policy.intent, AST_RAG_DEFAULT_FALLBACK.intent),
-    factCount: astRagNormalizePositiveInt(policy.factCount, AST_RAG_DEFAULT_FALLBACK.factCount, 1)
-  };
-}
-
 function astRagFallbackCleanSnippet(text) {
   const normalized = typeof text === 'string'
     ? text.replace(/\s+/g, ' ').trim()
@@ -129,7 +110,3 @@ function astRagFallbackFromCitations({
     citations: filtered.slice(0, 3)
   };
 }
-
-const AST_RAG_FALLBACK = Object.freeze({
-  fromCitations: astRagFallbackFromCitations
-});

--- a/apps_script_tools/rag/general/helpers.js
+++ b/apps_script_tools/rag/general/helpers.js
@@ -75,27 +75,6 @@ function astRagUniqueId(prefix = 'id') {
   return `${prefix}_${new Date().getTime()}_${randomPart}`;
 }
 
-function astRagHashString(value) {
-  const source = String(value == null ? '' : value);
-  try {
-    if (
-      typeof Utilities !== 'undefined' &&
-      Utilities &&
-      typeof Utilities.computeDigest === 'function' &&
-      Utilities.DigestAlgorithm &&
-      Utilities.DigestAlgorithm.SHA_256 &&
-      typeof Utilities.base64EncodeWebSafe === 'function'
-    ) {
-      const digest = Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, source);
-      return Utilities.base64EncodeWebSafe(digest).replace(/=+$/g, '');
-    }
-  } catch (_error) {
-    // fall through
-  }
-
-  return source.slice(0, 256);
-}
-
 function astRagBuildIndexVersion() {
   return `idxv_${new Date().getTime()}_${Math.floor(Math.random() * 1000000)}`;
 }

--- a/apps_script_tools/rag/general/queryCache.js
+++ b/apps_script_tools/rag/general/queryCache.js
@@ -222,44 +222,6 @@ function astRagCacheSet(cacheConfig, key, value, ttlSec, diagnosticsCollector = 
   }
 }
 
-function astRagCacheDelete(cacheConfig, key, diagnosticsCollector = null, context = {}) {
-  if (
-    !cacheConfig ||
-    cacheConfig.enabled !== true ||
-    typeof astCacheDeleteValue !== 'function'
-  ) {
-    if (typeof diagnosticsCollector === 'function') {
-      diagnosticsCollector({
-        operation: 'delete',
-        path: astRagNormalizeString(context.path, null),
-        backend: astRagNormalizeString(cacheConfig && cacheConfig.backend, AST_RAG_CACHE_DEFAULTS.backend),
-        namespace: astRagNormalizeString(cacheConfig && cacheConfig.namespace, AST_RAG_CACHE_DEFAULTS.namespace),
-        lockScope: astRagNormalizeString(cacheConfig && cacheConfig.lockScope, AST_RAG_CACHE_DEFAULTS.lockScope),
-        durationMs: 0,
-        lockWaitMs: 0,
-        lockContention: 0,
-        hit: false,
-        errorClass: null
-      });
-    }
-    return null;
-  }
-
-  const options = astRagBuildCacheOptions(cacheConfig, cacheConfig.ttlSec);
-  const operationMeta = astRagBuildCacheOperationMeta(options, 'delete', context);
-  astRagAttachCacheTrace(options, operationMeta);
-  const startedAtMs = new Date().getTime();
-
-  try {
-    return astCacheDeleteValue(key, options);
-  } catch (error) {
-    operationMeta.errorClass = error && error.name ? error.name : 'Error';
-    return null;
-  } finally {
-    astRagFinalizeCacheOperationMeta(operationMeta, startedAtMs, diagnosticsCollector);
-  }
-}
-
 function astRagBuildIndexDocumentCacheKey(indexFileId, versionToken) {
   return astRagBuildCacheKey({
     kind: 'index_document',

--- a/apps_script_tools/rag/general/vectorMath.js
+++ b/apps_script_tools/rag/general/vectorMath.js
@@ -78,12 +78,3 @@ function astRagCosineSimilarityWithNorm(leftVector, leftNorm, rightVector, right
 
   return dot / (normalizedLeftNorm * normalizedRightNorm);
 }
-
-function astRagCosineSimilarity(leftVector, rightVector) {
-  return astRagCosineSimilarityWithNorm(
-    leftVector,
-    astRagVectorNorm(leftVector),
-    rightVector,
-    astRagVectorNorm(rightVector)
-  );
-}

--- a/apps_script_tools/storage/Storage.js
+++ b/apps_script_tools/storage/Storage.js
@@ -1,45 +1,45 @@
 function astStorageRun(request = {}) {
-  return runStorageRequest(request);
+  return astRunStorageRequest(request);
 }
 
 function astStorageList(request = {}) {
-  return runStorageRequest(Object.assign({}, request, { operation: 'list' }));
+  return astRunStorageRequest(Object.assign({}, request, { operation: 'list' }));
 }
 
 function astStorageHead(request = {}) {
-  return runStorageRequest(Object.assign({}, request, { operation: 'head' }));
+  return astRunStorageRequest(Object.assign({}, request, { operation: 'head' }));
 }
 
 function astStorageRead(request = {}) {
-  return runStorageRequest(Object.assign({}, request, { operation: 'read' }));
+  return astRunStorageRequest(Object.assign({}, request, { operation: 'read' }));
 }
 
 function astStorageWrite(request = {}) {
-  return runStorageRequest(Object.assign({}, request, { operation: 'write' }));
+  return astRunStorageRequest(Object.assign({}, request, { operation: 'write' }));
 }
 
 function astStorageDelete(request = {}) {
-  return runStorageRequest(Object.assign({}, request, { operation: 'delete' }));
+  return astRunStorageRequest(Object.assign({}, request, { operation: 'delete' }));
 }
 
 function astStorageExists(request = {}) {
-  return runStorageRequest(Object.assign({}, request, { operation: 'exists' }));
+  return astRunStorageRequest(Object.assign({}, request, { operation: 'exists' }));
 }
 
 function astStorageCopy(request = {}) {
-  return runStorageRequest(Object.assign({}, request, { operation: 'copy' }));
+  return astRunStorageRequest(Object.assign({}, request, { operation: 'copy' }));
 }
 
 function astStorageMove(request = {}) {
-  return runStorageRequest(Object.assign({}, request, { operation: 'move' }));
+  return astRunStorageRequest(Object.assign({}, request, { operation: 'move' }));
 }
 
 function astStorageSignedUrl(request = {}) {
-  return runStorageRequest(Object.assign({}, request, { operation: 'signed_url' }));
+  return astRunStorageRequest(Object.assign({}, request, { operation: 'signed_url' }));
 }
 
 function astStorageMultipartWrite(request = {}) {
-  return runStorageRequest(Object.assign({}, request, { operation: 'multipart_write' }));
+  return astRunStorageRequest(Object.assign({}, request, { operation: 'multipart_write' }));
 }
 
 function astStorageConfigure(config = {}, options = {}) {

--- a/apps_script_tools/storage/general/capabilities.js
+++ b/apps_script_tools/storage/general/capabilities.js
@@ -55,10 +55,6 @@ function astStorageListProviders() {
   return AST_STORAGE_PROVIDERS.slice();
 }
 
-function astStorageListOperations() {
-  return AST_STORAGE_OPERATIONS.slice();
-}
-
 function astStorageGetCapabilities(provider) {
   const normalizedProvider = String(provider || '').trim().toLowerCase();
   const capabilities = AST_STORAGE_CAPABILITY_MATRIX[normalizedProvider];

--- a/apps_script_tools/storage/general/errors.js
+++ b/apps_script_tools/storage/general/errors.js
@@ -57,11 +57,3 @@ function astStorageBuildNotFoundError(provider, operation, uri, extra = {}) {
     Object.assign({ provider, operation, uri }, extra)
   );
 }
-
-function astStorageBuildProviderError(provider, operation, message, details = {}, cause = null) {
-  return new AstStorageProviderError(
-    message,
-    Object.assign({ provider, operation }, details),
-    cause
-  );
-}

--- a/apps_script_tools/storage/general/resolveStorageConfig.js
+++ b/apps_script_tools/storage/general/resolveStorageConfig.js
@@ -209,9 +209,9 @@ function astStorageNormalizeDatabricksHost(host) {
   return withoutProtocol;
 }
 
-function resolveStorageConfig(request) {
+function astResolveStorageConfig(request) {
   if (!astStorageIsPlainObject(request)) {
-    throw new AstStorageValidationError('resolveStorageConfig expected a normalized storage request object');
+    throw new AstStorageValidationError('astResolveStorageConfig expected a normalized storage request object');
   }
 
   const runtimeConfig = astStorageGetRuntimeConfig();
@@ -359,7 +359,7 @@ function resolveStorageConfig(request) {
     };
   }
 
-  throw new AstStorageValidationError('Unknown storage provider in resolveStorageConfig', {
+  throw new AstStorageValidationError('Unknown storage provider in astResolveStorageConfig', {
     provider
   });
 }

--- a/apps_script_tools/storage/general/runStorageRequest.js
+++ b/apps_script_tools/storage/general/runStorageRequest.js
@@ -136,11 +136,11 @@ function astStorageNormalizeResponse(request, adapterResult = {}) {
   return response;
 }
 
-function runStorageRequest(request = {}) {
-  const normalizedRequest = validateStorageRequest(request);
+function astRunStorageRequest(request = {}) {
+  const normalizedRequest = astValidateStorageRequest(request);
   astStorageAssertOperationSupported(normalizedRequest.provider, normalizedRequest.operation);
 
-  const resolvedConfig = resolveStorageConfig(normalizedRequest);
+  const resolvedConfig = astResolveStorageConfig(normalizedRequest);
   const adapter = astStorageGetProviderAdapter(normalizedRequest.provider);
 
   let adapterResult;

--- a/apps_script_tools/storage/general/validateStorageRequest.js
+++ b/apps_script_tools/storage/general/validateStorageRequest.js
@@ -312,7 +312,7 @@ function astStorageResolveRequestProvider({
   return provider;
 }
 
-function validateStorageRequest(request = {}) {
+function astValidateStorageRequest(request = {}) {
   if (!astStorageIsPlainObject(request)) {
     throw new AstStorageValidationError('Storage request must be an object');
   }

--- a/apps_script_tools/telemetry/general/sinks/storageJson.js
+++ b/apps_script_tools/telemetry/general/sinks/storageJson.js
@@ -105,13 +105,13 @@ function astTelemetryStorageBuildWriteRequest(uri, payloadText, config = {}) {
 }
 
 function astTelemetryStorageExecuteWrite(uri, payloadText, config = {}) {
-  if (typeof runStorageRequest !== 'function') {
+  if (typeof astRunStorageRequest !== 'function') {
     throw new AstTelemetryCapabilityError(
-      'runStorageRequest is required for telemetry storage_json sink'
+      'astRunStorageRequest is required for telemetry storage_json sink'
     );
   }
 
-  return runStorageRequest(astTelemetryStorageBuildWriteRequest(uri, payloadText, config));
+  return astRunStorageRequest(astTelemetryStorageBuildWriteRequest(uri, payloadText, config));
 }
 
 function astTelemetryStorageFlushBuffer(config = {}, options = {}) {

--- a/apps_script_tools/testing/ai/aiTools.js
+++ b/apps_script_tools/testing/ai/aiTools.js
@@ -2,14 +2,14 @@ AI_TOOLS_TESTS = [
   {
     description: 'AST.AI.tools() should execute function handlers and return tool results',
     test: () => {
-      const originalRunOpenAi = runOpenAi;
+      const originalRunOpenAi = astRunOpenAi;
       let callCount = 0;
 
-      runOpenAi = request => {
+      astRunOpenAi = request => {
         callCount += 1;
 
         if (callCount === 1) {
-          return normalizeAiResponse({
+          return astNormalizeAiResponse({
             provider: 'openai',
             operation: 'tools',
             model: 'gpt-4.1-mini',
@@ -23,7 +23,7 @@ AI_TOOLS_TESTS = [
           });
         }
 
-        return normalizeAiResponse({
+        return astNormalizeAiResponse({
           provider: 'openai',
           operation: 'tools',
           model: 'gpt-4.1-mini',
@@ -70,24 +70,24 @@ AI_TOOLS_TESTS = [
           throw new Error(`Expected tool result 10, but got ${response.output.toolResults[0].result}`);
         }
       } finally {
-        runOpenAi = originalRunOpenAi;
+        astRunOpenAi = originalRunOpenAi;
       }
     }
   },
   {
     description: 'AST.AI.tools() should resolve string handler names from global scope',
     test: () => {
-      const originalRunOpenAi = runOpenAi;
+      const originalRunOpenAi = astRunOpenAi;
       const originalGlobalHandler = this.astAiGlobalAdder;
       let callCount = 0;
 
       this.astAiGlobalAdder = args => args.left + args.right;
 
-      runOpenAi = request => {
+      astRunOpenAi = request => {
         callCount += 1;
 
         if (callCount === 1) {
-          return normalizeAiResponse({
+          return astNormalizeAiResponse({
             provider: 'openai',
             operation: 'tools',
             model: 'gpt-4.1-mini',
@@ -101,7 +101,7 @@ AI_TOOLS_TESTS = [
           });
         }
 
-        return normalizeAiResponse({
+        return astNormalizeAiResponse({
           provider: 'openai',
           operation: 'tools',
           model: 'gpt-4.1-mini',
@@ -141,7 +141,7 @@ AI_TOOLS_TESTS = [
           throw new Error(`Expected tool result 10, but got ${response.output.toolResults[0].result}`);
         }
       } finally {
-        runOpenAi = originalRunOpenAi;
+        astRunOpenAi = originalRunOpenAi;
         if (typeof originalGlobalHandler === 'undefined') {
           delete this.astAiGlobalAdder;
         } else {
@@ -153,10 +153,10 @@ AI_TOOLS_TESTS = [
   {
     description: 'AST.AI.tools() should throw when tool rounds exceed maxToolRounds',
     test: () => {
-      const originalRunOpenAi = runOpenAi;
+      const originalRunOpenAi = astRunOpenAi;
 
-      runOpenAi = request => {
-        return normalizeAiResponse({
+      astRunOpenAi = request => {
+        return astNormalizeAiResponse({
           provider: 'openai',
           operation: 'tools',
           model: 'gpt-4.1-mini',
@@ -198,23 +198,23 @@ AI_TOOLS_TESTS = [
           throw new Error(`Expected AstAiToolLoopError, but got ${error.name}: ${error.message}`);
         }
       } finally {
-        runOpenAi = originalRunOpenAi;
+        astRunOpenAi = originalRunOpenAi;
       }
     }
   },
   {
     description: 'AST.AI.tools() should downgrade named toolChoice to auto after first round',
     test: () => {
-      const originalRunOpenAi = runOpenAi;
+      const originalRunOpenAi = astRunOpenAi;
       const observedToolChoices = [];
       let callCount = 0;
 
-      runOpenAi = request => {
+      astRunOpenAi = request => {
         callCount += 1;
         observedToolChoices.push(request.toolChoice);
 
         if (callCount === 1) {
-          return normalizeAiResponse({
+          return astNormalizeAiResponse({
             provider: 'openai',
             operation: 'tools',
             model: 'gpt-4.1-mini',
@@ -228,7 +228,7 @@ AI_TOOLS_TESTS = [
           });
         }
 
-        return normalizeAiResponse({
+        return astNormalizeAiResponse({
           provider: 'openai',
           operation: 'tools',
           model: 'gpt-4.1-mini',
@@ -280,22 +280,22 @@ AI_TOOLS_TESTS = [
           throw new Error(`Expected second toolChoice to be auto, got ${JSON.stringify(observedToolChoices[1])}`);
         }
       } finally {
-        runOpenAi = originalRunOpenAi;
+        astRunOpenAi = originalRunOpenAi;
       }
     }
   },
   {
     description: 'AST.AI.tools() should replay idempotent tool calls without re-running handler',
     test: () => {
-      const originalRunOpenAi = runOpenAi;
+      const originalRunOpenAi = astRunOpenAi;
       let providerCallCount = 0;
       let handlerCallCount = 0;
 
-      runOpenAi = request => {
+      astRunOpenAi = request => {
         providerCallCount += 1;
 
         if (providerCallCount === 1) {
-          return normalizeAiResponse({
+          return astNormalizeAiResponse({
             provider: 'openai',
             operation: 'tools',
             model: 'gpt-4.1-mini',
@@ -310,7 +310,7 @@ AI_TOOLS_TESTS = [
         }
 
         if (providerCallCount === 2) {
-          return normalizeAiResponse({
+          return astNormalizeAiResponse({
             provider: 'openai',
             operation: 'tools',
             model: 'gpt-4.1-mini',
@@ -324,7 +324,7 @@ AI_TOOLS_TESTS = [
           });
         }
 
-        return normalizeAiResponse({
+        return astNormalizeAiResponse({
           provider: 'openai',
           operation: 'tools',
           model: 'gpt-4.1-mini',
@@ -377,7 +377,7 @@ AI_TOOLS_TESTS = [
           throw new Error('Expected 2 tool results including replayed call');
         }
       } finally {
-        runOpenAi = originalRunOpenAi;
+        astRunOpenAi = originalRunOpenAi;
       }
     }
   }

--- a/apps_script_tools/testing/database/loadDatabricksTable.js
+++ b/apps_script_tools/testing/database/loadDatabricksTable.js
@@ -1,9 +1,9 @@
 const DATABASE_LOAD_DATABRICKS_TABLE_TESTS = [
   {
-    description: 'loadDatabricksTable() should require mergeKey in merge mode',
+    description: 'astLoadDatabricksTable() should require mergeKey in merge mode',
     test: () => {
       try {
-        loadDatabricksTable({
+        astLoadDatabricksTable({
           arrays: [
             ['id', 'name'],
             [1, 'Alice']
@@ -27,18 +27,18 @@ const DATABASE_LOAD_DATABRICKS_TABLE_TESTS = [
     },
   },
   {
-    description: 'loadDatabricksTable() should wrap provider failures with DatabricksLoadError',
+    description: 'astLoadDatabricksTable() should wrap provider failures with DatabricksLoadError',
     test: () => {
-      const originalRunDatabricksSql = runDatabricksSql;
+      const originalRunDatabricksSql = astRunDatabricksSql;
 
-      runDatabricksSql = () => {
+      astRunDatabricksSql = () => {
         const providerError = new Error('statement failed');
         providerError.name = 'DatabricksSqlError';
         throw providerError;
       };
 
       try {
-        loadDatabricksTable({
+        astLoadDatabricksTable({
           arrays: [
             ['id', 'name'],
             [1, 'Alice']
@@ -59,23 +59,23 @@ const DATABASE_LOAD_DATABRICKS_TABLE_TESTS = [
           throw new Error(`Expected DatabricksLoadError, got ${error.name}`);
         }
       } finally {
-        runDatabricksSql = originalRunDatabricksSql;
+        astRunDatabricksSql = originalRunDatabricksSql;
       }
     },
   },
   {
-    description: 'loadDatabricksTable() should forward polling options to Databricks SQL statements',
+    description: 'astLoadDatabricksTable() should forward polling options to Databricks SQL statements',
     test: () => {
-      const originalRunDatabricksSql = runDatabricksSql;
+      const originalRunDatabricksSql = astRunDatabricksSql;
       const capturedOptions = [];
 
-      runDatabricksSql = (sql, parameters, placeholders, options) => {
+      astRunDatabricksSql = (sql, parameters, placeholders, options) => {
         capturedOptions.push(options);
         return {};
       };
 
       try {
-        loadDatabricksTable({
+        astLoadDatabricksTable({
           arrays: [
             ['id', 'name'],
             [1, 'Alice']
@@ -95,11 +95,11 @@ const DATABASE_LOAD_DATABRICKS_TABLE_TESTS = [
           }
         });
       } finally {
-        runDatabricksSql = originalRunDatabricksSql;
+        astRunDatabricksSql = originalRunDatabricksSql;
       }
 
       if (capturedOptions.length === 0) {
-        throw new Error('Expected runDatabricksSql to be called');
+        throw new Error('Expected astRunDatabricksSql to be called');
       }
 
       const expected = JSON.stringify({ maxWaitMs: 2000, pollIntervalMs: 250 });

--- a/apps_script_tools/testing/database/runDatabricksSql.js
+++ b/apps_script_tools/testing/database/runDatabricksSql.js
@@ -1,9 +1,9 @@
 const DATABASE_RUN_DATABRICKS_SQL_TESTS = [
   {
-    description: 'runDatabricksSql() should reject pollIntervalMs greater than maxWaitMs',
+    description: 'astRunDatabricksSql() should reject pollIntervalMs greater than maxWaitMs',
     test: () => {
       try {
-        runDatabricksSql(
+        astRunDatabricksSql(
           'select 1',
           {
             host: 'dbc.example.com',
@@ -26,7 +26,7 @@ const DATABASE_RUN_DATABRICKS_SQL_TESTS = [
     },
   },
   {
-    description: 'runDatabricksSql() should cap final polling sleep to remaining timeout budget',
+    description: 'astRunDatabricksSql() should cap final polling sleep to remaining timeout budget',
     test: () => {
       const originalFetch = UrlFetchApp.fetch;
       const originalSleep = Utilities.sleep;
@@ -57,7 +57,7 @@ const DATABASE_RUN_DATABRICKS_SQL_TESTS = [
       Date.now = () => now;
 
       try {
-        runDatabricksSql(
+        astRunDatabricksSql(
           'select 1',
           {
             host: 'dbc.example.com',

--- a/apps_script_tools/testing/database/runSqlQuery.js
+++ b/apps_script_tools/testing/database/runSqlQuery.js
@@ -83,9 +83,9 @@ const DATABASE_RUN_SQL_QUERY_TESTS = [
   {
     description: 'runSqlQuery() should surface Databricks provider failures as thrown errors',
     test: () => {
-      const originalRunDatabricksSql = runDatabricksSql;
+      const originalRunDatabricksSql = astRunDatabricksSql;
 
-      runDatabricksSql = () => {
+      astRunDatabricksSql = () => {
         throw new Error('Databricks statement failed');
       };
 
@@ -106,7 +106,7 @@ const DATABASE_RUN_SQL_QUERY_TESTS = [
           throw new Error(`Unexpected error message: ${error.message}`);
         }
       } finally {
-        runDatabricksSql = originalRunDatabricksSql;
+        astRunDatabricksSql = originalRunDatabricksSql;
       }
     },
   },
@@ -134,10 +134,10 @@ const DATABASE_RUN_SQL_QUERY_TESTS = [
   {
     description: 'runSqlQuery() should forward normalized options to providers',
     test: () => {
-      const originalRunBigQuerySql = runBigQuerySql;
+      const originalRunBigQuerySql = astRunBigQuerySql;
       let captured = null;
 
-      runBigQuerySql = (sql, parameters, placeholders, options) => {
+      astRunBigQuerySql = (sql, parameters, placeholders, options) => {
         captured = { sql, parameters, placeholders, options };
         return DataFrame.fromRecords([{ ok: true }]);
       };
@@ -156,24 +156,24 @@ const DATABASE_RUN_SQL_QUERY_TESTS = [
         });
 
         if (!captured) {
-          throw new Error('Expected runBigQuerySql to be called');
+          throw new Error('Expected astRunBigQuerySql to be called');
         }
 
         if (captured.options.maxWaitMs !== 2000 || captured.options.pollIntervalMs !== 250) {
           throw new Error(`Expected options to be forwarded, got ${JSON.stringify(captured.options)}`);
         }
       } finally {
-        runBigQuerySql = originalRunBigQuerySql;
+        astRunBigQuerySql = originalRunBigQuerySql;
       }
     },
   },
   {
     description: 'runSqlQuery() should forward normalized options to Databricks provider',
     test: () => {
-      const originalRunDatabricksSql = runDatabricksSql;
+      const originalRunDatabricksSql = astRunDatabricksSql;
       let captured = null;
 
-      runDatabricksSql = (sql, parameters, placeholders, options) => {
+      astRunDatabricksSql = (sql, parameters, placeholders, options) => {
         captured = { sql, parameters, placeholders, options };
         return DataFrame.fromRecords([{ ok: true }]);
       };
@@ -195,24 +195,24 @@ const DATABASE_RUN_SQL_QUERY_TESTS = [
         });
 
         if (!captured) {
-          throw new Error('Expected runDatabricksSql to be called');
+          throw new Error('Expected astRunDatabricksSql to be called');
         }
 
         if (captured.options.maxWaitMs !== 2000 || captured.options.pollIntervalMs !== 300) {
           throw new Error(`Expected options to be forwarded, got ${JSON.stringify(captured.options)}`);
         }
       } finally {
-        runDatabricksSql = originalRunDatabricksSql;
+        astRunDatabricksSql = originalRunDatabricksSql;
       }
     },
   },
   {
     description: 'astSqlPrepare()/astSqlExecutePrepared() should bind params and route to detailed provider execution',
     test: () => {
-      const originalExecuteBigQuerySqlDetailed = executeBigQuerySqlDetailed;
+      const originalExecuteBigQuerySqlDetailed = astExecuteBigQuerySqlDetailed;
       let captured = null;
 
-      executeBigQuerySqlDetailed = (sql, parameters, placeholders, options) => {
+      astExecuteBigQuerySqlDetailed = (sql, parameters, placeholders, options) => {
         captured = { sql, parameters, placeholders, options };
         return {
           dataFrame: DataFrame.fromRecords([{ ok: true }]),
@@ -244,7 +244,7 @@ const DATABASE_RUN_SQL_QUERY_TESTS = [
         });
 
         if (!captured) {
-          throw new Error('Expected executeBigQuerySqlDetailed to be called');
+          throw new Error('Expected astExecuteBigQuerySqlDetailed to be called');
         }
         if (!/id = 9/.test(captured.sql) || !/region = 'north'/.test(captured.sql)) {
           throw new Error(`Unexpected rendered SQL: ${captured.sql}`);
@@ -253,17 +253,17 @@ const DATABASE_RUN_SQL_QUERY_TESTS = [
           throw new Error(`Unexpected execution payload: ${JSON.stringify(out.execution)}`);
         }
       } finally {
-        executeBigQuerySqlDetailed = originalExecuteBigQuerySqlDetailed;
+        astExecuteBigQuerySqlDetailed = originalExecuteBigQuerySqlDetailed;
       }
     },
   },
   {
     description: 'astSqlStatus() should route status requests through provider adapter',
     test: () => {
-      const originalGetBigQuerySqlStatus = getBigQuerySqlStatus;
+      const originalGetBigQuerySqlStatus = astGetBigQuerySqlStatus;
       let captured = null;
 
-      getBigQuerySqlStatus = (parameters, jobId) => {
+      astGetBigQuerySqlStatus = (parameters, jobId) => {
         captured = { parameters, jobId };
         return {
           provider: 'bigquery',
@@ -287,17 +287,17 @@ const DATABASE_RUN_SQL_QUERY_TESTS = [
           throw new Error(`Expected RUNNING, got ${status.state}`);
         }
       } finally {
-        getBigQuerySqlStatus = originalGetBigQuerySqlStatus;
+        astGetBigQuerySqlStatus = originalGetBigQuerySqlStatus;
       }
     },
   },
   {
     description: 'astSqlCancel() should route cancel requests through provider adapter',
     test: () => {
-      const originalCancelDatabricksSql = cancelDatabricksSql;
+      const originalCancelDatabricksSql = astCancelDatabricksSql;
       let captured = null;
 
-      cancelDatabricksSql = (parameters, statementId) => {
+      astCancelDatabricksSql = (parameters, statementId) => {
         captured = { parameters, statementId };
         return {
           provider: 'databricks',
@@ -324,14 +324,14 @@ const DATABASE_RUN_SQL_QUERY_TESTS = [
           throw new Error(`Expected canceled=true, got ${JSON.stringify(status)}`);
         }
       } finally {
-        cancelDatabricksSql = originalCancelDatabricksSql;
+        astCancelDatabricksSql = originalCancelDatabricksSql;
       }
     },
   },
   {
-    description: 'replacePlaceHoldersInQuery() should escape regex placeholder keys safely',
+    description: 'astReplacePlaceHoldersInQuery() should escape regex placeholder keys safely',
     test: () => {
-      const output = replacePlaceHoldersInQuery(
+      const output = astReplacePlaceHoldersInQuery(
         'select {{a+b}} as plus_key, {{region.name}} as region_key',
         { 'a+b': 5, 'region.name': 'north' }
       );

--- a/apps_script_tools/testing/dataframe/dataframeToTable.js
+++ b/apps_script_tools/testing/dataframe/dataframeToTable.js
@@ -1,12 +1,12 @@
 DATAFRAME_TO_TABLE_TESTS = [
   {
-    description: 'DataFrame.toTable() should route BigQuery loads to loadBigQueryTable',
+    description: 'DataFrame.toTable() should route BigQuery loads to astLoadBigQueryTable',
     test: () => {
-      const originalLoadBigQueryTable = loadBigQueryTable;
+      const originalLoadBigQueryTable = astLoadBigQueryTable;
       let callCount = 0;
       let capturedConfig = null;
 
-      loadBigQueryTable = config => {
+      astLoadBigQueryTable = config => {
         callCount += 1;
         capturedConfig = config;
       };
@@ -25,10 +25,10 @@ DATAFRAME_TO_TABLE_TESTS = [
         }
       });
 
-      loadBigQueryTable = originalLoadBigQueryTable;
+      astLoadBigQueryTable = originalLoadBigQueryTable;
 
       if (callCount !== 1) {
-        throw new Error(`Expected loadBigQueryTable to be called once, got ${callCount}`);
+        throw new Error(`Expected astLoadBigQueryTable to be called once, got ${callCount}`);
       }
 
       if (!capturedConfig || !Array.isArray(capturedConfig.arrays)) {
@@ -37,13 +37,13 @@ DATAFRAME_TO_TABLE_TESTS = [
     },
   },
   {
-    description: 'DataFrame.toTable() should route Databricks loads to loadDatabricksTable',
+    description: 'DataFrame.toTable() should route Databricks loads to astLoadDatabricksTable',
     test: () => {
-      const originalLoadDatabricksTable = loadDatabricksTable;
+      const originalLoadDatabricksTable = astLoadDatabricksTable;
       let callCount = 0;
       let capturedConfig = null;
 
-      loadDatabricksTable = config => {
+      astLoadDatabricksTable = config => {
         callCount += 1;
         capturedConfig = config;
       };
@@ -71,10 +71,10 @@ DATAFRAME_TO_TABLE_TESTS = [
         }
       });
 
-      loadDatabricksTable = originalLoadDatabricksTable;
+      astLoadDatabricksTable = originalLoadDatabricksTable;
 
       if (callCount !== 1) {
-        throw new Error(`Expected loadDatabricksTable to be called once, got ${callCount}`);
+        throw new Error(`Expected astLoadDatabricksTable to be called once, got ${callCount}`);
       }
 
       if (!capturedConfig || !Array.isArray(capturedConfig.arrays)) {

--- a/apps_script_tools/testing/rag/ragGrounding.js
+++ b/apps_script_tools/testing/rag/ragGrounding.js
@@ -4,7 +4,7 @@ RAG_GROUNDING_TESTS = [
     test: () => {
       const originalLoad = astRagLoadIndexDocument;
       const originalEmbed = astRagEmbedTexts;
-      const originalRunAiRequest = runAiRequest;
+      const originalRunAiRequest = astRunAiRequest;
 
       astRagLoadIndexDocument = () => ({
         indexFileId: 'idx',
@@ -37,7 +37,7 @@ RAG_GROUNDING_TESTS = [
         }
       });
 
-      runAiRequest = () => ({
+      astRunAiRequest = () => ({
         output: {
           json: {
             answer: 'Grounded evidence text [S1]',
@@ -94,7 +94,7 @@ RAG_GROUNDING_TESTS = [
       } finally {
         astRagLoadIndexDocument = originalLoad;
         astRagEmbedTexts = originalEmbed;
-        runAiRequest = originalRunAiRequest;
+        astRunAiRequest = originalRunAiRequest;
       }
     }
   },
@@ -103,7 +103,7 @@ RAG_GROUNDING_TESTS = [
     test: () => {
       const originalLoad = astRagLoadIndexDocument;
       const originalEmbed = astRagEmbedTexts;
-      const originalRunAiRequest = runAiRequest;
+      const originalRunAiRequest = astRunAiRequest;
 
       astRagLoadIndexDocument = () => ({
         indexFileId: 'idx',
@@ -136,7 +136,7 @@ RAG_GROUNDING_TESTS = [
         }
       });
 
-      runAiRequest = () => ({
+      astRunAiRequest = () => ({
         output: {
           json: {
             answer: 'Ungrounded response with no citations',
@@ -174,7 +174,7 @@ RAG_GROUNDING_TESTS = [
       } finally {
         astRagLoadIndexDocument = originalLoad;
         astRagEmbedTexts = originalEmbed;
-        runAiRequest = originalRunAiRequest;
+        astRunAiRequest = originalRunAiRequest;
       }
     }
   },
@@ -183,7 +183,7 @@ RAG_GROUNDING_TESTS = [
     test: () => {
       const originalLoad = astRagLoadIndexDocument;
       const originalEmbed = astRagEmbedTexts;
-      const originalRunAiRequest = runAiRequest;
+      const originalRunAiRequest = astRunAiRequest;
 
       astRagLoadIndexDocument = () => ({
         indexFileId: 'idx',
@@ -216,7 +216,7 @@ RAG_GROUNDING_TESTS = [
         }
       });
 
-      runAiRequest = () => ({
+      astRunAiRequest = () => ({
         output: {
           json: {
             answer: 'Risk details [S1]',
@@ -256,7 +256,7 @@ RAG_GROUNDING_TESTS = [
       } finally {
         astRagLoadIndexDocument = originalLoad;
         astRagEmbedTexts = originalEmbed;
-        runAiRequest = originalRunAiRequest;
+        astRunAiRequest = originalRunAiRequest;
       }
     }
   },
@@ -265,7 +265,7 @@ RAG_GROUNDING_TESTS = [
     test: () => {
       const originalLoad = astRagLoadIndexDocument;
       const originalEmbed = astRagEmbedTexts;
-      const originalRunAiRequest = runAiRequest;
+      const originalRunAiRequest = astRunAiRequest;
 
       astRagLoadIndexDocument = () => ({
         indexFileId: 'idx',
@@ -299,7 +299,7 @@ RAG_GROUNDING_TESTS = [
       });
 
       let aiCallCount = 0;
-      runAiRequest = () => {
+      astRunAiRequest = () => {
         aiCallCount += 1;
         return {
           output: {
@@ -346,7 +346,7 @@ RAG_GROUNDING_TESTS = [
       } finally {
         astRagLoadIndexDocument = originalLoad;
         astRagEmbedTexts = originalEmbed;
-        runAiRequest = originalRunAiRequest;
+        astRunAiRequest = originalRunAiRequest;
       }
     }
   }

--- a/apps_script_tools/utilities/structures/BinarySearchTree.js
+++ b/apps_script_tools/utilities/structures/BinarySearchTree.js
@@ -84,4 +84,3 @@ class BinarySearchTree {
     yield* inOrderTraversal(this.root);
   ;}
 }
-  

--- a/apps_script_tools/utilities/structures/Graph.js
+++ b/apps_script_tools/utilities/structures/Graph.js
@@ -61,4 +61,3 @@ class Graph {
     };
   }
 }
-  

--- a/apps_script_tools/utilities/structures/TernarySearchTree.js
+++ b/apps_script_tools/utilities/structures/TernarySearchTree.js
@@ -59,4 +59,3 @@ class TernarySearchTree {
     return searchNode(this.root, word, 0);
   };
 }
-  

--- a/tests/local/ai-capabilities.test.mjs
+++ b/tests/local/ai-capabilities.test.mjs
@@ -20,12 +20,12 @@ test('astGetAiCapabilities reports capability matrix values', () => {
   assert.equal(capabilities.imageGeneration, false);
 });
 
-test('runAiRequest throws AstAiCapabilityError for unsupported image generation', () => {
+test('astRunAiRequest throws AstAiCapabilityError for unsupported image generation', () => {
   const context = createGasContext();
   loadAiScripts(context);
 
   assert.throws(
-    () => context.runAiRequest({
+    () => context.astRunAiRequest({
       provider: 'vertex_gemini',
       operation: 'image',
       model: 'gemini-2.0-flash',
@@ -40,7 +40,7 @@ test('runAiRequest throws AstAiCapabilityError for unsupported image generation'
   );
 });
 
-test('runAiRequest includeRaw=true includes provider raw payload', () => {
+test('astRunAiRequest includeRaw=true includes provider raw payload', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -58,7 +58,7 @@ test('runAiRequest includeRaw=true includes provider raw payload', () => {
 
   loadAiScripts(context);
 
-  const output = context.runAiRequest({
+  const output = context.astRunAiRequest({
     provider: 'openai',
     operation: 'text',
     model: 'gpt-4.1-mini',

--- a/tests/local/ai-image.test.mjs
+++ b/tests/local/ai-image.test.mjs
@@ -28,7 +28,7 @@ function imageRequest(provider) {
   };
 }
 
-test('runOpenAi returns normalized image payload', () => {
+test('astRunOpenAi returns normalized image payload', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -43,7 +43,7 @@ test('runOpenAi returns normalized image payload', () => {
 
   loadAiScripts(context);
 
-  const output = context.runOpenAi(imageRequest('openai'), {
+  const output = context.astRunOpenAi(imageRequest('openai'), {
     provider: 'openai',
     apiKey: 'key',
     model: 'gpt-image-1'
@@ -53,7 +53,7 @@ test('runOpenAi returns normalized image payload', () => {
   assert.equal(output.output.images[0].mimeType, 'image/png');
 });
 
-test('runGemini returns normalized image payload', () => {
+test('astRunGemini returns normalized image payload', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -74,7 +74,7 @@ test('runGemini returns normalized image payload', () => {
 
   loadAiScripts(context);
 
-  const output = context.runGemini(imageRequest('gemini'), {
+  const output = context.astRunGemini(imageRequest('gemini'), {
     provider: 'gemini',
     apiKey: 'key',
     model: 'gemini-2.0-flash-preview-image-generation'
@@ -84,7 +84,7 @@ test('runGemini returns normalized image payload', () => {
   assert.equal(output.output.images[0].base64, 'Z2VtaW5pSW1hZ2U=');
 });
 
-test('runOpenRouter and runPerplexity image parsing handles generic payload', () => {
+test('astRunOpenRouter and astRunPerplexity image parsing handles generic payload', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -98,13 +98,13 @@ test('runOpenRouter and runPerplexity image parsing handles generic payload', ()
 
   loadAiScripts(context);
 
-  const openRouter = context.runOpenRouter(imageRequest('openrouter'), {
+  const openRouter = context.astRunOpenRouter(imageRequest('openrouter'), {
     provider: 'openrouter',
     apiKey: 'key',
     model: 'openrouter/model'
   });
 
-  const perplexity = context.runPerplexity(imageRequest('perplexity'), {
+  const perplexity = context.astRunPerplexity(imageRequest('perplexity'), {
     provider: 'perplexity',
     apiKey: 'key',
     model: 'sonar-image'
@@ -114,7 +114,7 @@ test('runOpenRouter and runPerplexity image parsing handles generic payload', ()
   assert.equal(perplexity.output.images.length, 1);
 });
 
-test('runOpenAi throws parse error when image payload is missing', () => {
+test('astRunOpenAi throws parse error when image payload is missing', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -126,7 +126,7 @@ test('runOpenAi throws parse error when image payload is missing', () => {
   loadAiScripts(context);
 
   assert.throws(
-    () => context.runOpenAi(imageRequest('openai'), {
+    () => context.astRunOpenAi(imageRequest('openai'), {
       provider: 'openai',
       apiKey: 'key',
       model: 'gpt-image-1'

--- a/tests/local/ai-output-repair.test.mjs
+++ b/tests/local/ai-output-repair.test.mjs
@@ -5,7 +5,7 @@ import { createGasContext } from './helpers.mjs';
 import { loadAiScripts } from './ai-helpers.mjs';
 
 function normalizedTextResponse(context, text, finishReason = null) {
-  return context.normalizeAiResponse({
+  return context.astNormalizeAiResponse({
     provider: 'openai',
     operation: 'text',
     model: 'gpt-4.1-mini',
@@ -37,8 +37,8 @@ test('OutputRepair.continueIfTruncated requests continuation when finishReason i
   loadAiScripts(context, { includeAst: true });
 
   let calls = 0;
-  const originalRunOpenAi = context.runOpenAi;
-  context.runOpenAi = () => {
+  const originalRunOpenAi = context.astRunOpenAi;
+  context.astRunOpenAi = () => {
     calls += 1;
     return normalizedTextResponse(context, ' and the final milestone is reopening.');
   };
@@ -51,7 +51,7 @@ test('OutputRepair.continueIfTruncated requests continuation when finishReason i
     auth: { apiKey: 'test-key' }
   });
 
-  context.runOpenAi = originalRunOpenAi;
+  context.astRunOpenAi = originalRunOpenAi;
 
   assert.equal(calls, 1);
   assert.equal(result.continued, true);
@@ -65,8 +65,8 @@ test('OutputRepair.continueIfTruncated merges overlap to avoid duplicate continu
   const context = createGasContext();
   loadAiScripts(context, { includeAst: true });
 
-  const originalRunOpenAi = context.runOpenAi;
-  context.runOpenAi = () => normalizedTextResponse(
+  const originalRunOpenAi = context.astRunOpenAi;
+  context.astRunOpenAi = () => normalizedTextResponse(
     context,
     'are plan, build, and launch.'
   );
@@ -79,7 +79,7 @@ test('OutputRepair.continueIfTruncated merges overlap to avoid duplicate continu
     auth: { apiKey: 'test-key' }
   });
 
-  context.runOpenAi = originalRunOpenAi;
+  context.astRunOpenAi = originalRunOpenAi;
 
   assert.equal(result.text, 'The project phases are plan, build, and launch.');
 });
@@ -89,8 +89,8 @@ test('OutputRepair.continueIfTruncated uses the partial tail in continuation pro
   loadAiScripts(context, { includeAst: true });
 
   let capturedPrompt = '';
-  const originalRunOpenAi = context.runOpenAi;
-  context.runOpenAi = request => {
+  const originalRunOpenAi = context.astRunOpenAi;
+  context.astRunOpenAi = request => {
     capturedPrompt = request.input;
     return normalizedTextResponse(context, ' and completion.');
   };
@@ -107,7 +107,7 @@ test('OutputRepair.continueIfTruncated uses the partial tail in continuation pro
     auth: { apiKey: 'test-key' }
   });
 
-  context.runOpenAi = originalRunOpenAi;
+  context.astRunOpenAi = originalRunOpenAi;
 
   assert.equal(capturedPrompt.includes('HEAD_MARKER_SHOULD_NOT_BE_IN_TAIL'), false);
   assert.equal(capturedPrompt.includes('TAIL_MARKER_SHOULD_BE_PRESENT'), true);

--- a/tests/local/ai-providers-structured.test.mjs
+++ b/tests/local/ai-providers-structured.test.mjs
@@ -36,7 +36,7 @@ function structuredRequest(provider) {
   };
 }
 
-test('runOpenAi parses structured output', () => {
+test('astRunOpenAi parses structured output', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -52,7 +52,7 @@ test('runOpenAi parses structured output', () => {
 
   loadAiScripts(context);
 
-  const output = context.runOpenAi(structuredRequest('openai'), {
+  const output = context.astRunOpenAi(structuredRequest('openai'), {
     provider: 'openai',
     apiKey: 'key',
     model: 'gpt-4.1-mini'
@@ -61,7 +61,7 @@ test('runOpenAi parses structured output', () => {
   assert.equal(JSON.stringify(output.output.json), JSON.stringify({ ok: true, source: 'openai' }));
 });
 
-test('runGemini parses structured output', () => {
+test('astRunGemini parses structured output', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -76,7 +76,7 @@ test('runGemini parses structured output', () => {
 
   loadAiScripts(context);
 
-  const output = context.runGemini(structuredRequest('gemini'), {
+  const output = context.astRunGemini(structuredRequest('gemini'), {
     provider: 'gemini',
     apiKey: 'key',
     model: 'gemini-2.0-flash'
@@ -85,7 +85,7 @@ test('runGemini parses structured output', () => {
   assert.equal(JSON.stringify(output.output.json), JSON.stringify({ ok: true, source: 'gemini' }));
 });
 
-test('runVertexGemini parses structured output', () => {
+test('astRunVertexGemini parses structured output', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -100,7 +100,7 @@ test('runVertexGemini parses structured output', () => {
 
   loadAiScripts(context);
 
-  const output = context.runVertexGemini(structuredRequest('vertex_gemini'), {
+  const output = context.astRunVertexGemini(structuredRequest('vertex_gemini'), {
     provider: 'vertex_gemini',
     projectId: 'proj',
     location: 'us-central1',
@@ -111,7 +111,7 @@ test('runVertexGemini parses structured output', () => {
   assert.equal(JSON.stringify(output.output.json), JSON.stringify({ ok: true, source: 'vertex' }));
 });
 
-test('runOpenRouter parses structured output', () => {
+test('astRunOpenRouter parses structured output', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -126,7 +126,7 @@ test('runOpenRouter parses structured output', () => {
 
   loadAiScripts(context);
 
-  const output = context.runOpenRouter(structuredRequest('openrouter'), {
+  const output = context.astRunOpenRouter(structuredRequest('openrouter'), {
     provider: 'openrouter',
     apiKey: 'key',
     model: 'openrouter/model'
@@ -135,7 +135,7 @@ test('runOpenRouter parses structured output', () => {
   assert.equal(JSON.stringify(output.output.json), JSON.stringify({ ok: true, source: 'openrouter' }));
 });
 
-test('runPerplexity parses structured output', () => {
+test('astRunPerplexity parses structured output', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -150,7 +150,7 @@ test('runPerplexity parses structured output', () => {
 
   loadAiScripts(context);
 
-  const output = context.runPerplexity(structuredRequest('perplexity'), {
+  const output = context.astRunPerplexity(structuredRequest('perplexity'), {
     provider: 'perplexity',
     apiKey: 'key',
     model: 'sonar-pro'

--- a/tests/local/ai-providers-text.test.mjs
+++ b/tests/local/ai-providers-text.test.mjs
@@ -28,7 +28,7 @@ function baseRequest(operation = 'text') {
   };
 }
 
-test('runOpenAi normalizes text output', () => {
+test('astRunOpenAi normalizes text output', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -46,7 +46,7 @@ test('runOpenAi normalizes text output', () => {
 
   loadAiScripts(context);
 
-  const output = context.runOpenAi(baseRequest('text'), {
+  const output = context.astRunOpenAi(baseRequest('text'), {
     provider: 'openai',
     apiKey: 'key',
     model: 'gpt-4.1-mini'
@@ -57,7 +57,7 @@ test('runOpenAi normalizes text output', () => {
   assert.equal(output.provider, 'openai');
 });
 
-test('runGemini normalizes text output', () => {
+test('astRunGemini normalizes text output', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -82,7 +82,7 @@ test('runGemini normalizes text output', () => {
     provider: 'gemini'
   });
 
-  const output = context.runGemini(request, {
+  const output = context.astRunGemini(request, {
     provider: 'gemini',
     apiKey: 'key',
     model: 'gemini-2.0-flash'
@@ -93,7 +93,7 @@ test('runGemini normalizes text output', () => {
   assert.equal(output.provider, 'gemini');
 });
 
-test('runGemini forwards system messages as systemInstruction when request.system is omitted', () => {
+test('astRunGemini forwards system messages as systemInstruction when request.system is omitted', () => {
   let capturedPayload = null;
 
   const context = createGasContext({
@@ -127,7 +127,7 @@ test('runGemini forwards system messages as systemInstruction when request.syste
     ]
   });
 
-  context.runGemini(request, {
+  context.astRunGemini(request, {
     provider: 'gemini',
     apiKey: 'key',
     model: 'gemini-2.0-flash'
@@ -137,7 +137,7 @@ test('runGemini forwards system messages as systemInstruction when request.syste
   assert.equal(capturedPayload.contents.length, 1);
 });
 
-test('runVertexGemini normalizes text output', () => {
+test('astRunVertexGemini normalizes text output', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -162,7 +162,7 @@ test('runVertexGemini normalizes text output', () => {
     provider: 'vertex_gemini'
   });
 
-  const output = context.runVertexGemini(request, {
+  const output = context.astRunVertexGemini(request, {
     provider: 'vertex_gemini',
     projectId: 'p',
     location: 'us-central1',
@@ -175,7 +175,7 @@ test('runVertexGemini normalizes text output', () => {
   assert.equal(output.provider, 'vertex_gemini');
 });
 
-test('runVertexGemini forwards system messages as systemInstruction when request.system is omitted', () => {
+test('astRunVertexGemini forwards system messages as systemInstruction when request.system is omitted', () => {
   let capturedPayload = null;
 
   const context = createGasContext({
@@ -209,7 +209,7 @@ test('runVertexGemini forwards system messages as systemInstruction when request
     ]
   });
 
-  context.runVertexGemini(request, {
+  context.astRunVertexGemini(request, {
     provider: 'vertex_gemini',
     projectId: 'p',
     location: 'us-central1',
@@ -221,7 +221,7 @@ test('runVertexGemini forwards system messages as systemInstruction when request
   assert.equal(capturedPayload.contents.length, 1);
 });
 
-test('runOpenRouter normalizes text output', () => {
+test('astRunOpenRouter normalizes text output', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -242,7 +242,7 @@ test('runOpenRouter normalizes text output', () => {
     provider: 'openrouter'
   });
 
-  const output = context.runOpenRouter(request, {
+  const output = context.astRunOpenRouter(request, {
     provider: 'openrouter',
     apiKey: 'key',
     model: 'openrouter/model'
@@ -253,7 +253,7 @@ test('runOpenRouter normalizes text output', () => {
   assert.equal(output.provider, 'openrouter');
 });
 
-test('runPerplexity normalizes text output', () => {
+test('astRunPerplexity normalizes text output', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: () => asResponse({
@@ -274,7 +274,7 @@ test('runPerplexity normalizes text output', () => {
     provider: 'perplexity'
   });
 
-  const output = context.runPerplexity(request, {
+  const output = context.astRunPerplexity(request, {
     provider: 'perplexity',
     apiKey: 'key',
     model: 'sonar-pro'

--- a/tests/local/ai-streaming.test.mjs
+++ b/tests/local/ai-streaming.test.mjs
@@ -4,14 +4,14 @@ import assert from 'node:assert/strict';
 import { createGasContext } from './helpers.mjs';
 import { loadAiScripts } from './ai-helpers.mjs';
 
-test('runAiRequest emits deterministic stream events for text responses', () => {
+test('astRunAiRequest emits deterministic stream events for text responses', () => {
   const context = createGasContext();
   loadAiScripts(context);
 
   const events = [];
-  const originalRunOpenAi = context.runOpenAi;
+  const originalRunOpenAi = context.astRunOpenAi;
 
-  context.runOpenAi = () => context.normalizeAiResponse({
+  context.astRunOpenAi = () => context.astNormalizeAiResponse({
     provider: 'openai',
     operation: 'text',
     model: 'gpt-4.1-mini',
@@ -20,7 +20,7 @@ test('runAiRequest emits deterministic stream events for text responses', () => 
     }
   });
 
-  const response = context.runAiRequest({
+  const response = context.astRunAiRequest({
     provider: 'openai',
     model: 'gpt-4.1-mini',
     input: 'hello',
@@ -33,7 +33,7 @@ test('runAiRequest emits deterministic stream events for text responses', () => 
     }
   });
 
-  context.runOpenAi = originalRunOpenAi;
+  context.astRunOpenAi = originalRunOpenAi;
 
   assert.equal(response.output.text, 'abcdefghi');
   assert.equal(
@@ -51,12 +51,12 @@ test('AST.AI.stream helper forces stream mode and emits token events', () => {
   loadAiScripts(context, { includeAst: true });
 
   const events = [];
-  const originalRunOpenAi = context.runOpenAi;
+  const originalRunOpenAi = context.astRunOpenAi;
   let seenRequest = null;
 
-  context.runOpenAi = request => {
+  context.astRunOpenAi = request => {
     seenRequest = request;
-    return context.normalizeAiResponse({
+    return context.astNormalizeAiResponse({
       provider: 'openai',
       operation: 'text',
       model: 'gpt-4.1-mini',
@@ -78,7 +78,7 @@ test('AST.AI.stream helper forces stream mode and emits token events', () => {
     }
   });
 
-  context.runOpenAi = originalRunOpenAi;
+  context.astRunOpenAi = originalRunOpenAi;
 
   assert.equal(response.output.text, 'wxyz');
   assert.equal(Boolean(seenRequest && seenRequest.options && seenRequest.options.stream), true);
@@ -88,18 +88,18 @@ test('AST.AI.stream helper forces stream mode and emits token events', () => {
   );
 });
 
-test('runAiRequest stream mode emits tool_call and tool_result events for tool workflows', () => {
+test('astRunAiRequest stream mode emits tool_call and tool_result events for tool workflows', () => {
   const context = createGasContext();
   loadAiScripts(context);
 
   const events = [];
-  const originalRunOpenAi = context.runOpenAi;
+  const originalRunOpenAi = context.astRunOpenAi;
   let calls = 0;
 
-  context.runOpenAi = () => {
+  context.astRunOpenAi = () => {
     calls += 1;
     if (calls === 1) {
-      return context.normalizeAiResponse({
+      return context.astNormalizeAiResponse({
         provider: 'openai',
         operation: 'tools',
         model: 'gpt-4.1-mini',
@@ -113,7 +113,7 @@ test('runAiRequest stream mode emits tool_call and tool_result events for tool w
       });
     }
 
-    return context.normalizeAiResponse({
+    return context.astNormalizeAiResponse({
       provider: 'openai',
       operation: 'tools',
       model: 'gpt-4.1-mini',
@@ -123,7 +123,7 @@ test('runAiRequest stream mode emits tool_call and tool_result events for tool w
     });
   };
 
-  const response = context.runAiRequest({
+  const response = context.astRunAiRequest({
     provider: 'openai',
     operation: 'tools',
     model: 'gpt-4.1-mini',
@@ -152,7 +152,7 @@ test('runAiRequest stream mode emits tool_call and tool_result events for tool w
     }
   });
 
-  context.runOpenAi = originalRunOpenAi;
+  context.astRunOpenAi = originalRunOpenAi;
 
   assert.equal(response.output.text, 'done');
   assert.equal(response.output.toolResults.length, 1);
@@ -181,9 +181,9 @@ test('stream events use resolved config model when request.model is omitted', ()
   loadAiScripts(context);
 
   const events = [];
-  const originalRunOpenAi = context.runOpenAi;
+  const originalRunOpenAi = context.astRunOpenAi;
 
-  context.runOpenAi = () => context.normalizeAiResponse({
+  context.astRunOpenAi = () => context.astNormalizeAiResponse({
     provider: 'openai',
     operation: 'text',
     output: {
@@ -191,7 +191,7 @@ test('stream events use resolved config model when request.model is omitted', ()
     }
   });
 
-  const response = context.runAiRequest({
+  const response = context.astRunAiRequest({
     provider: 'openai',
     input: 'hello',
     auth: { apiKey: 'key' },
@@ -202,7 +202,7 @@ test('stream events use resolved config model when request.model is omitted', ()
     }
   });
 
-  context.runOpenAi = originalRunOpenAi;
+  context.astRunOpenAi = originalRunOpenAi;
 
   assert.equal(response.model, '');
   const eventModels = events.map(event => event.model);

--- a/tests/local/bigquery-empty.test.mjs
+++ b/tests/local/bigquery-empty.test.mjs
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createGasContext, loadCoreDataContext, loadScripts } from './helpers.mjs';
 
-test('runBigQuerySql returns empty DataFrame with schema columns', () => {
+test('astRunBigQuerySql returns empty DataFrame with schema columns', () => {
   const context = createGasContext({
     BigQuery: {
       Jobs: {
@@ -31,14 +31,14 @@ test('runBigQuerySql returns empty DataFrame with schema columns', () => {
     'apps_script_tools/database/bigQuery/runBigQuerySql.js'
   ]);
 
-  const result = context.runBigQuerySql('select id, name from users', { projectId: 'proj' });
+  const result = context.astRunBigQuerySql('select id, name from users', { projectId: 'proj' });
 
   assert.equal(result instanceof context.DataFrame, true);
   assert.equal(JSON.stringify(result.columns), JSON.stringify(['id', 'name']));
   assert.equal(result.len(), 0);
 });
 
-test('runBigQuerySql collects paginated rows when first page has no rows', () => {
+test('astRunBigQuerySql collects paginated rows when first page has no rows', () => {
   const context = createGasContext({
     BigQuery: {
       Jobs: {
@@ -80,7 +80,7 @@ test('runBigQuerySql collects paginated rows when first page has no rows', () =>
     'apps_script_tools/database/bigQuery/runBigQuerySql.js'
   ]);
 
-  const result = context.runBigQuerySql('select id, name from users', { projectId: 'proj' });
+  const result = context.astRunBigQuerySql('select id, name from users', { projectId: 'proj' });
 
   assert.equal(result.len(), 1);
   assert.equal(
@@ -89,7 +89,7 @@ test('runBigQuerySql collects paginated rows when first page has no rows', () =>
   );
 });
 
-test('runBigQuerySql throws timeout errors when query polling exceeds maxWaitMs', () => {
+test('astRunBigQuerySql throws timeout errors when query polling exceeds maxWaitMs', () => {
   let fakeNow = 0;
   const sleepDurations = [];
   class FakeDate extends Date {
@@ -130,7 +130,7 @@ test('runBigQuerySql throws timeout errors when query polling exceeds maxWaitMs'
   ]);
 
   assert.throws(() => {
-    context.runBigQuerySql(
+    context.astRunBigQuerySql(
       'select * from users',
       { projectId: 'proj' },
       {},
@@ -141,7 +141,7 @@ test('runBigQuerySql throws timeout errors when query polling exceeds maxWaitMs'
   assert.equal(JSON.stringify(sleepDurations), JSON.stringify([250, 250, 250, 250]));
 });
 
-test('runBigQuerySql rejects pollIntervalMs greater than maxWaitMs', () => {
+test('astRunBigQuerySql rejects pollIntervalMs greater than maxWaitMs', () => {
   const context = createGasContext();
 
   loadCoreDataContext(context);
@@ -151,7 +151,7 @@ test('runBigQuerySql rejects pollIntervalMs greater than maxWaitMs', () => {
   ]);
 
   assert.throws(() => {
-    context.runBigQuerySql(
+    context.astRunBigQuerySql(
       'select 1',
       { projectId: 'proj' },
       {},
@@ -160,7 +160,7 @@ test('runBigQuerySql rejects pollIntervalMs greater than maxWaitMs', () => {
   }, /options\.pollIntervalMs cannot be greater than options\.maxWaitMs/);
 });
 
-test('runBigQuerySql caps final sleep to remaining timeout budget', () => {
+test('astRunBigQuerySql caps final sleep to remaining timeout budget', () => {
   let fakeNow = 0;
   const sleepDurations = [];
   class FakeDate extends Date {
@@ -201,7 +201,7 @@ test('runBigQuerySql caps final sleep to remaining timeout budget', () => {
   ]);
 
   assert.throws(() => {
-    context.runBigQuerySql(
+    context.astRunBigQuerySql(
       'select * from users',
       { projectId: 'proj' },
       {},

--- a/tests/local/cache-runtime.test.mjs
+++ b/tests/local/cache-runtime.test.mjs
@@ -109,7 +109,7 @@ function createStorageRunnerMock() {
   return {
     objects,
     requests,
-    runStorageRequest: request => {
+    astRunStorageRequest: request => {
       requests.push(
         JSON.parse(
           JSON.stringify(request || {})
@@ -611,7 +611,7 @@ test('script_properties backend isolates collision-prone namespace names', () =>
 test('storage_json backend supports persistence through AST.Storage providers', () => {
   const storage = createStorageRunnerMock();
   const context = createGasContext({
-    runStorageRequest: storage.runStorageRequest,
+    astRunStorageRequest: storage.astRunStorageRequest,
     LockService: {
       getScriptLock: () => ({
         tryLock: () => true,
@@ -661,7 +661,7 @@ test('storage_json backend supports persistence through AST.Storage providers', 
 test('storage_json backend isolates collision-prone namespace names', () => {
   const storage = createStorageRunnerMock();
   const context = createGasContext({
-    runStorageRequest: storage.runStorageRequest,
+    astRunStorageRequest: storage.astRunStorageRequest,
     LockService: {
       getScriptLock: () => ({
         tryLock: () => true,
@@ -702,7 +702,7 @@ test('storage_json trim probe is not capped at 50k and uses tag mutation lock pa
   const storage = createStorageRunnerMock();
   let scriptLockCalls = 0;
   const context = createGasContext({
-    runStorageRequest: storage.runStorageRequest,
+    astRunStorageRequest: storage.astRunStorageRequest,
     LockService: {
       getScriptLock: () => ({
         tryLock: () => {

--- a/tests/local/canonical-keys.test.mjs
+++ b/tests/local/canonical-keys.test.mjs
@@ -4,8 +4,8 @@ import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
 test('dropDuplicates treats null/undefined/missing equivalently for key comparisons', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);
@@ -22,8 +22,8 @@ test('dropDuplicates treats null/undefined/missing equivalently for key comparis
 
 test('dropDuplicates canonicalizes object keys for deterministic comparison', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);
@@ -39,8 +39,8 @@ test('dropDuplicates canonicalizes object keys for deterministic comparison', ()
 
 test('merge aligns null and undefined join keys', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);

--- a/tests/local/databricks-errors.test.mjs
+++ b/tests/local/databricks-errors.test.mjs
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createGasContext, loadScripts } from './helpers.mjs';
 
-test('runDatabricksSql throws DatabricksSqlError on failed statements', () => {
+test('astRunDatabricksSql throws DatabricksSqlError on failed statements', () => {
   let callCount = 0;
   const context = createGasContext({
     UrlFetchApp: {
@@ -32,7 +32,7 @@ test('runDatabricksSql throws DatabricksSqlError on failed statements', () => {
   ]);
 
   assert.throws(
-    () => context.runDatabricksSql('select 1', {
+    () => context.astRunDatabricksSql('select 1', {
       host: 'dbc.example.com',
       sqlWarehouseId: 'warehouse-1',
       schema: 'default',
@@ -47,7 +47,7 @@ test('runDatabricksSql throws DatabricksSqlError on failed statements', () => {
   );
 });
 
-test('runDatabricksSql validates required Databricks parameters', () => {
+test('astRunDatabricksSql validates required Databricks parameters', () => {
   const context = createGasContext();
 
   loadScripts(context, [
@@ -56,7 +56,7 @@ test('runDatabricksSql validates required Databricks parameters', () => {
   ]);
 
   assert.throws(
-    () => context.runDatabricksSql('select 1', {
+    () => context.astRunDatabricksSql('select 1', {
       host: 'dbc.example.com',
       sqlWarehouseId: 'warehouse-1',
       schema: 'default'
@@ -65,7 +65,7 @@ test('runDatabricksSql validates required Databricks parameters', () => {
   );
 });
 
-test('runDatabricksSql rejects pollIntervalMs greater than maxWaitMs', () => {
+test('astRunDatabricksSql rejects pollIntervalMs greater than maxWaitMs', () => {
   const context = createGasContext();
 
   loadScripts(context, [
@@ -74,7 +74,7 @@ test('runDatabricksSql rejects pollIntervalMs greater than maxWaitMs', () => {
   ]);
 
   assert.throws(
-    () => context.runDatabricksSql(
+    () => context.astRunDatabricksSql(
       'select 1',
       {
         host: 'dbc.example.com',
@@ -89,7 +89,7 @@ test('runDatabricksSql rejects pollIntervalMs greater than maxWaitMs', () => {
   );
 });
 
-test('runDatabricksSql times out based on elapsed maxWaitMs budget', () => {
+test('astRunDatabricksSql times out based on elapsed maxWaitMs budget', () => {
   let fakeNow = 0;
   const sleepDurations = [];
   class FakeDate extends Date {
@@ -133,7 +133,7 @@ test('runDatabricksSql times out based on elapsed maxWaitMs budget', () => {
   ]);
 
   assert.throws(
-    () => context.runDatabricksSql(
+    () => context.astRunDatabricksSql(
       'select 1',
       {
         host: 'dbc.example.com',
@@ -150,7 +150,7 @@ test('runDatabricksSql times out based on elapsed maxWaitMs budget', () => {
   assert.equal(JSON.stringify(sleepDurations), JSON.stringify([250, 250, 250, 250]));
 });
 
-test('runDatabricksSql caps final sleep to remaining timeout budget', () => {
+test('astRunDatabricksSql caps final sleep to remaining timeout budget', () => {
   let fakeNow = 0;
   const sleepDurations = [];
   class FakeDate extends Date {
@@ -194,7 +194,7 @@ test('runDatabricksSql caps final sleep to remaining timeout budget', () => {
   ]);
 
   assert.throws(
-    () => context.runDatabricksSql(
+    () => context.astRunDatabricksSql(
       'select 1',
       {
         host: 'dbc.example.com',

--- a/tests/local/dataframe-columns.test.mjs
+++ b/tests/local/dataframe-columns.test.mjs
@@ -4,8 +4,8 @@ import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
 test('DataFrame.fromColumns builds DataFrame and toColumns round-trips data', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);
@@ -32,8 +32,8 @@ test('DataFrame.fromColumns builds DataFrame and toColumns round-trips data', ()
 
 test('DataFrame.toArrays does not force toRecords conversion path', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);

--- a/tests/local/dataframe-drop-duplicates.test.mjs
+++ b/tests/local/dataframe-drop-duplicates.test.mjs
@@ -4,8 +4,8 @@ import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
 test('DataFrame.dropDuplicates uses all columns by default', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);
@@ -27,8 +27,8 @@ test('DataFrame.dropDuplicates uses all columns by default', () => {
 
 test('DataFrame.dropDuplicates compares Date/object values by content for subset keys', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);
@@ -48,8 +48,8 @@ test('DataFrame.dropDuplicates compares Date/object values by content for subset
 
 test('DataFrame.dropDuplicates preserves schema for typed empty DataFrames', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);

--- a/tests/local/dataframe-expr-dsl.test.mjs
+++ b/tests/local/dataframe-expr-dsl.test.mjs
@@ -4,8 +4,8 @@ import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
 function createContext() {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
   loadCoreDataContext(context);
   return context;

--- a/tests/local/dataframe-markdown.test.mjs
+++ b/tests/local/dataframe-markdown.test.mjs
@@ -4,8 +4,8 @@ import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
 test('DataFrame.toMarkdown renders headers and data', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);
@@ -25,8 +25,8 @@ test('DataFrame.toMarkdown renders headers and data', () => {
 
 test('DataFrame.toMarkdown handles empty DataFrame with defined columns', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);

--- a/tests/local/dataframe-schema-contracts.test.mjs
+++ b/tests/local/dataframe-schema-contracts.test.mjs
@@ -4,8 +4,8 @@ import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
 function createContext() {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
   loadCoreDataContext(context);
   return context;

--- a/tests/local/dataframe-schema.test.mjs
+++ b/tests/local/dataframe-schema.test.mjs
@@ -4,8 +4,8 @@ import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
 test('DataFrame.schema returns inferred and casted types in local context', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);

--- a/tests/local/dataframe-selectexpr-window.test.mjs
+++ b/tests/local/dataframe-selectexpr-window.test.mjs
@@ -4,8 +4,8 @@ import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
 function createContext() {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);

--- a/tests/local/dataframe-surrogate-key.test.mjs
+++ b/tests/local/dataframe-surrogate-key.test.mjs
@@ -4,8 +4,8 @@ import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
 test('DataFrame.generateSurrogateKey does not mutate provided column array', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);
@@ -28,8 +28,8 @@ test('DataFrame.generateSurrogateKey does not mutate provided column array', () 
 
 test('DataFrame.generateSurrogateKey validates input columns', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);

--- a/tests/local/dataframe-to-table.test.mjs
+++ b/tests/local/dataframe-to-table.test.mjs
@@ -2,13 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
-test('DataFrame.toTable routes to loadBigQueryTable', () => {
+test('DataFrame.toTable routes to astLoadBigQueryTable', () => {
   let called = 0;
   let captured = null;
 
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: config => {
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: config => {
       called += 1;
       captured = config;
     }
@@ -34,16 +34,16 @@ test('DataFrame.toTable routes to loadBigQueryTable', () => {
   assert.ok(Array.isArray(captured.arrays));
 });
 
-test('DataFrame.toTable routes to loadDatabricksTable', () => {
+test('DataFrame.toTable routes to astLoadDatabricksTable', () => {
   let called = 0;
   let captured = null;
 
   const context = createGasContext({
-    loadDatabricksTable: config => {
+    astLoadDatabricksTable: config => {
       called += 1;
       captured = config;
     },
-    loadBigQueryTable: () => {}
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);

--- a/tests/local/dataframe-union-immutability.test.mjs
+++ b/tests/local/dataframe-union-immutability.test.mjs
@@ -5,8 +5,8 @@ import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
 test('DataFrame.union returns a clone when the right DataFrame is empty', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);

--- a/tests/local/groupby-agg-output-names.test.mjs
+++ b/tests/local/groupby-agg-output-names.test.mjs
@@ -5,8 +5,8 @@ import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
 test('GroupBy.agg assigns unique output names for anonymous custom functions', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);

--- a/tests/local/load-bigquery-table.test.mjs
+++ b/tests/local/load-bigquery-table.test.mjs
@@ -21,17 +21,17 @@ function baseConfig(mode = 'insert') {
   };
 }
 
-test('loadBigQueryTable rejects unsupported load modes', () => {
+test('astLoadBigQueryTable rejects unsupported load modes', () => {
   const context = createGasContext();
   loadScripts(context, [SCRIPT]);
 
   assert.throws(
-    () => context.loadBigQueryTable(baseConfig('upsert')),
+    () => context.astLoadBigQueryTable(baseConfig('upsert')),
     /Invalid BigQuery load mode/
   );
 });
 
-test('loadBigQueryTable throws when insert returns immediate errorResult', () => {
+test('astLoadBigQueryTable throws when insert returns immediate errorResult', () => {
   const context = createGasContext({
     BigQuery: {
       Jobs: {
@@ -47,12 +47,12 @@ test('loadBigQueryTable throws when insert returns immediate errorResult', () =>
   loadScripts(context, [SCRIPT]);
 
   assert.throws(
-    () => context.loadBigQueryTable(baseConfig('insert')),
+    () => context.astLoadBigQueryTable(baseConfig('insert')),
     /BigQuery load failed/
   );
 });
 
-test('loadBigQueryTable throws timeout error when polling exceeds maxWaitMs', () => {
+test('astLoadBigQueryTable throws timeout error when polling exceeds maxWaitMs', () => {
   let fakeNow = 0;
   const sleepDurations = [];
   class FakeDate extends Date {
@@ -88,14 +88,14 @@ test('loadBigQueryTable throws timeout error when polling exceeds maxWaitMs', ()
   config.options = { maxWaitMs: 1000, pollIntervalMs: 250 };
 
   assert.throws(
-    () => context.loadBigQueryTable(config),
+    () => context.astLoadBigQueryTable(config),
     /BigQuery load timed out after 1000ms/
   );
 
   assert.equal(JSON.stringify(sleepDurations), JSON.stringify([250, 250, 250, 250]));
 });
 
-test('loadBigQueryTable rejects pollIntervalMs greater than maxWaitMs', () => {
+test('astLoadBigQueryTable rejects pollIntervalMs greater than maxWaitMs', () => {
   const context = createGasContext();
   loadScripts(context, [SCRIPT]);
 
@@ -103,12 +103,12 @@ test('loadBigQueryTable rejects pollIntervalMs greater than maxWaitMs', () => {
   config.options = { maxWaitMs: 100, pollIntervalMs: 200 };
 
   assert.throws(
-    () => context.loadBigQueryTable(config),
+    () => context.astLoadBigQueryTable(config),
     /options\.pollIntervalMs cannot be greater than options\.maxWaitMs/
   );
 });
 
-test('loadBigQueryTable caps final sleep to remaining timeout budget', () => {
+test('astLoadBigQueryTable caps final sleep to remaining timeout budget', () => {
   let fakeNow = 0;
   const sleepDurations = [];
   class FakeDate extends Date {
@@ -144,7 +144,7 @@ test('loadBigQueryTable caps final sleep to remaining timeout budget', () => {
   config.options = { maxWaitMs: 1000, pollIntervalMs: 600 };
 
   assert.throws(
-    () => context.loadBigQueryTable(config),
+    () => context.astLoadBigQueryTable(config),
     /BigQuery load timed out after 1000ms/
   );
 

--- a/tests/local/load-databricks-table.test.mjs
+++ b/tests/local/load-databricks-table.test.mjs
@@ -27,10 +27,10 @@ function baseConfig(mode = 'insert') {
   };
 }
 
-test('loadDatabricksTable forwards options to each Databricks SQL statement', () => {
+test('astLoadDatabricksTable forwards options to each Databricks SQL statement', () => {
   const captured = [];
   const context = createGasContext({
-    runDatabricksSql: (...args) => {
+    astRunDatabricksSql: (...args) => {
       captured.push(args);
       return {};
     }
@@ -41,7 +41,7 @@ test('loadDatabricksTable forwards options to each Databricks SQL statement', ()
     SCRIPT
   ]);
 
-  context.loadDatabricksTable(baseConfig('insert'));
+  context.astLoadDatabricksTable(baseConfig('insert'));
 
   assert.ok(captured.length >= 2);
   assert.equal(
@@ -53,9 +53,9 @@ test('loadDatabricksTable forwards options to each Databricks SQL statement', ()
   );
 });
 
-test('loadDatabricksTable throws for unsupported write mode', () => {
+test('astLoadDatabricksTable throws for unsupported write mode', () => {
   const context = createGasContext({
-    runDatabricksSql: () => ({})
+    astRunDatabricksSql: () => ({})
   });
 
   loadScripts(context, [
@@ -64,14 +64,14 @@ test('loadDatabricksTable throws for unsupported write mode', () => {
   ]);
 
   assert.throws(
-    () => context.loadDatabricksTable(baseConfig('upsert')),
+    () => context.astLoadDatabricksTable(baseConfig('upsert')),
     /Unsupported mode/
   );
 });
 
-test('loadDatabricksTable requires mergeKey in merge mode', () => {
+test('astLoadDatabricksTable requires mergeKey in merge mode', () => {
   const context = createGasContext({
-    runDatabricksSql: () => ({})
+    astRunDatabricksSql: () => ({})
   });
 
   loadScripts(context, [
@@ -83,14 +83,14 @@ test('loadDatabricksTable requires mergeKey in merge mode', () => {
   delete config.mergeKey;
 
   assert.throws(
-    () => context.loadDatabricksTable(config),
+    () => context.astLoadDatabricksTable(config),
     /mergeKey is required for merge mode/
   );
 });
 
-test('loadDatabricksTable validates mergeKey exists in headers', () => {
+test('astLoadDatabricksTable validates mergeKey exists in headers', () => {
   const context = createGasContext({
-    runDatabricksSql: () => ({})
+    astRunDatabricksSql: () => ({})
   });
 
   loadScripts(context, [
@@ -102,14 +102,14 @@ test('loadDatabricksTable validates mergeKey exists in headers', () => {
   config.mergeKey = 'missing_id';
 
   assert.throws(
-    () => context.loadDatabricksTable(config),
+    () => context.astLoadDatabricksTable(config),
     /must exist in header columns/
   );
 });
 
-test('loadDatabricksTable validates row width matches header width', () => {
+test('astLoadDatabricksTable validates row width matches header width', () => {
   const context = createGasContext({
-    runDatabricksSql: () => ({})
+    astRunDatabricksSql: () => ({})
   });
 
   loadScripts(context, [
@@ -124,14 +124,14 @@ test('loadDatabricksTable validates row width matches header width', () => {
   ];
 
   assert.throws(
-    () => context.loadDatabricksTable(config),
+    () => context.astLoadDatabricksTable(config),
     /has length 1, expected 2/
   );
 });
 
-test('loadDatabricksTable validates schema coverage for headers', () => {
+test('astLoadDatabricksTable validates schema coverage for headers', () => {
   const context = createGasContext({
-    runDatabricksSql: () => ({})
+    astRunDatabricksSql: () => ({})
   });
 
   loadScripts(context, [
@@ -143,14 +143,14 @@ test('loadDatabricksTable validates schema coverage for headers', () => {
   config.tableSchema = { id: 'INT' };
 
   assert.throws(
-    () => context.loadDatabricksTable(config),
+    () => context.astLoadDatabricksTable(config),
     /tableSchema is missing definitions for columns: name/
   );
 });
 
-test('loadDatabricksTable validates polling options', () => {
+test('astLoadDatabricksTable validates polling options', () => {
   const context = createGasContext({
-    runDatabricksSql: () => ({})
+    astRunDatabricksSql: () => ({})
   });
 
   loadScripts(context, [
@@ -165,14 +165,14 @@ test('loadDatabricksTable validates polling options', () => {
   };
 
   assert.throws(
-    () => context.loadDatabricksTable(config),
+    () => context.astLoadDatabricksTable(config),
     /options\.pollIntervalMs cannot be greater than options\.maxWaitMs/
   );
 });
 
-test('loadDatabricksTable wraps statement failures in DatabricksLoadError', () => {
+test('astLoadDatabricksTable wraps statement failures in DatabricksLoadError', () => {
   const context = createGasContext({
-    runDatabricksSql: () => {
+    astRunDatabricksSql: () => {
       const err = new Error('statement failed');
       err.name = 'DatabricksSqlError';
       throw err;
@@ -185,7 +185,7 @@ test('loadDatabricksTable wraps statement failures in DatabricksLoadError', () =
   ]);
 
   assert.throws(
-    () => context.loadDatabricksTable(baseConfig('insert')),
+    () => context.astLoadDatabricksTable(baseConfig('insert')),
     error => {
       assert.equal(error.name, 'DatabricksLoadError');
       assert.match(error.message, /Databricks load failed during create table/);
@@ -196,10 +196,10 @@ test('loadDatabricksTable wraps statement failures in DatabricksLoadError', () =
   );
 });
 
-test('loadDatabricksTable executes merge statements when mergeKey is valid', () => {
+test('astLoadDatabricksTable executes merge statements when mergeKey is valid', () => {
   const capturedSql = [];
   const context = createGasContext({
-    runDatabricksSql: (sql) => {
+    astRunDatabricksSql: (sql) => {
       capturedSql.push(sql);
       return {};
     }
@@ -213,7 +213,7 @@ test('loadDatabricksTable executes merge statements when mergeKey is valid', () 
   const config = baseConfig('merge');
   config.mergeKey = 'id';
 
-  context.loadDatabricksTable(config);
+  context.astLoadDatabricksTable(config);
 
   const hasMergeStatement = capturedSql.some(sql => String(sql).toLowerCase().includes('merge into'));
   assert.equal(hasMergeStatement, true);

--- a/tests/local/rag-runtime.test.mjs
+++ b/tests/local/rag-runtime.test.mjs
@@ -1682,7 +1682,7 @@ test('answer enforces strict citation mapping and abstains on missing grounding'
     usage: { inputTokens: 1, totalTokens: 1 }
   });
 
-  context.runAiRequest = () => ({
+  context.astRunAiRequest = () => ({
     output: {
       json: {
         answer: 'Contact support@example.com [S1]',
@@ -1719,7 +1719,7 @@ test('answer enforces strict citation mapping and abstains on missing grounding'
   assert.equal(grounded.citations[0].finalScore, grounded.citations[0].score);
   assert.equal(grounded.citations[0].rerankScore, null);
 
-  context.runAiRequest = () => ({
+  context.astRunAiRequest = () => ({
     output: {
       json: {
         answer: 'I think it is support@example.com.',
@@ -1777,7 +1777,7 @@ test('answer supports lexical retrieval mode without embedding calls', () => {
     throw new Error('astRagEmbedTexts should not run in lexical mode');
   };
 
-  context.runAiRequest = () => ({
+  context.astRunAiRequest = () => ({
     output: {
       json: {
         answer: 'The timeline includes preparation and reopening [S1]',
@@ -1852,7 +1852,7 @@ test('answer cache reuses grounded response when history is empty', () => {
       usage: { inputTokens: 1, totalTokens: 1 }
     };
   };
-  context.runAiRequest = () => {
+  context.astRunAiRequest = () => {
     generationCalls += 1;
     return {
       output: {
@@ -1929,7 +1929,7 @@ test('answer cache key includes generation prompt controls', () => {
     usage: { inputTokens: 1, totalTokens: 1 }
   });
 
-  context.runAiRequest = () => {
+  context.astRunAiRequest = () => {
     generationCalls += 1;
     return {
       output: {
@@ -2008,7 +2008,7 @@ test('answer returns insufficient_context when access policy excludes all retrie
   });
 
   let aiCallCount = 0;
-  context.runAiRequest = () => {
+  context.astRunAiRequest = () => {
     aiCallCount += 1;
     return {
       output: {
@@ -2087,7 +2087,7 @@ test('answer citation validation rejects inaccessible cited chunks when access i
     vectorScore: 1,
     lexicalScore: null
   }];
-  context.runAiRequest = () => ({
+  context.astRunAiRequest = () => ({
     output: {
       json: {
         answer: 'Denied content [S1]',
@@ -2163,7 +2163,7 @@ test('answer diagnostics include stable retrieval and generation metadata', () =
     usage: { inputTokens: 1, totalTokens: 1 }
   });
 
-  context.runAiRequest = () => ({
+  context.astRunAiRequest = () => ({
     finishReason: 'STOP',
     output: {
       json: {
@@ -2270,7 +2270,7 @@ test('answer diagnostics include context budget stats when generation budget is 
     usage: { inputTokens: 1, totalTokens: 1 }
   });
 
-  context.runAiRequest = request => {
+  context.astRunAiRequest = request => {
     const input = Array.isArray(request && request.input) ? request.input : [];
     const userPrompt = input[input.length - 1] || {};
     assert.equal(typeof userPrompt.content, 'string');
@@ -2530,7 +2530,7 @@ test('answer maxRetrievalMs is enforced on cached-answer fast path', () => {
     usage: { inputTokens: 1, totalTokens: 1 }
   });
 
-  context.runAiRequest = () => {
+  context.astRunAiRequest = () => {
     generationCalls += 1;
     return {
       output: {
@@ -2624,7 +2624,7 @@ test('answer generation controls customize grounding prompt while keeping citati
     usage: { inputTokens: 1, totalTokens: 1 }
   });
 
-  context.runAiRequest = request => {
+  context.astRunAiRequest = request => {
     capturedMessages = request.input;
     return {
       output: {
@@ -2695,7 +2695,7 @@ test('answer omits diagnostics by default when diagnostics option is not enabled
     usage: { inputTokens: 1, totalTokens: 1 }
   });
 
-  context.runAiRequest = () => ({
+  context.astRunAiRequest = () => ({
     output: {
       json: {
         answer: 'No diagnostics response [S1]',
@@ -2780,7 +2780,7 @@ test('answer recovery policy relaxes retrieval and applies recovered candidates'
     }];
   };
 
-  context.runAiRequest = () => ({
+  context.astRunAiRequest = () => ({
     output: {
       json: {
         answer: 'Recovery answer [S1]',
@@ -3306,7 +3306,7 @@ test('answer reuses retrieval payload and skips query embedding when payload is 
       usage: { inputTokens: 1, totalTokens: 1 }
     };
   };
-  context.runAiRequest = () => ({
+  context.astRunAiRequest = () => ({
     output: {
       json: {
         answer: 'Project launch is underway [S1]',
@@ -3385,7 +3385,7 @@ test('answer bypasses answer cache when retrieval payload is provided', () => {
   context.astRagEmbedTexts = () => {
     throw new Error('Embedding path should not run when retrieval payload is supplied');
   };
-  context.runAiRequest = () => {
+  context.astRunAiRequest = () => {
     generationCalls += 1;
     return {
       output: {

--- a/tests/local/sql-ergonomics.test.mjs
+++ b/tests/local/sql-ergonomics.test.mjs
@@ -36,7 +36,7 @@ test('AST.Sql exposes prepare/executePrepared/status/cancel/providers/capabiliti
 test('astSqlPrepare + astSqlExecutePrepared binds typed params and executes provider detailed path', () => {
   let captured = null;
   const context = createGasContext({
-    executeBigQuerySqlDetailed: (sql, parameters, placeholders, options) => {
+    astExecuteBigQuerySqlDetailed: (sql, parameters, placeholders, options) => {
       captured = { sql, parameters, placeholders, options };
       return {
         dataFrame: { kind: 'df' },
@@ -47,8 +47,8 @@ test('astSqlPrepare + astSqlExecutePrepared binds typed params and executes prov
         }
       };
     },
-    runBigQuerySql: () => ({ kind: 'fallback' }),
-    runDatabricksSql: () => ({ kind: 'dbx' })
+    astRunBigQuerySql: () => ({ kind: 'fallback' }),
+    astRunDatabricksSql: () => ({ kind: 'dbx' })
   });
 
   loadSqlRuntime(context);
@@ -85,8 +85,8 @@ test('astSqlPrepare + astSqlExecutePrepared binds typed params and executes prov
 
 test('astSqlExecutePrepared falls back to executeQuery when detailed provider helper is unavailable', () => {
   const context = createGasContext({
-    runBigQuerySql: () => ({ kind: 'fallback-df' }),
-    runDatabricksSql: () => ({ kind: 'dbx' })
+    astRunBigQuerySql: () => ({ kind: 'fallback-df' }),
+    astRunDatabricksSql: () => ({ kind: 'dbx' })
   });
 
   loadSqlRuntime(context);
@@ -109,8 +109,8 @@ test('astSqlExecutePrepared falls back to executeQuery when detailed provider he
 
 test('astSqlExecutePrepared throws for missing required prepared params', () => {
   const context = createGasContext({
-    runBigQuerySql: () => ({ kind: 'unused' }),
-    runDatabricksSql: () => ({ kind: 'unused' })
+    astRunBigQuerySql: () => ({ kind: 'unused' }),
+    astRunDatabricksSql: () => ({ kind: 'unused' })
   });
 
   loadSqlRuntime(context);
@@ -133,9 +133,9 @@ test('astSqlExecutePrepared throws for missing required prepared params', () => 
 test('astSqlStatus routes to provider status helpers', () => {
   let captured = null;
   const context = createGasContext({
-    runBigQuerySql: () => ({ kind: 'unused' }),
-    runDatabricksSql: () => ({ kind: 'unused' }),
-    getBigQuerySqlStatus: (parameters, jobId) => {
+    astRunBigQuerySql: () => ({ kind: 'unused' }),
+    astRunDatabricksSql: () => ({ kind: 'unused' }),
+    astGetBigQuerySqlStatus: (parameters, jobId) => {
       captured = { parameters, jobId };
       return {
         provider: 'bigquery',
@@ -162,9 +162,9 @@ test('astSqlStatus routes to provider status helpers', () => {
 test('astSqlCancel routes to provider cancel helpers', () => {
   let captured = null;
   const context = createGasContext({
-    runBigQuerySql: () => ({ kind: 'unused' }),
-    runDatabricksSql: () => ({ kind: 'unused' }),
-    cancelDatabricksSql: (parameters, statementId) => {
+    astRunBigQuerySql: () => ({ kind: 'unused' }),
+    astRunDatabricksSql: () => ({ kind: 'unused' }),
+    astCancelDatabricksSql: (parameters, statementId) => {
       captured = { parameters, statementId };
       return {
         provider: 'databricks',

--- a/tests/local/sql-execution-control.test.mjs
+++ b/tests/local/sql-execution-control.test.mjs
@@ -9,7 +9,7 @@ function createResponse(body = '{}', statusCode = 200) {
   };
 }
 
-test('getBigQuerySqlStatus maps DONE state to SUCCEEDED', () => {
+test('astGetBigQuerySqlStatus maps DONE state to SUCCEEDED', () => {
   const context = createGasContext({
     BigQuery: {
       Jobs: {
@@ -22,7 +22,7 @@ test('getBigQuerySqlStatus maps DONE state to SUCCEEDED', () => {
 
   loadScripts(context, ['apps_script_tools/database/bigQuery/runBigQuerySql.js']);
 
-  const status = context.getBigQuerySqlStatus(
+  const status = context.astGetBigQuerySqlStatus(
     { projectId: 'project-1' },
     'job-1'
   );
@@ -33,7 +33,7 @@ test('getBigQuerySqlStatus maps DONE state to SUCCEEDED', () => {
   assert.equal(status.complete, true);
 });
 
-test('cancelBigQuerySql delegates to BigQuery.Jobs.cancel', () => {
+test('astCancelBigQuerySql delegates to BigQuery.Jobs.cancel', () => {
   let called = null;
   const context = createGasContext({
     BigQuery: {
@@ -52,7 +52,7 @@ test('cancelBigQuerySql delegates to BigQuery.Jobs.cancel', () => {
 
   loadScripts(context, ['apps_script_tools/database/bigQuery/runBigQuerySql.js']);
 
-  const status = context.cancelBigQuerySql(
+  const status = context.astCancelBigQuerySql(
     { projectId: 'project-1' },
     'job-2'
   );
@@ -62,7 +62,7 @@ test('cancelBigQuerySql delegates to BigQuery.Jobs.cancel', () => {
   assert.equal(status.canceled, true);
 });
 
-test('getBigQuerySqlStatus maps DONE + stopped reason to CANCELED', () => {
+test('astGetBigQuerySqlStatus maps DONE + stopped reason to CANCELED', () => {
   const context = createGasContext({
     BigQuery: {
       Jobs: {
@@ -81,7 +81,7 @@ test('getBigQuerySqlStatus maps DONE + stopped reason to CANCELED', () => {
 
   loadScripts(context, ['apps_script_tools/database/bigQuery/runBigQuerySql.js']);
 
-  const status = context.getBigQuerySqlStatus(
+  const status = context.astGetBigQuerySqlStatus(
     { projectId: 'project-1' },
     'job-3'
   );
@@ -90,7 +90,7 @@ test('getBigQuerySqlStatus maps DONE + stopped reason to CANCELED', () => {
   assert.equal(status.complete, true);
 });
 
-test('getDatabricksSqlStatus returns normalized statement status', () => {
+test('astGetDatabricksSqlStatus returns normalized statement status', () => {
   let calledUrl = null;
   const context = createGasContext({
     UrlFetchApp: {
@@ -107,7 +107,7 @@ test('getDatabricksSqlStatus returns normalized statement status', () => {
 
   loadScripts(context, ['apps_script_tools/database/databricks/runDatabricksSql.js']);
 
-  const status = context.getDatabricksSqlStatus(
+  const status = context.astGetDatabricksSqlStatus(
     {
       host: 'https://dbc.example.com/',
       token: 'token'
@@ -122,7 +122,7 @@ test('getDatabricksSqlStatus returns normalized statement status', () => {
   assert.equal(status.complete, false);
 });
 
-test('cancelDatabricksSql posts cancel and returns latest status', () => {
+test('astCancelDatabricksSql posts cancel and returns latest status', () => {
   const calls = [];
   const context = createGasContext({
     UrlFetchApp: {
@@ -144,7 +144,7 @@ test('cancelDatabricksSql posts cancel and returns latest status', () => {
 
   loadScripts(context, ['apps_script_tools/database/databricks/runDatabricksSql.js']);
 
-  const status = context.cancelDatabricksSql(
+  const status = context.astCancelDatabricksSql(
     {
       host: 'dbc.example.com',
       token: 'token'
@@ -159,7 +159,7 @@ test('cancelDatabricksSql posts cancel and returns latest status', () => {
   assert.equal(status.state, 'CANCELED');
 });
 
-test('cancelDatabricksSql throws when cancel endpoint returns non-2xx', () => {
+test('astCancelDatabricksSql throws when cancel endpoint returns non-2xx', () => {
   const context = createGasContext({
     UrlFetchApp: {
       fetch: url => {
@@ -179,7 +179,7 @@ test('cancelDatabricksSql throws when cancel endpoint returns non-2xx', () => {
   loadScripts(context, ['apps_script_tools/database/databricks/runDatabricksSql.js']);
 
   assert.throws(
-    () => context.cancelDatabricksSql(
+    () => context.astCancelDatabricksSql(
       {
         host: 'dbc.example.com',
         token: 'token'

--- a/tests/local/sql-placeholder-safety.test.mjs
+++ b/tests/local/sql-placeholder-safety.test.mjs
@@ -2,14 +2,14 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createGasContext, loadScripts } from './helpers.mjs';
 
-test('replacePlaceHoldersInQuery escapes placeholder names for regex-safe replacement', () => {
+test('astReplacePlaceHoldersInQuery escapes placeholder names for regex-safe replacement', () => {
   const context = createGasContext();
 
   loadScripts(context, [
     'apps_script_tools/database/general/replacePlaceHoldersInQuery.js'
   ]);
 
-  const output = context.replacePlaceHoldersInQuery(
+  const output = context.astReplacePlaceHoldersInQuery(
     'select {{a+b}} as plus_key, {{region.name}} as region_key, {{a+b}} as repeated_plus',
     { 'a+b': 5, 'region.name': 'north' }
   );
@@ -20,12 +20,12 @@ test('replacePlaceHoldersInQuery escapes placeholder names for regex-safe replac
   );
 });
 
-test('replacePlaceHoldersInQuery validates query type', () => {
+test('astReplacePlaceHoldersInQuery validates query type', () => {
   const context = createGasContext();
 
   loadScripts(context, [
     'apps_script_tools/database/general/replacePlaceHoldersInQuery.js'
   ]);
 
-  assert.throws(() => context.replacePlaceHoldersInQuery(null, {}), /Query must be a string/);
+  assert.throws(() => context.astReplacePlaceHoldersInQuery(null, {}), /Query must be a string/);
 });

--- a/tests/local/sql-provider-adapters.test.mjs
+++ b/tests/local/sql-provider-adapters.test.mjs
@@ -4,8 +4,8 @@ import { createGasContext, loadScripts } from './helpers.mjs';
 
 function createContext(overrides = {}) {
   return createGasContext({
-    runDatabricksSql: () => ({ provider: 'databricks' }),
-    runBigQuerySql: () => ({ provider: 'bigquery' }),
+    astRunDatabricksSql: () => ({ provider: 'databricks' }),
+    astRunBigQuerySql: () => ({ provider: 'bigquery' }),
     ...overrides
   });
 }
@@ -44,11 +44,11 @@ test('astGetSqlProviderAdapter returns typed validation error for unknown provid
 test('runSqlQuery uses adapter registry dispatch for provider execution', () => {
   const calls = [];
   const context = createContext({
-    runDatabricksSql: () => {
+    astRunDatabricksSql: () => {
       calls.push('databricks');
       return { provider: 'databricks' };
     },
-    runBigQuerySql: () => {
+    astRunBigQuerySql: () => {
       calls.push('bigquery');
       return { provider: 'bigquery' };
     }

--- a/tests/local/sql-provider-validation.test.mjs
+++ b/tests/local/sql-provider-validation.test.mjs
@@ -4,8 +4,8 @@ import { createGasContext, loadScripts } from './helpers.mjs';
 
 test('runSqlQuery validates required BigQuery parameters', () => {
   const context = createGasContext({
-    runDatabricksSql: () => ({ provider: 'databricks' }),
-    runBigQuerySql: () => ({ provider: 'bigquery' })
+    astRunDatabricksSql: () => ({ provider: 'databricks' }),
+    astRunBigQuerySql: () => ({ provider: 'bigquery' })
   });
 
   loadScripts(context, [
@@ -25,8 +25,8 @@ test('runSqlQuery validates required BigQuery parameters', () => {
 
 test('runSqlQuery validates required Databricks parameters', () => {
   const context = createGasContext({
-    runDatabricksSql: () => ({ provider: 'databricks' }),
-    runBigQuerySql: () => ({ provider: 'bigquery' })
+    astRunDatabricksSql: () => ({ provider: 'databricks' }),
+    astRunBigQuerySql: () => ({ provider: 'bigquery' })
   });
 
   loadScripts(context, [
@@ -51,8 +51,8 @@ test('runSqlQuery validates required Databricks parameters', () => {
 test('runSqlQuery forwards normalized options to BigQuery provider', () => {
   let captured = null;
   const context = createGasContext({
-    runDatabricksSql: () => ({ provider: 'databricks' }),
-    runBigQuerySql: (sql, parameters, placeholders, options) => {
+    astRunDatabricksSql: () => ({ provider: 'databricks' }),
+    astRunBigQuerySql: (sql, parameters, placeholders, options) => {
       captured = { sql, parameters, placeholders, options };
       return { provider: 'bigquery' };
     }
@@ -93,11 +93,11 @@ test('runSqlQuery forwards normalized options to BigQuery provider', () => {
 test('runSqlQuery forwards default options to Databricks provider', () => {
   let capturedOptions = null;
   const context = createGasContext({
-    runDatabricksSql: (_sql, _parameters, _placeholders, options) => {
+    astRunDatabricksSql: (_sql, _parameters, _placeholders, options) => {
       capturedOptions = options;
       return { provider: 'databricks' };
     },
-    runBigQuerySql: () => ({ provider: 'bigquery' })
+    astRunBigQuerySql: () => ({ provider: 'bigquery' })
   });
 
   loadScripts(context, [
@@ -130,11 +130,11 @@ test('runSqlQuery forwards default options to Databricks provider', () => {
 test('runSqlQuery forwards custom options to Databricks provider', () => {
   let captured = null;
   const context = createGasContext({
-    runDatabricksSql: (sql, parameters, placeholders, options) => {
+    astRunDatabricksSql: (sql, parameters, placeholders, options) => {
       captured = { sql, parameters, placeholders, options };
       return { provider: 'databricks' };
     },
-    runBigQuerySql: () => ({ provider: 'bigquery' })
+    astRunBigQuerySql: () => ({ provider: 'bigquery' })
   });
 
   loadScripts(context, [
@@ -179,8 +179,8 @@ test('runSqlQuery forwards custom options to Databricks provider', () => {
 
 test('runSqlQuery rejects options.pollIntervalMs larger than options.maxWaitMs', () => {
   const context = createGasContext({
-    runDatabricksSql: () => ({ provider: 'databricks' }),
-    runBigQuerySql: () => ({ provider: 'bigquery' })
+    astRunDatabricksSql: () => ({ provider: 'databricks' }),
+    astRunBigQuerySql: () => ({ provider: 'bigquery' })
   });
 
   loadScripts(context, [

--- a/tests/local/sql-validation.test.mjs
+++ b/tests/local/sql-validation.test.mjs
@@ -4,8 +4,8 @@ import { createGasContext, loadScripts } from './helpers.mjs';
 
 test('runSqlQuery rejects placeholders unless unsafe option is enabled', () => {
   const context = createGasContext({
-    runDatabricksSql: () => ({ provider: 'databricks' }),
-    runBigQuerySql: () => ({ provider: 'bigquery' })
+    astRunDatabricksSql: () => ({ provider: 'databricks' }),
+    astRunBigQuerySql: () => ({ provider: 'bigquery' })
   });
 
   loadScripts(context, [

--- a/tests/local/standardize-records-prototype.test.mjs
+++ b/tests/local/standardize-records-prototype.test.mjs
@@ -5,8 +5,8 @@ import { createGasContext, loadCoreDataContext } from './helpers.mjs';
 
 test('standardizeRecords ignores inherited enumerable properties', () => {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);

--- a/tests/local/storage-dbfs.test.mjs
+++ b/tests/local/storage-dbfs.test.mjs
@@ -90,32 +90,32 @@ test('DBFS list/head/read/write/delete operations return normalized output', () 
 
   loadStorageScripts(context);
 
-  const listResult = context.runStorageRequest({
+  const listResult = context.astRunStorageRequest({
     uri: 'dbfs:/mnt/data',
     operation: 'list'
   });
   assert.equal(listResult.output.items.length, 1);
 
-  const headResult = context.runStorageRequest({
+  const headResult = context.astRunStorageRequest({
     uri: 'dbfs:/mnt/data/file-1.txt',
     operation: 'head'
   });
   assert.equal(headResult.output.object.size, 3);
 
-  const readResult = context.runStorageRequest({
+  const readResult = context.astRunStorageRequest({
     uri: 'dbfs:/mnt/data/file-1.txt',
     operation: 'read'
   });
   assert.equal(readResult.output.data.base64, 'aGk=');
 
-  const writeResult = context.runStorageRequest({
+  const writeResult = context.astRunStorageRequest({
     uri: 'dbfs:/mnt/data/new.txt',
     operation: 'write',
     payload: { text: 'hello' }
   });
   assert.equal(writeResult.output.written.size, 5);
 
-  const deleteResult = context.runStorageRequest({
+  const deleteResult = context.astRunStorageRequest({
     uri: 'dbfs:/mnt/data/new.txt',
     operation: 'delete'
   });
@@ -160,7 +160,7 @@ test('DBFS chunked write uses create/add-block/close for large payloads', () => 
   loadStorageScripts(context);
 
   const largeText = 'x'.repeat(2 * 1024 * 1024);
-  const out = context.runStorageRequest({
+  const out = context.astRunStorageRequest({
     uri: 'dbfs:/mnt/data/large.txt',
     operation: 'write',
     payload: {
@@ -198,7 +198,7 @@ test('DBFS maps missing resources to AstStorageNotFoundError', () => {
   loadStorageScripts(context);
 
   assert.throws(
-    () => context.runStorageRequest({
+    () => context.astRunStorageRequest({
       uri: 'dbfs:/mnt/missing.txt',
       operation: 'head'
     }),
@@ -239,7 +239,7 @@ test('DBFS list marks truncated when maxItems caps file list', () => {
 
   loadStorageScripts(context);
 
-  const out = context.runStorageRequest({
+  const out = context.astRunStorageRequest({
     uri: 'dbfs:/mnt/data',
     operation: 'list',
     options: {
@@ -274,7 +274,7 @@ test('DBFS exists returns false instead of throwing for missing paths', () => {
 
   loadStorageScripts(context);
 
-  const out = context.runStorageRequest({
+  const out = context.astRunStorageRequest({
     uri: 'dbfs:/mnt/missing.txt',
     operation: 'exists'
   });
@@ -332,7 +332,7 @@ test('DBFS copy/move/multipart_write operations return normalized output', () =>
 
   loadStorageScripts(context);
 
-  const copied = context.runStorageRequest({
+  const copied = context.astRunStorageRequest({
     operation: 'copy',
     fromUri: 'dbfs:/mnt/data/source.txt',
     toUri: 'dbfs:/mnt/data/copied.txt'
@@ -340,14 +340,14 @@ test('DBFS copy/move/multipart_write operations return normalized output', () =>
   assert.equal(copied.output.copied.fromUri, 'dbfs:/mnt/data/source.txt');
   assert.equal(copied.output.copied.toUri, 'dbfs:/mnt/data/copied.txt');
 
-  const moved = context.runStorageRequest({
+  const moved = context.astRunStorageRequest({
     operation: 'move',
     fromUri: 'dbfs:/mnt/data/source.txt',
     toUri: 'dbfs:/mnt/data/moved.txt'
   });
   assert.equal(moved.output.moved.deletedSource, true);
 
-  const multipart = context.runStorageRequest({
+  const multipart = context.astRunStorageRequest({
     operation: 'multipart_write',
     uri: 'dbfs:/mnt/data/multipart.txt',
     payload: {
@@ -375,7 +375,7 @@ test('DBFS signed_url is rejected as unsupported capability', () => {
   loadStorageScripts(context);
 
   assert.throws(
-    () => context.runStorageRequest({
+    () => context.astRunStorageRequest({
       uri: 'dbfs:/mnt/data/file.txt',
       operation: 'signed_url'
     }),
@@ -401,7 +401,7 @@ test('DBFS write rejects conditional preconditions as unsupported capability', (
   loadStorageScripts(context);
 
   assert.throws(
-    () => context.runStorageRequest({
+    () => context.astRunStorageRequest({
       uri: 'dbfs:/mnt/data/file.txt',
       operation: 'write',
       options: {

--- a/tests/local/storage-gcs.test.mjs
+++ b/tests/local/storage-gcs.test.mjs
@@ -68,7 +68,7 @@ test('GCS list/read/delete operations return normalized output', () => {
 
   loadStorageScripts(context);
 
-  const listResult = context.runStorageRequest({
+  const listResult = context.astRunStorageRequest({
     uri: 'gcs://my-bucket/folder/',
     operation: 'list'
   });
@@ -77,7 +77,7 @@ test('GCS list/read/delete operations return normalized output', () => {
   assert.equal(listResult.output.items.length, 1);
   assert.equal(listResult.page.nextPageToken, 'token-2');
 
-  const readResult = context.runStorageRequest({
+  const readResult = context.astRunStorageRequest({
     uri: 'gcs://my-bucket/folder/a.txt',
     operation: 'read'
   });
@@ -85,7 +85,7 @@ test('GCS list/read/delete operations return normalized output', () => {
   assert.equal(readResult.output.data.mimeType, 'text/plain');
   assert.equal(readResult.output.data.text, 'hi');
 
-  const delResult = context.runStorageRequest({
+  const delResult = context.astRunStorageRequest({
     uri: 'gcs://my-bucket/folder/a.txt',
     operation: 'delete'
   });
@@ -110,7 +110,7 @@ test('GCS maps 404 to AstStorageNotFoundError', () => {
   loadStorageScripts(context);
 
   assert.throws(
-    () => context.runStorageRequest({
+    () => context.astRunStorageRequest({
       uri: 'gcs://my-bucket/missing.txt',
       operation: 'head'
     }),
@@ -167,7 +167,7 @@ test('GCS service-account mode exchanges JWT assertion token', () => {
 
   loadStorageScripts(context);
 
-  const result = context.runStorageRequest({
+  const result = context.astRunStorageRequest({
     uri: 'gcs://my-bucket/',
     operation: 'list',
     auth: {
@@ -205,7 +205,7 @@ test('GCS read returns soft-cap warnings when payload exceeds configured limit',
   loadStorageScripts(context);
   context.astStorageGetSoftLimitBytes = () => 1;
 
-  const out = context.runStorageRequest({
+  const out = context.astRunStorageRequest({
     uri: 'gcs://bucket/path.txt',
     operation: 'read'
   });
@@ -241,7 +241,7 @@ test('GCS list marks truncated when maxItems caps merged results', () => {
 
   loadStorageScripts(context);
 
-  const out = context.runStorageRequest({
+  const out = context.astRunStorageRequest({
     uri: 'gcs://my-bucket/folder/',
     operation: 'list',
     options: {
@@ -268,7 +268,7 @@ test('GCS exists returns false instead of throwing for missing objects', () => {
 
   loadStorageScripts(context);
 
-  const out = context.runStorageRequest({
+  const out = context.astRunStorageRequest({
     uri: 'gcs://my-bucket/missing.txt',
     operation: 'exists'
   });
@@ -346,7 +346,7 @@ test('GCS copy/move/signed_url/multipart_write operations return normalized outp
 
   loadStorageScripts(context);
 
-  const copied = context.runStorageRequest({
+  const copied = context.astRunStorageRequest({
     operation: 'copy',
     fromUri: 'gcs://source-bucket/path/a.txt',
     toUri: 'gcs://target-bucket/path/b.txt'
@@ -354,14 +354,14 @@ test('GCS copy/move/signed_url/multipart_write operations return normalized outp
   assert.equal(copied.output.copied.fromUri, 'gcs://source-bucket/path/a.txt');
   assert.equal(copied.output.copied.toUri, 'gcs://target-bucket/path/b.txt');
 
-  const moved = context.runStorageRequest({
+  const moved = context.astRunStorageRequest({
     operation: 'move',
     fromUri: 'gcs://source-bucket/path/a.txt',
     toUri: 'gcs://target-bucket/path/c.txt'
   });
   assert.equal(moved.output.moved.deletedSource, true);
 
-  const signed = context.runStorageRequest({
+  const signed = context.astRunStorageRequest({
     operation: 'signed_url',
     uri: 'gcs://target-bucket/path/b.txt',
     options: {
@@ -382,7 +382,7 @@ test('GCS copy/move/signed_url/multipart_write operations return normalized outp
   assert.equal(signed.output.signedUrl.method, 'PUT');
   assert.match(signed.output.signedUrl.url, /X-Goog-Signature=/);
 
-  const multipart = context.runStorageRequest({
+  const multipart = context.astRunStorageRequest({
     operation: 'multipart_write',
     uri: 'gcs://target-bucket/path/upload.txt',
     payload: {
@@ -420,7 +420,7 @@ test('GCS write maps ifNoneMatch="*" to create-only generation precondition', ()
 
   loadStorageScripts(context);
 
-  const out = context.runStorageRequest({
+  const out = context.astRunStorageRequest({
     uri: 'gcs://my-bucket/path/new.txt',
     operation: 'write',
     payload: { text: 'hello' },

--- a/tests/local/storage-s3.test.mjs
+++ b/tests/local/storage-s3.test.mjs
@@ -137,7 +137,7 @@ test('S3 list/read/write/delete operations return normalized output', () => {
 
   loadStorageScripts(context);
 
-  const listResult = context.runStorageRequest({
+  const listResult = context.astRunStorageRequest({
     uri: 's3://bucket-1/folder/',
     operation: 'list'
   });
@@ -145,20 +145,20 @@ test('S3 list/read/write/delete operations return normalized output', () => {
   assert.equal(listResult.output.items.length, 1);
   assert.equal(listResult.output.items[0].key, 'folder/a.txt');
 
-  const readResult = context.runStorageRequest({
+  const readResult = context.astRunStorageRequest({
     uri: 's3://bucket-1/folder/a.txt',
     operation: 'read'
   });
   assert.equal(readResult.output.data.text, 'hi');
 
-  const writeResult = context.runStorageRequest({
+  const writeResult = context.astRunStorageRequest({
     uri: 's3://bucket-1/folder/new.txt',
     operation: 'write',
     payload: { text: 'hello' }
   });
   assert.equal(writeResult.output.written.etag, 'etag-write');
 
-  const deleteResult = context.runStorageRequest({
+  const deleteResult = context.astRunStorageRequest({
     uri: 's3://bucket-1/folder/new.txt',
     operation: 'delete'
   });
@@ -186,7 +186,7 @@ test('S3 maps 404 to AstStorageNotFoundError', () => {
   loadStorageScripts(context);
 
   assert.throws(
-    () => context.runStorageRequest({
+    () => context.astRunStorageRequest({
       uri: 's3://bucket/missing.txt',
       operation: 'head'
     }),
@@ -234,7 +234,7 @@ test('S3 list marks truncated when maxItems caps provider results', () => {
 
   loadStorageScripts(context);
 
-  const out = context.runStorageRequest({
+  const out = context.astRunStorageRequest({
     uri: 's3://bucket-1/folder/',
     operation: 'list',
     options: {
@@ -270,7 +270,7 @@ test('S3 exists returns false instead of throwing for missing objects', () => {
 
   loadStorageScripts(context);
 
-  const out = context.runStorageRequest({
+  const out = context.astRunStorageRequest({
     uri: 's3://bucket/missing.txt',
     operation: 'exists'
   });
@@ -344,7 +344,7 @@ test('S3 copy/move/signed_url/multipart_write operations return normalized outpu
 
   loadStorageScripts(context);
 
-  const copied = context.runStorageRequest({
+  const copied = context.astRunStorageRequest({
     operation: 'copy',
     fromUri: 's3://bucket-a/path/source.txt',
     toUri: 's3://bucket-a/path/copied.txt'
@@ -352,14 +352,14 @@ test('S3 copy/move/signed_url/multipart_write operations return normalized outpu
   assert.equal(copied.output.copied.fromUri, 's3://bucket-a/path/source.txt');
   assert.equal(copied.output.copied.toUri, 's3://bucket-a/path/copied.txt');
 
-  const moved = context.runStorageRequest({
+  const moved = context.astRunStorageRequest({
     operation: 'move',
     fromUri: 's3://bucket-a/path/source.txt',
     toUri: 's3://bucket-a/path/moved.txt'
   });
   assert.equal(moved.output.moved.deletedSource, true);
 
-  const signed = context.runStorageRequest({
+  const signed = context.astRunStorageRequest({
     operation: 'signed_url',
     uri: 's3://bucket-a/path/moved.txt',
     options: {
@@ -373,7 +373,7 @@ test('S3 copy/move/signed_url/multipart_write operations return normalized outpu
   assert.match(signed.output.signedUrl.url, /X-Amz-Signature=/);
   assert.equal(signed.output.signedUrl.expiresInSec, 300);
 
-  const multipart = context.runStorageRequest({
+  const multipart = context.astRunStorageRequest({
     operation: 'multipart_write',
     uri: 's3://bucket-a/path/large.txt',
     payload: {
@@ -422,7 +422,7 @@ test('S3 multipart_write handles zero-byte payloads without multipart completion
 
   loadStorageScripts(context);
 
-  const out = context.runStorageRequest({
+  const out = context.astRunStorageRequest({
     operation: 'multipart_write',
     uri: 's3://bucket-a/path/empty.txt',
     payload: {
@@ -472,7 +472,7 @@ test('S3 write forwards if-none-match precondition headers', () => {
 
   loadStorageScripts(context);
 
-  const out = context.runStorageRequest({
+  const out = context.astRunStorageRequest({
     uri: 's3://bucket-a/path/create-only.txt',
     operation: 'write',
     payload: { text: 'hello' },

--- a/tests/local/storage-validation.test.mjs
+++ b/tests/local/storage-validation.test.mjs
@@ -15,12 +15,12 @@ function createResponse({ status = 200, body = '', headers = {}, blobBytes = nul
   };
 }
 
-test('validateStorageRequest rejects unknown providers', () => {
+test('astValidateStorageRequest rejects unknown providers', () => {
   const context = createGasContext();
   loadStorageScripts(context);
 
   assert.throws(
-    () => context.validateStorageRequest({
+    () => context.astValidateStorageRequest({
       provider: 'azure',
       operation: 'list',
       location: { bucket: 'x' }
@@ -29,11 +29,11 @@ test('validateStorageRequest rejects unknown providers', () => {
   );
 });
 
-test('validateStorageRequest normalizes URI provider and location', () => {
+test('astValidateStorageRequest normalizes URI provider and location', () => {
   const context = createGasContext();
   loadStorageScripts(context);
 
-  const request = context.validateStorageRequest({
+  const request = context.astValidateStorageRequest({
     uri: 'gcs://bucket-a/path/to/file.json',
     operation: 'head'
   });
@@ -44,11 +44,11 @@ test('validateStorageRequest normalizes URI provider and location', () => {
   assert.equal(request.uri, 'gcs://bucket-a/path/to/file.json');
 });
 
-test('validateStorageRequest normalizes write payload from text/json to base64', () => {
+test('astValidateStorageRequest normalizes write payload from text/json to base64', () => {
   const context = createGasContext();
   loadStorageScripts(context);
 
-  const textRequest = context.validateStorageRequest({
+  const textRequest = context.astValidateStorageRequest({
     uri: 's3://my-bucket/path.txt',
     operation: 'write',
     payload: {
@@ -60,7 +60,7 @@ test('validateStorageRequest normalizes write payload from text/json to base64',
   assert.equal(typeof textRequest.payload.base64, 'string');
   assert.equal(textRequest.payload.mimeType, 'text/plain');
 
-  const jsonRequest = context.validateStorageRequest({
+  const jsonRequest = context.astValidateStorageRequest({
     uri: 'dbfs:/mnt/data.json',
     operation: 'write',
     payload: {
@@ -72,12 +72,12 @@ test('validateStorageRequest normalizes write payload from text/json to base64',
   assert.equal(jsonRequest.payload.mimeType, 'application/json');
 });
 
-test('validateStorageRequest enforces single payload mode for write', () => {
+test('astValidateStorageRequest enforces single payload mode for write', () => {
   const context = createGasContext();
   loadStorageScripts(context);
 
   assert.throws(
-    () => context.validateStorageRequest({
+    () => context.astValidateStorageRequest({
       uri: 'gcs://bucket/path.txt',
       operation: 'write',
       payload: {
@@ -89,11 +89,11 @@ test('validateStorageRequest enforces single payload mode for write', () => {
   );
 });
 
-test('validateStorageRequest applies option defaults and validates operation', () => {
+test('astValidateStorageRequest applies option defaults and validates operation', () => {
   const context = createGasContext();
   loadStorageScripts(context);
 
-  const request = context.validateStorageRequest({
+  const request = context.astValidateStorageRequest({
     uri: 's3://my-bucket',
     operation: 'list'
   });
@@ -102,7 +102,7 @@ test('validateStorageRequest applies option defaults and validates operation', (
   assert.equal(request.options.retries, 2);
 
   assert.throws(
-    () => context.validateStorageRequest({
+    () => context.astValidateStorageRequest({
       uri: 's3://my-bucket/key',
       operation: 'clone'
     }),
@@ -110,11 +110,11 @@ test('validateStorageRequest applies option defaults and validates operation', (
   );
 });
 
-test('validateStorageRequest normalizes conditional preconditions', () => {
+test('astValidateStorageRequest normalizes conditional preconditions', () => {
   const context = createGasContext();
   loadStorageScripts(context);
 
-  const request = context.validateStorageRequest({
+  const request = context.astValidateStorageRequest({
     uri: 's3://my-bucket/key.txt',
     operation: 'write',
     options: {
@@ -126,7 +126,7 @@ test('validateStorageRequest normalizes conditional preconditions', () => {
   assert.equal(request.preconditions.ifMatch, '12345');
   assert.equal(request.preconditions.ifNoneMatch, null);
 
-  const requestCreateOnly = context.validateStorageRequest({
+  const requestCreateOnly = context.astValidateStorageRequest({
     uri: 's3://my-bucket/key.txt',
     operation: 'write',
     options: {
@@ -137,7 +137,7 @@ test('validateStorageRequest normalizes conditional preconditions', () => {
   assert.equal(requestCreateOnly.preconditions.ifNoneMatch, '*');
 
   assert.throws(
-    () => context.validateStorageRequest({
+    () => context.astValidateStorageRequest({
       uri: 's3://my-bucket/key.txt',
       operation: 'write',
       options: {
@@ -150,11 +150,11 @@ test('validateStorageRequest normalizes conditional preconditions', () => {
   );
 });
 
-test('validateStorageRequest normalizes copy request fromUri/toUri and inferred provider', () => {
+test('astValidateStorageRequest normalizes copy request fromUri/toUri and inferred provider', () => {
   const context = createGasContext();
   loadStorageScripts(context);
 
-  const request = context.validateStorageRequest({
+  const request = context.astValidateStorageRequest({
     operation: 'copy',
     fromUri: 'gcs://source-bucket/path/a.txt',
     toUri: 'gcs://target-bucket/path/b.txt'

--- a/tests/local/telemetry-runtime.test.mjs
+++ b/tests/local/telemetry-runtime.test.mjs
@@ -304,7 +304,7 @@ test('Telemetry reset clears buffered drive_json records', () => {
 test('Telemetry storage_json sink supports manual flush mode', () => {
   const writes = [];
   const context = createGasContext({
-    runStorageRequest: request => {
+    astRunStorageRequest: request => {
       writes.push(request);
       return {
         provider: 's3',
@@ -339,7 +339,7 @@ test('Telemetry storage_json sink supports manual flush mode', () => {
 test('Telemetry reset clears buffered storage_json records', () => {
   const writes = [];
   const context = createGasContext({
-    runStorageRequest: request => {
+    astRunStorageRequest: request => {
       writes.push(request);
       return {
         provider: 's3',
@@ -372,7 +372,7 @@ test('Telemetry reset clears buffered storage_json records', () => {
 test('Telemetry storage_json sink flushes on threshold', () => {
   const writes = [];
   const context = createGasContext({
-    runStorageRequest: request => {
+    astRunStorageRequest: request => {
       writes.push(request);
       return {
         provider: 'gcs',
@@ -435,7 +435,7 @@ test('Telemetry keeps running traces eligible for endSpan under maxTraceCount pr
   assert.equal(context.AST.Telemetry.getTrace('trace_1'), null);
 });
 
-test('runAiRequest emits telemetry span_end records', () => {
+test('astRunAiRequest emits telemetry span_end records', () => {
   const logger = createLoggerCapture();
   const context = createGasContext({
     Logger: logger.Logger,
@@ -471,7 +471,7 @@ test('runAiRequest emits telemetry span_end records', () => {
     sink: 'logger'
   });
 
-  const response = context.runAiRequest({
+  const response = context.astRunAiRequest({
     provider: 'openai',
     operation: 'text',
     input: 'hello',
@@ -497,7 +497,7 @@ test('runAiRequest emits telemetry span_end records', () => {
   assert.equal(spanLog.span.status, 'ok');
 });
 
-test('runAiRequest telemetry attributes provider/model to successful fallback attempt', () => {
+test('astRunAiRequest telemetry attributes provider/model to successful fallback attempt', () => {
   const logger = createLoggerCapture();
   const context = createGasContext({
     Logger: logger.Logger
@@ -512,17 +512,17 @@ test('runAiRequest telemetry attributes provider/model to successful fallback at
     sink: 'logger'
   });
 
-  const originalRunOpenAi = context.runOpenAi;
-  const originalRunGemini = context.runGemini;
+  const originalRunOpenAi = context.astRunOpenAi;
+  const originalRunGemini = context.astRunGemini;
 
-  context.runOpenAi = () => {
+  context.astRunOpenAi = () => {
     const error = new Error('temporary upstream failure');
     error.name = 'AstAiProviderError';
     error.details = { statusCode: 503 };
     throw error;
   };
 
-  context.runGemini = request => context.normalizeAiResponse({
+  context.astRunGemini = request => context.astNormalizeAiResponse({
     provider: 'gemini',
     operation: 'text',
     model: request.model,
@@ -531,7 +531,7 @@ test('runAiRequest telemetry attributes provider/model to successful fallback at
     }
   });
 
-  const response = context.runAiRequest({
+  const response = context.astRunAiRequest({
     input: 'hello',
     routing: {
       strategy: 'priority',
@@ -550,8 +550,8 @@ test('runAiRequest telemetry attributes provider/model to successful fallback at
     }
   });
 
-  context.runOpenAi = originalRunOpenAi;
-  context.runGemini = originalRunGemini;
+  context.astRunOpenAi = originalRunOpenAi;
+  context.astRunGemini = originalRunGemini;
 
   assert.equal(response.provider, 'gemini');
 

--- a/tests/perf/run-perf.mjs
+++ b/tests/perf/run-perf.mjs
@@ -169,8 +169,8 @@ function formatSummary(payload) {
 
 function runAllBenchmarks(options) {
   const context = createGasContext({
-    loadDatabricksTable: () => {},
-    loadBigQueryTable: () => {}
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
   });
 
   loadCoreDataContext(context);


### PR DESCRIPTION
## Summary
This PR applies the strict internal naming policy repo-wide and removes legacy allowlist behavior.

### What changed
- Enforced strict lint contract for top-level functions in `scripts/lint.mjs`:
  - Internal functions must be named `ast*`, `__ast*`, or `*_`.
  - Otherwise they must be explicitly public (AST binding/global assignment).
- Removed legacy exception model (`scripts/internal-function-name-allowlist.json` is no longer used).
- Renamed non-compliant internal top-level functions across core runtime modules (AI, RAG, Storage, SQL, DataFrame/Series helpers, telemetry, tests) to comply with the strict convention.
- Updated AST binding helper naming in `apps_script_tools/AST.js` (`resolveAstBinding` -> `astResolveAstBinding`) with all call sites aligned.
- Updated docs to codify the policy and breaking semantics:
  - `CONTRIBUTING.md`
  - `README.md`
  - `CHANGELOG.md`

## Breaking change
This intentionally removes backward compatibility for legacy internal symbol names.
- There is no internal-name allowlist fallback.
- Non-compliant top-level internal function names are now lint failures.

Public `AST` API entrypoints are unchanged.

## Validation
Executed and passing:
- `npm run lint`
- `npm run test:local` (371/371)
- `npm run test:perf:check`
- `clasp push` (script id `1gZ_6DiLeDhh-a4qcezluTFDshw4OEhTXbeD3wthl_UdHEAFkXf6i6Ho_`)
- `clasp run runAllTests` (1496/1496)

## Risk and mitigation
- Primary risk is rename fallout for internal references.
- Mitigated via full local + GAS suite pass and perf gate pass.
- No behavioral changes intended beyond strict internal naming enforcement.
