### PR TITLE
docs: full v0.0.4 consistency sweep (mkdocs + release messaging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Current release state:
 - RAG request-level cache controls for embedding/search/answer hot paths with backend overrides.
 - New `AST.Jobs` module with script-properties checkpointing and run/enqueue/resume/status/list/cancel contracts.
 - New `AST.Chat` module with `ThreadStore.create(...)` for user-scoped thread persistence, lock-aware writes, and bounded history assembly.
+- Breaking contract: internal non-`AST` top-level globals are intentionally unstable; consume documented surfaces through `ASTX.*` only.
 - DataFrame schema contracts with `validateSchema(...)` reporting and `enforceSchema(...)` strict/coercion pathways.
 - `AST.AI.tools(...)` guardrails for timeout, payload caps, retries, and idempotent replay.
 - `AST.AI.structured(...)` reliability policy with schema retries and optional JSON/LLM repair.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,6 +26,8 @@ Use semantic tags:
   - embedding provider registry and custom provider registration
   - grounding/citation/abstention behavior
   - `AST.Storage` contracts (`list`, `head`, `read`, `write`, `delete`) for `gcs`, `s3`, and `dbfs`
+  - `AST.Chat` `ThreadStore` contracts for durable user-scoped thread state
+  - breaking note that internal non-`AST` top-level globals are intentionally unstable
 - Confirm docs and README release-state messaging is consistent:
   - published is `v0.0.3`
   - `v0.0.4` is unreleased until tag + GitHub release publish

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -16,6 +16,8 @@
 - Drive-only ingestion support includes txt/pdf/Docs/Slides (+ notes).
 - Embedding provider registry supports built-ins and runtime custom providers.
 - Storage module (`AST.Storage`) ships unified CRUD for `gcs`, `s3`, and `dbfs`.
+- Chat module (`AST.Chat`) ships durable thread state contracts for app chat workflows.
+- Breaking contract is documented: internal non-`AST` top-level globals are intentionally unstable and should not be consumed directly.
 - Release-note source of truth is `CHANGELOG.md` (`v0.0.4` section).
 
 ## Pre-release checks

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 <span class="subtitle">A production-focused Google Apps Script data toolkit</span>
 
-`apps-script-tools` is a library-first toolkit for tabular data workflows in Google Apps Script. It exposes a single public namespace (`AST`) for dataframe-style transforms, SQL execution, and Apps Script workspace IO.
+`apps-script-tools` is a library-first toolkit for production Apps Script workflows. It exposes a single public namespace (`AST`) for dataframe transforms, SQL execution, workspace helpers, AI/RAG, storage, caching, telemetry, jobs, and chat state.
 
 ## Who this is for
 
@@ -26,6 +26,7 @@
 - `AST.Telemetry`: request-level tracing spans/events with redaction and sink controls.
 - `AST.TelemetryHelpers`: safe wrappers for span lifecycle orchestration.
 - `AST.Jobs`: script-properties checkpointed multi-step job runner with retry/resume and status controls.
+- `AST.Chat`: durable user-scoped thread persistence and bounded history assembly.
 - `AST.Sql`: validated SQL execution for Databricks and BigQuery.
 - `AST.Utils`: utility helpers (`arraySum`, `dateAdd`, `toSnakeCase`, and others).
 
@@ -45,6 +46,7 @@ flowchart LR
     B --> O[AST.Telemetry]
     B --> V[AST.TelemetryHelpers]
     B --> T[AST.Jobs]
+    B --> W[AST.Chat]
     D --> F[BigQuery]
     D --> G[Databricks SQL API]
     I --> J[OpenAI / Gemini / Vertex / OpenRouter / Perplexity]
@@ -53,6 +55,7 @@ flowchart LR
     Q --> R["Memory / Drive JSON / Script Properties / Storage JSON"]
     O --> P[Logger / Drive NDJSON / Storage NDJSON]
     T --> U["Script Properties Checkpoints"]
+    W --> X["Durable Thread Store"]
     C --> H[Records / Arrays / Sheets]
 ```
 
@@ -76,6 +79,8 @@ flowchart LR
 - `AST.TelemetryHelpers` wrappers (`withSpan`, `wrap`, safe start/end/event helpers) for non-blocking app instrumentation.
 - RAG hot-path cache controls for embedding/search/answer reuse across repeated queries.
 - `AST.Jobs` orchestration contracts (`run`, `enqueue`, `resume`, `status`, `list`, `cancel`) with script-properties checkpoint state.
+- `AST.Chat` `ThreadStore` contracts for per-user durable thread state and deterministic history bounds.
+- Breaking contract: internal non-`AST` top-level globals are intentionally not stable; consume APIs through `ASTX.*` only.
 
 ## Import pattern
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,12 +104,10 @@ nav:
     - AI Quick Start: getting-started/ai-quickstart.md
     - RAG Quick Start: getting-started/rag-quickstart.md
     - Storage Quick Start: getting-started/storage-quickstart.md
-    - API:
-      - Quick Reference: api/quick-reference.md
-      - Tools: api/tools.md
-      - Chat Contracts: api/chat-contracts.md
-      - Telemetry Contracts: api/telemetry-contracts.md
-    - Jobs Contracts: api/jobs-contracts.md
+  - API:
+    - Quick Reference: api/quick-reference.md
+    - Tools: api/tools.md
+    - SQL Contracts: api/sql-contracts.md
     - AI Contracts: api/ai-contracts.md
     - AI Providers: api/ai-providers.md
     - AI Tool Calling: api/ai-tool-calling.md
@@ -117,7 +115,9 @@ nav:
     - RAG Embedding Providers: api/rag-embedding-providers.md
     - Storage Contracts: api/storage-contracts.md
     - Storage Providers: api/storage-providers.md
-    - SQL Contracts: api/sql-contracts.md
+    - Chat Contracts: api/chat-contracts.md
+    - Jobs Contracts: api/jobs-contracts.md
+    - Telemetry Contracts: api/telemetry-contracts.md
     - DataFrame Patterns: api/dataframe-patterns.md
   - Performance:
     - Architecture: performance/architecture.md


### PR DESCRIPTION
## Summary
Docs consistency sweep for the current `v0.0.4` release line.

## What changed
- Fixed MkDocs nav structure so API docs are a first-class top-level section (not nested under Getting Started).
- Updated docs landing page to reflect current platform scope and architecture, including `AST.Chat`.
- Added explicit internal-symbol stability guidance (consume via `ASTX.*`, not non-`AST` globals).
- Synced release docs (`RELEASE.md` + docs release page) with current release-line scope and breaking contract notes.

## Files
- `mkdocs.yml`
- `docs/index.md`
- `docs/development/release.md`
- `README.md`
- `RELEASE.md`

## Validation
- `mkdocs build --strict` ✅
