### PR TITLE
fix(dataframe): prevent reserved member column shadowing (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - `AST.Runtime.configureFromProps(...)` now supports module `DBT`.
 - `AST.Runtime.configureFromProps(...)` now supports module `Secrets`.
 - `AST.Runtime.configureFromProps(...)` now supports module `Triggers`.
+- `DataFrame` now rejects column names that collide with reserved DataFrame members (for example `sort`, `len`, `columns`, `data`, `index`) to prevent method/property shadowing on instances.
 - `AST.Config.fromScriptProperties(...)` now defaults implicit ScriptProperties reads to fresh snapshots (avoids stale shared memoized defaults in warm GAS web-app runtimes); optional `cacheDefaultHandle=true` re-enables implicit-handle memoization.
 - `AST.Runtime.configureFromProps(...)` now forwards explicit ScriptProperties handle and config snapshot controls (`scriptProperties`, `disableCache`, `forceRefresh`, `cacheScopeId`, `cacheDefaultHandle`) to `AST.Config.fromScriptProperties(...)`.
 - Local/perf test suites now include DBT manifest coverage and performance thresholds.

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -37,6 +37,8 @@ ASTX.Utils
 
 ## `DataFrame` essentials
 
+Note: column names cannot collide with reserved `DataFrame` members (for example `sort`, `len`, `columns`, `data`, `index`).
+
 ```javascript
 ASTX.DataFrame.fromRecords(records)
 ASTX.DataFrame.fromColumns(columns, options)

--- a/tests/local/dataframe-reserved-columns.test.mjs
+++ b/tests/local/dataframe-reserved-columns.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createGasContext, loadCoreDataContext } from './helpers.mjs';
+
+function createDataFrameContext() {
+  const context = createGasContext({
+    astLoadDatabricksTable: () => {},
+    astLoadBigQueryTable: () => {}
+  });
+  loadCoreDataContext(context);
+  return context;
+}
+
+test('DataFrame rejects column names that shadow reserved members', () => {
+  const context = createDataFrameContext();
+
+  assert.throws(
+    () => {
+      context.DataFrame.fromColumns({
+        sort: [2, 1],
+        amount: [20, 10]
+      });
+    },
+    /reserved DataFrame members: sort/
+  );
+});
+
+test('DataFrame.sort remains callable for non-reserved column names', () => {
+  const context = createDataFrameContext();
+
+  const df = context.DataFrame.fromColumns({
+    metric_sort: [2, 1],
+    amount: [20, 10]
+  });
+
+  assert.equal(typeof df.sort, 'function');
+  const sorted = df.sort('metric_sort');
+  assert.equal(JSON.stringify(sorted.metric_sort.array), JSON.stringify([1, 2]));
+});
+
+test('DataFrame.rename rejects target names that collide with reserved members', () => {
+  const context = createDataFrameContext();
+  const df = context.DataFrame.fromColumns({
+    value: [1, 2]
+  });
+
+  assert.throws(
+    () => {
+      df.rename({ value: 'len' });
+    },
+    /reserved DataFrame members: len/
+  );
+});


### PR DESCRIPTION
## Summary
This PR fixes a correctness bug where DataFrame columns could shadow built-in DataFrame members (for example `sort`, `len`, `data`, `columns`, `index`) because columns are exposed as instance properties.

When a shadowing column exists, method/property access is overridden at runtime (for example `df.sort` resolves to a `Series` instead of the sort function), producing subtle failures in downstream code.

Closes #126.

## Root Cause
`DataFrame` assigns columns onto the instance using property definitions. Without a reserved-name guard, user-provided column names can collide with existing instance/prototype members.

## Changes
- Added reserved-member detection in `DataFrame` construction.
- Added a deterministic error when collisions are found:
  - `DataFrame column names conflict with reserved DataFrame members: ...`
- Reserved set includes:
  - Core instance fields: `data`, `columns`, `index`
  - All names on `DataFrame.prototype`
- Guard is applied from constructor, so all creation paths are protected (`fromColumns`, `fromRecords`, and rename paths that reconstruct DataFrames).

## Tests Added
- `tests/local/dataframe-reserved-columns.test.mjs`
  - rejects a reserved collision (`sort`) at construction
  - verifies `df.sort` remains callable for non-reserved column names
  - verifies rename into reserved member (`len`) throws

## Docs / Release Notes
- Updated quick reference with reserved-name note:
  - `docs/api/quick-reference.md`
- Added changelog entry under `v0.0.5`:
  - `CHANGELOG.md`

## Validation
- `npm run lint`
- `npm run test:local`
- `npm run test:perf:check`

All passed locally and on CI.

## Compatibility
This is a behavior-tightening change: previously accepted (but unsafe) reserved column names now fail fast with a clear error to prevent runtime shadowing bugs.
