### PR TITLE
fix(config): explicit script properties handling for GAS web apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@
 - `AST.Runtime.configureFromProps(...)` now supports module `DBT`.
 - `AST.Runtime.configureFromProps(...)` now supports module `Secrets`.
 - `AST.Runtime.configureFromProps(...)` now supports module `Triggers`.
+- `AST.Config.fromScriptProperties(...)` now defaults implicit ScriptProperties reads to fresh snapshots (avoids stale shared memoized defaults in warm GAS web-app runtimes); optional `cacheDefaultHandle=true` re-enables implicit-handle memoization.
+- `AST.Runtime.configureFromProps(...)` now forwards explicit ScriptProperties handle and config snapshot controls (`scriptProperties`, `disableCache`, `forceRefresh`, `cacheScopeId`, `cacheDefaultHandle`) to `AST.Config.fromScriptProperties(...)`.
 - Local/perf test suites now include DBT manifest coverage and performance thresholds.
 - Local/perf test suites now include DBT artifact/diff/impact coverage and deterministic diff benchmark thresholds.
 - `AST.AI`, `AST.RAG`, and `AST.Storage` config resolution now supports optional `secret://...` values through `AST.Secrets.resolveValue(...)`.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ function demoAstLibrary() {
 function demoAstAi() {
   const ASTX = ASTLib.AST || ASTLib;
   ASTX.Runtime.configureFromProps({
-    modules: ['AI']
+    modules: ['AI'],
+    scriptProperties: PropertiesService.getScriptProperties()
   });
 
   const response = ASTX.AI.stream({

--- a/apps_script_tools/ai/general/resolveAiConfig.js
+++ b/apps_script_tools/ai/general/resolveAiConfig.js
@@ -143,7 +143,8 @@ function astGetScriptPropertiesSnapshot(options = {}) {
   if (typeof astConfigGetScriptPropertiesSnapshotMemoized === 'function') {
     return astConfigGetScriptPropertiesSnapshotMemoized({
       keys: AST_AI_CONFIG_KEYS,
-      forceRefresh
+      forceRefresh,
+      cacheDefaultHandle: true
     });
   }
 

--- a/apps_script_tools/cache/general/config.js
+++ b/apps_script_tools/cache/general/config.js
@@ -135,7 +135,8 @@ function astCacheClearRuntimeConfig() {
 function astCacheGetScriptPropertiesSnapshot() {
   if (typeof astConfigGetScriptPropertiesSnapshotMemoized === 'function') {
     return astConfigGetScriptPropertiesSnapshotMemoized({
-      keys: AST_CACHE_CONFIG_KEYS
+      keys: AST_CACHE_CONFIG_KEYS,
+      cacheDefaultHandle: true
     });
   }
 

--- a/apps_script_tools/chat/general/runtime.js
+++ b/apps_script_tools/chat/general/runtime.js
@@ -50,7 +50,8 @@ function astChatInvalidateScriptPropertiesSnapshotCache() {
 function astChatGetScriptPropertiesSnapshot() {
   if (typeof astConfigGetScriptPropertiesSnapshotMemoized === 'function') {
     return astConfigGetScriptPropertiesSnapshotMemoized({
-      keys: AST_CHAT_CONFIG_KEYS
+      keys: AST_CHAT_CONFIG_KEYS,
+      cacheDefaultHandle: true
     });
   }
 

--- a/apps_script_tools/config/Config.js
+++ b/apps_script_tools/config/Config.js
@@ -711,6 +711,12 @@ function astConfigGetScriptPropertiesSnapshotMemoized(options = {}) {
     )
   );
   const explicitCacheScopeId = astConfigNormalizeString(options.cacheScopeId, '');
+  const cacheDefaultHandle = astConfigResolveFirstBoolean([options.cacheDefaultHandle], false);
+  const shouldDisableImplicitHandleCache = (
+    !hasExplicitScriptPropertiesHandle
+    && !explicitCacheScopeId
+    && !cacheDefaultHandle
+  );
   const sharedCacheScopeId = explicitCacheScopeId
     || (hasExplicitScriptPropertiesHandle ? '' : AST_CONFIG_DEFAULT_HANDLE_CACHE_ID);
 
@@ -735,7 +741,8 @@ function astConfigGetScriptPropertiesSnapshotMemoized(options = {}) {
     scriptProperties,
     requestedKeys,
     Object.assign({}, options, {
-      cacheScopeId: sharedCacheScopeId
+      cacheScopeId: sharedCacheScopeId,
+      disableCache: astConfigNormalizeBoolean(options.disableCache, false) || shouldDisableImplicitHandleCache
     })
   );
   return astConfigBuildOutput(entries, Object.assign({}, options, {

--- a/apps_script_tools/rag/general/helpers.js
+++ b/apps_script_tools/rag/general/helpers.js
@@ -97,7 +97,8 @@ function astRagToScriptPropertiesSnapshot(allowedKeys, options = {}) {
   if (typeof astConfigGetScriptPropertiesSnapshotMemoized === 'function') {
     return astConfigGetScriptPropertiesSnapshotMemoized({
       keys: Array.isArray(allowedKeys) ? allowedKeys : [],
-      forceRefresh
+      forceRefresh,
+      cacheDefaultHandle: true
     });
   }
 

--- a/apps_script_tools/runtime/Runtime.js
+++ b/apps_script_tools/runtime/Runtime.js
@@ -240,7 +240,11 @@ function astRuntimeResolveProperties(options = {}) {
     keys: options.keys,
     prefix: options.prefix,
     stripPrefix: options.stripPrefix,
-    includeEmpty: options.includeEmpty
+    includeEmpty: options.includeEmpty,
+    cacheScopeId: options.cacheScopeId,
+    disableCache: options.disableCache,
+    forceRefresh: options.forceRefresh,
+    cacheDefaultHandle: options.cacheDefaultHandle
   });
 
   if (!astRuntimeIsPlainObject(rawProperties)) {

--- a/apps_script_tools/storage/general/resolveStorageConfig.js
+++ b/apps_script_tools/storage/general/resolveStorageConfig.js
@@ -88,7 +88,8 @@ function astStorageClearRuntimeConfig() {
 function astStorageGetScriptPropertiesSnapshot() {
   if (typeof astConfigGetScriptPropertiesSnapshotMemoized === 'function') {
     return astConfigGetScriptPropertiesSnapshotMemoized({
-      keys: AST_STORAGE_CONFIG_KEYS
+      keys: AST_STORAGE_CONFIG_KEYS,
+      cacheDefaultHandle: true
     });
   }
 

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -462,6 +462,8 @@ ASTX.GitHub.clearConfig()
 - `ASTX.TelemetryHelpers.withSpan(...)` safely closes spans on success/error and rethrows task errors.
 - Jobs step handlers must be globally resolvable named functions and return JSON-serializable values.
 - Jobs checkpoint storage currently supports `checkpointStore='properties'` only.
+- `ASTX.Config.fromScriptProperties(...)` supports explicit handle injection with `scriptProperties: PropertiesService.getScriptProperties()` for deterministic GAS web-app behavior.
+- default implicit config snapshots are fresh reads; set `cacheDefaultHandle: true` to opt into implicit-handle memoization.
 - GitHub mutation operations support `options.dryRun=true` planning and skip network writes.
 - GitHub read operations support optional cache + ETag revalidation with stale-on-error fallback.
 - GitHub API auth defaults to PAT (`GITHUB_TOKEN`) unless overridden per request.

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -379,10 +379,13 @@ High-signal behavior:
 
 - values are normalized to trimmed strings.
 - supports `keys` filtering and prefix filtering (`prefix`, `stripPrefix`).
+- accepts explicit handle injection via `scriptProperties: PropertiesService.getScriptProperties()`.
+- default implicit-handle reads are fresh (no shared memoized snapshot). Set `cacheDefaultHandle: true` to opt into implicit-handle memoization.
 - gracefully returns `{}` when script properties are unavailable.
 
 ```javascript
 const props = ASTX.Config.fromScriptProperties({
+  scriptProperties: PropertiesService.getScriptProperties(),
   prefix: 'OPENAI_',
   stripPrefix: true
 });
@@ -402,10 +405,12 @@ High-signal behavior:
 - default target modules: `AI`, `RAG`, `DBT`, `Cache`, `Storage`, `Secrets`, `Telemetry`, `Jobs`, `Triggers`, `GitHub`.
 - configuration merge policy is controlled by `options.merge` (default `true`).
 - supports scoped application with `options.modules` (for example `['AI', 'RAG']`).
+- forwards `scriptProperties`/`keys`/`prefix`/`stripPrefix` and config snapshot controls (`disableCache`, `forceRefresh`, `cacheScopeId`, `cacheDefaultHandle`) to `AST.Config.fromScriptProperties(...)`.
 
 ```javascript
 const summary = ASTX.Runtime.configureFromProps({
-  modules: ['AI', 'RAG', 'Storage']
+  modules: ['AI', 'RAG', 'Storage'],
+  scriptProperties: PropertiesService.getScriptProperties()
 });
 
 Logger.log(summary.configuredModules);


### PR DESCRIPTION
Summary:\n- Harden Config.fromScriptProperties implicit-handle behavior to read fresh snapshots by default\n- Add cacheDefaultHandle opt-in for implicit-handle memoization\n- Forward snapshot controls through Runtime.configureFromProps\n- Keep module-level performance by explicitly opting AI/Cache/Chat/RAG/Storage config readers into default-handle memoization\n\nDocs:\n- Document explicit scriptProperties handle usage\n- Document cacheDefaultHandle and runtime pass-through controls\n\nValidation:\n- npm run lint\n- npm run test:local\n- npm run test:perf:check\n- mkdocs build --strict\n\nCloses #123