### PR TITLE
fix(rag): fail fast on malformed sharded index roots

### DIFF
--- a/apps_script_tools/rag/general/driveIndexStore.js
+++ b/apps_script_tools/rag/general/driveIndexStore.js
@@ -400,7 +400,19 @@ function astRagLoadIndexChunks(indexFileId, indexDocument = {}, options = {}) {
     return indexDocument.chunks.map(astRagHydrateLoadedChunk);
   }
 
+  const allRefs = astRagNormalizeShardRefs(indexDocument.shards || []);
+  if (!allRefs.length) {
+    throw new AstRagIndexError('Sharded index file is missing shard references', {
+      indexFileId
+    });
+  }
+
   const selectedRefs = astRagSelectShardRefs(indexDocument, options);
+  if (!selectedRefs.length) {
+    throw new AstRagIndexError('Sharded index file does not contain selected shard references', {
+      indexFileId
+    });
+  }
   return astRagLoadShardChunks(indexFileId, selectedRefs, options);
 }
 

--- a/tests/local/rag-runtime.test.mjs
+++ b/tests/local/rag-runtime.test.mjs
@@ -4032,6 +4032,37 @@ test('loadIndexDocument throws when single-layout index is missing chunks array'
   );
 });
 
+test('loadIndexDocument throws when sharded-layout index is missing shard references', () => {
+  const badIndex = makeDriveFile({
+    id: 'index_missing_shards',
+    name: 'bad-sharded-index.json',
+    mimeType: 'application/json',
+    text: JSON.stringify({
+      schemaVersion: '1.0',
+      indexName: 'bad-sharded-index',
+      storage: {
+        layout: 'sharded',
+        totalShards: 2
+      },
+      sources: [],
+      chunks: []
+    })
+  });
+  const drive = createDriveRuntime({
+    files: [badIndex]
+  });
+
+  const context = createGasContext({
+    DriveApp: drive.DriveApp
+  });
+  loadRagScripts(context, { includeAst: true });
+
+  assert.throws(
+    () => context.astRagLoadIndexDocument('index_missing_shards'),
+    /missing shard references/i
+  );
+});
+
 test('buildIndex preserves existing sharding when rebuilding existing indexFileId without sharding override', () => {
   const fileA = makeDriveFile({
     id: 'file_shard_preserve_a',


### PR DESCRIPTION
## Summary
- fail fast when a document is classified as sharded but has no valid shard references
- fail fast when selected shard references resolve to an empty set during chunk hydration
- add regression coverage for malformed sharded root documents

## Why
A malformed sharded root (`storage.layout=sharded` with missing/empty shard refs) previously loaded as an empty corpus, masking index corruption and returning silently empty retrieval results.

## Validation
- npm run lint
- npm run test:local
- node --test tests/local/rag-runtime.test.mjs

Refs #108