### PR TITLE
release: v0.0.4 prep state + docs rollover to v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## v0.0.4 (unreleased)
+## v0.0.5 (unreleased)
+
+### Planned
+
+- TBD
+
+## v0.0.4 - 2026-02-25
 
 ### Added
 
@@ -142,7 +148,7 @@
 
 ### Changed
 
-- `AST.VERSION` and package version moved to `0.0.4` development line.
+- `AST.VERSION` and package version set to `0.0.4` for this release line.
 - Breaking: internal non-`AST` top-level functions are now strictly internalized (`ast*` / `__ast*` / `*_` naming). Downstream consumers must use documented `AST` namespace APIs instead of direct global helper/function names.
 - `AST` namespace now exposes `AST.RAG`.
 - `AST` namespace now exposes `AST.Cache`.

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@
 
 Current release state:
 
-- Published: `v0.0.3`
-- Next release target on `master`: `v0.0.4` (unreleased)
+- Published: `v0.0.4`
+- Next release target on `master`: `v0.0.5` (unreleased)
 
-`v0.0.4` release-line highlights already on `master`:
+`v0.0.4` release highlights:
 
 - New `AST.RAG` module with Drive ingestion (`txt`, `pdf`, Docs, Slides + notes).
 - RAG embedding registry with built-in providers and runtime custom provider registration.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,9 +18,9 @@ Use semantic tags:
 8. optional live-provider AI smoke: `clasp run runAiLiveSmoke --params '["openai","Reply with OK",""]'`
 9. validate library from a clean consumer Apps Script project
 
-## `v0.0.4` Release Prep Notes
+## `v0.0.5` Release Prep Notes
 
-- Confirm `CHANGELOG.md` `v0.0.4 (unreleased)` includes:
+- Confirm `CHANGELOG.md` `v0.0.5 (unreleased)` includes:
   - `AST.RAG` surface and typed error model
   - Drive ingestion coverage (`txt`, `pdf`, Docs, Slides + notes)
   - embedding provider registry and custom provider registration
@@ -29,10 +29,10 @@ Use semantic tags:
   - `AST.Chat` `ThreadStore` contracts for durable user-scoped thread state
   - breaking note that internal non-`AST` top-level globals are intentionally unstable
 - Confirm docs and README release-state messaging is consistent:
-  - published is `v0.0.3`
-  - `v0.0.4` is unreleased until tag + GitHub release publish
+  - published is `v0.0.4`
+  - `v0.0.5` is unreleased until tag + GitHub release publish
 - For release notes, include exact mapping:
-  - `v0.0.4 -> Apps Script version N` (from `clasp version` output)
+  - `v0.0.5 -> Apps Script version N` (from `clasp version` output)
 
 ## Apps Script Publish (`clasp`)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,8 @@
 
 ## Supported Version
 
-Current published release line: `v0.0.3`.
-Next release target on `master`: `v0.0.4` (unreleased).
+Current published release line: `v0.0.4`.
+Next release target on `master`: `v0.0.5` (unreleased).
 
 ## Reporting Security Issues
 

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -7,10 +7,10 @@
 
 ## Current state
 
-- Published release: `v0.0.3`
-- Next release target on `master`: `v0.0.4` (unreleased)
+- Published release: `v0.0.4`
+- Next release target on `master`: `v0.0.5` (unreleased)
 
-`v0.0.4` release scope check:
+`v0.0.4` release closeout check:
 
 - RAG module (`AST.RAG`) shipped on `master` with docs and tests.
 - Drive-only ingestion support includes txt/pdf/Docs/Slides (+ notes).
@@ -18,7 +18,7 @@
 - Storage module (`AST.Storage`) ships unified CRUD for `gcs`, `s3`, and `dbfs`.
 - Chat module (`AST.Chat`) ships durable thread state contracts for app chat workflows.
 - Breaking contract is documented: internal non-`AST` top-level globals are intentionally unstable and should not be consumed directly.
-- Release-note source of truth is `CHANGELOG.md` (`v0.0.4` section).
+- Release-note source of truth is `CHANGELOG.md` (`v0.0.4` released section).
 
 ## Pre-release checks
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,12 +61,12 @@ flowchart LR
 
 ## Public release
 
-- Current published release: `v0.0.3`
-- Next release target on `master`: `v0.0.4` (unreleased)
+- Current published release: `v0.0.4`
+- Next release target on `master`: `v0.0.5` (unreleased)
 - Script ID: `1gZ_6DiLeDhh-a4qcezluTFDshw4OEhTXbeD3wthl_UdHEAFkXf6i6Ho_`
 - Docs: <https://joe-broadhead.github.io/apps-script-tools/>
 
-## `v0.0.4` release-line scope
+## `v0.0.4` release highlights
 
 - `AST.RAG` module for Drive-only ingestion (`txt`, `pdf`, Docs, Slides + speaker notes).
 - Embedding provider registry with built-ins and runtime custom provider registration.


### PR DESCRIPTION
## Summary
Release-prep update for `v0.0.4` publication state and post-release docs rollover.

## What changed
- Marked `v0.0.4` as released in `CHANGELOG.md`.
- Added new top-line `v0.0.5 (unreleased)` section in `CHANGELOG.md`.
- Updated release-state messaging across docs:
  - published line is now `v0.0.4`
  - next target on `master` is now `v0.0.5 (unreleased)`
- Updated release prep references in release docs from `v0.0.4` to `v0.0.5`.

## Files
- `CHANGELOG.md`
- `README.md`
- `docs/index.md`
- `docs/development/release.md`
- `RELEASE.md`
- `SECURITY.md`

## Validation performed
- `npm run lint`
- `npm run test:local`
- `npm run test:perf:check`
- `mkdocs build --strict`
- `clasp push`
- `clasp run runAllTests`
- `clasp run runPerformanceBenchmarks`
