### PR TITLE
fix(dbt): prevent manifest defaults from overriding artifact sources

### DIFF
--- a/apps_script_tools/dbt/general/validateDbtRequest.js
+++ b/apps_script_tools/dbt/general/validateDbtRequest.js
@@ -652,7 +652,7 @@ function astDbtValidateLoadArtifactRequest(request = {}) {
     throw new AstDbtValidationError('loadArtifact request must be an object');
   }
 
-  const defaults = astDbtResolveLoadDefaults(request);
+  const defaults = astDbtResolveArtifactDefaults(request);
   const options = astDbtNormalizeLoadOptions(request.options || {}, defaults);
   const artifactType = astDbtNormalizeArtifactType(request.artifactType || request.type, '');
   if (!artifactType) {
@@ -687,7 +687,7 @@ function astDbtValidateInspectArtifactRequest(request = {}) {
   }
 
   const artifactType = astDbtNormalizeArtifactType(request.artifactType || request.type, '');
-  const defaults = astDbtResolveLoadDefaults(request);
+  const defaults = astDbtResolveArtifactDefaults(request);
 
   return {
     operation: 'inspect_artifact',
@@ -703,6 +703,14 @@ function astDbtValidateInspectArtifactRequest(request = {}) {
     providerOptions: request.providerOptions || null,
     options: astDbtNormalizeLoadOptions(request.options || {}, defaults)
   };
+}
+
+function astDbtResolveArtifactDefaults(request = {}) {
+  const defaults = astDbtResolveLoadDefaults(request);
+  // Artifact operations should not inherit manifest source defaults.
+  defaults.uri = null;
+  defaults.fileId = null;
+  return defaults;
 }
 
 function astDbtValidateDiffEntitiesRequest(request = {}) {


### PR DESCRIPTION
Summary:
- fix artifact source normalization so loadArtifact/inspectArtifact do not inherit DBT_MANIFEST_URI or DBT_MANIFEST_DRIVE_FILE_ID
- preserve manifest defaults for validation/cache options only
- add regression test for provider+location artifact load path in configured environments

Why:
A review finding on PR #117 identified that when manifest defaults are configured, artifact requests using provider + location (without uri) could resolve to the manifest URI and read the wrong object.

Validation:
- npm run lint
- npm run test:local
- node --test tests/local/dbt-artifacts-diff-impact.test.mjs