### PR TITLE
ci: harden workflows and centralize clasp setup (issue #131)

### DIFF
--- a/.github/actions/setup-clasp/action.yml
+++ b/.github/actions/setup-clasp/action.yml
@@ -1,0 +1,68 @@
+name: Setup clasp auth and binding
+description: Install clasp, configure OAuth credentials, and bind a target Apps Script project.
+
+inputs:
+  script-id:
+    description: Apps Script project ID.
+    required: true
+  root-dir:
+    description: Project rootDir for .clasp.json.
+    required: false
+    default: apps_script_tools
+  clasp-client-id:
+    description: OAuth client ID used by clasp.
+    required: true
+  clasp-client-secret:
+    description: OAuth client secret used by clasp.
+    required: true
+  clasp-refresh-token:
+    description: OAuth refresh token used by clasp.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install clasp
+      shell: bash
+      run: npm install -g @google/clasp
+
+    - name: Configure clasp auth
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -z "${{ inputs.script-id }}" ]; then
+          echo "Missing script-id input. Configure repository variable GAS_SCRIPT_ID."
+          exit 1
+        fi
+        if [ -z "${{ inputs.clasp-client-id }}" ] || [ -z "${{ inputs.clasp-client-secret }}" ] || [ -z "${{ inputs.clasp-refresh-token }}" ]; then
+          echo "Missing clasp credentials. Set CLASP_CLIENT_ID, CLASP_CLIENT_SECRET, and CLASP_REFRESH_TOKEN secrets."
+          exit 1
+        fi
+        cat > ~/.clasprc.json <<JSON
+        {
+          "token": {
+            "access_token": "",
+            "refresh_token": "${{ inputs.clasp-refresh-token }}",
+            "scope": "https://www.googleapis.com/auth/script.projects https://www.googleapis.com/auth/script.deployments https://www.googleapis.com/auth/service.management https://www.googleapis.com/auth/cloud-platform",
+            "token_type": "Bearer",
+            "expiry_date": 0
+          },
+          "oauth2ClientSettings": {
+            "clientId": "${{ inputs.clasp-client-id }}",
+            "clientSecret": "${{ inputs.clasp-client-secret }}",
+            "redirectUri": "http://localhost"
+          },
+          "isLocalCreds": false
+        }
+        JSON
+
+    - name: Configure script binding
+      shell: bash
+      run: |
+        set -euo pipefail
+        cat > .clasp.json <<JSON
+        {
+          "scriptId": "${{ inputs.script-id }}",
+          "rootDir": "${{ inputs.root-dir }}"
+        }
+        JSON

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-local-tests:
     runs-on: ubuntu-latest
@@ -17,6 +20,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Install Node dependencies (lockfile-aware)
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci --ignore-scripts
+          else
+            npm install --ignore-scripts --no-audit --no-fund
+          fi
 
       - name: Lint and Local Tests
         run: |
@@ -35,6 +46,14 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install Node dependencies (lockfile-aware)
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci --ignore-scripts
+          else
+            npm install --ignore-scripts --no-audit --no-fund
+          fi
+
       - name: Run performance threshold checks
         run: npm run test:perf:check
 
@@ -49,6 +68,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Install Node dependencies (lockfile-aware)
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci --ignore-scripts
+          else
+            npm install --ignore-scripts --no-audit --no-fund
+          fi
 
       - name: Run performance benchmarks report
         run: npm run test:perf

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-mkdocs-material
+          key: ${{ runner.os }}-pip-${{ hashFiles('docs/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 

--- a/.github/workflows/integration-ai-live.yml
+++ b/.github/workflows/integration-ai-live.yml
@@ -25,11 +25,14 @@ on:
         default: ""
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   live-ai-smoke:
     runs-on: ubuntu-latest
     env:
-      SCRIPT_ID: 1gZ_6DiLeDhh-a4qcezluTFDshw4OEhTXbeD3wthl_UdHEAFkXf6i6Ho_
+      SCRIPT_ID: ${{ vars.GAS_SCRIPT_ID }}
       CLASP_CLIENT_ID: ${{ secrets.CLASP_CLIENT_ID }}
       CLASP_CLIENT_SECRET: ${{ secrets.CLASP_CLIENT_SECRET }}
       CLASP_REFRESH_TOKEN: ${{ secrets.CLASP_REFRESH_TOKEN }}
@@ -42,40 +45,22 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install clasp
-        run: npm install -g @google/clasp
-
-      - name: Configure clasp auth
+      - name: Install Node dependencies (lockfile-aware)
         run: |
-          test -n "$CLASP_CLIENT_ID"
-          test -n "$CLASP_CLIENT_SECRET"
-          test -n "$CLASP_REFRESH_TOKEN"
-          cat > ~/.clasprc.json <<JSON
-          {
-            "token": {
-              "access_token": "",
-              "refresh_token": "${CLASP_REFRESH_TOKEN}",
-              "scope": "https://www.googleapis.com/auth/script.projects https://www.googleapis.com/auth/script.deployments https://www.googleapis.com/auth/service.management https://www.googleapis.com/auth/cloud-platform",
-              "token_type": "Bearer",
-              "expiry_date": 0
-            },
-            "oauth2ClientSettings": {
-              "clientId": "${CLASP_CLIENT_ID}",
-              "clientSecret": "${CLASP_CLIENT_SECRET}",
-              "redirectUri": "http://localhost"
-            },
-            "isLocalCreds": false
-          }
-          JSON
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci --ignore-scripts
+          else
+            npm install --ignore-scripts --no-audit --no-fund
+          fi
 
-      - name: Configure script binding
-        run: |
-          cat > .clasp.json <<JSON
-          {
-            "scriptId": "${SCRIPT_ID}",
-            "rootDir": "apps_script_tools"
-          }
-          JSON
+      - name: Setup clasp auth and binding
+        uses: ./.github/actions/setup-clasp
+        with:
+          script-id: ${{ env.SCRIPT_ID }}
+          root-dir: apps_script_tools
+          clasp-client-id: ${{ env.CLASP_CLIENT_ID }}
+          clasp-client-secret: ${{ env.CLASP_CLIENT_SECRET }}
+          clasp-refresh-token: ${{ env.CLASP_REFRESH_TOKEN }}
 
       - name: Push and execute live AI smoke
         run: |

--- a/.github/workflows/integration-gas.yml
+++ b/.github/workflows/integration-gas.yml
@@ -26,11 +26,14 @@ on:
           - functional
           - perf
 
+permissions:
+  contents: read
+
 jobs:
   gas-tests:
     runs-on: ubuntu-latest
     env:
-      SCRIPT_ID: 1gZ_6DiLeDhh-a4qcezluTFDshw4OEhTXbeD3wthl_UdHEAFkXf6i6Ho_
+      SCRIPT_ID: ${{ vars.GAS_SCRIPT_ID }}
       CLASP_CLIENT_ID: ${{ secrets.CLASP_CLIENT_ID }}
       CLASP_CLIENT_SECRET: ${{ secrets.CLASP_CLIENT_SECRET }}
       CLASP_REFRESH_TOKEN: ${{ secrets.CLASP_REFRESH_TOKEN }}
@@ -43,40 +46,22 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install clasp
-        run: npm install -g @google/clasp
-
-      - name: Configure clasp auth
+      - name: Install Node dependencies (lockfile-aware)
         run: |
-          test -n "$CLASP_CLIENT_ID"
-          test -n "$CLASP_CLIENT_SECRET"
-          test -n "$CLASP_REFRESH_TOKEN"
-          cat > ~/.clasprc.json <<JSON
-          {
-            "token": {
-              "access_token": "",
-              "refresh_token": "${CLASP_REFRESH_TOKEN}",
-              "scope": "https://www.googleapis.com/auth/script.projects https://www.googleapis.com/auth/script.deployments https://www.googleapis.com/auth/service.management https://www.googleapis.com/auth/cloud-platform",
-              "token_type": "Bearer",
-              "expiry_date": 0
-            },
-            "oauth2ClientSettings": {
-              "clientId": "${CLASP_CLIENT_ID}",
-              "clientSecret": "${CLASP_CLIENT_SECRET}",
-              "redirectUri": "http://localhost"
-            },
-            "isLocalCreds": false
-          }
-          JSON
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci --ignore-scripts
+          else
+            npm install --ignore-scripts --no-audit --no-fund
+          fi
 
-      - name: Configure script binding
-        run: |
-          cat > .clasp.json <<JSON
-          {
-            "scriptId": "${SCRIPT_ID}",
-            "rootDir": "apps_script_tools"
-          }
-          JSON
+      - name: Setup clasp auth and binding
+        uses: ./.github/actions/setup-clasp
+        with:
+          script-id: ${{ env.SCRIPT_ID }}
+          root-dir: apps_script_tools
+          clasp-client-id: ${{ env.CLASP_CLIENT_ID }}
+          clasp-client-secret: ${{ env.CLASP_CLIENT_SECRET }}
+          clasp-refresh-token: ${{ env.CLASP_REFRESH_TOKEN }}
 
       - name: Push and execute integration tests
         run: |

--- a/.github/workflows/integration-github-live.yml
+++ b/.github/workflows/integration-github-live.yml
@@ -14,11 +14,14 @@ on:
         default: ""
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   live-github-smoke:
     runs-on: ubuntu-latest
     env:
-      SCRIPT_ID: 1gZ_6DiLeDhh-a4qcezluTFDshw4OEhTXbeD3wthl_UdHEAFkXf6i6Ho_
+      SCRIPT_ID: ${{ vars.GAS_SCRIPT_ID }}
       CLASP_CLIENT_ID: ${{ secrets.CLASP_CLIENT_ID }}
       CLASP_CLIENT_SECRET: ${{ secrets.CLASP_CLIENT_SECRET }}
       CLASP_REFRESH_TOKEN: ${{ secrets.CLASP_REFRESH_TOKEN }}
@@ -32,41 +35,26 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install clasp
-        run: npm install -g @google/clasp
-
-      - name: Configure clasp auth
+      - name: Install Node dependencies (lockfile-aware)
         run: |
-          test -n "$CLASP_CLIENT_ID"
-          test -n "$CLASP_CLIENT_SECRET"
-          test -n "$CLASP_REFRESH_TOKEN"
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci --ignore-scripts
+          else
+            npm install --ignore-scripts --no-audit --no-fund
+          fi
+
+      - name: Validate GitHub token
+        run: |
           test -n "$GITHUB_TOKEN"
-          cat > ~/.clasprc.json <<JSON
-          {
-            "token": {
-              "access_token": "",
-              "refresh_token": "${CLASP_REFRESH_TOKEN}",
-              "scope": "https://www.googleapis.com/auth/script.projects https://www.googleapis.com/auth/script.deployments https://www.googleapis.com/auth/service.management https://www.googleapis.com/auth/cloud-platform",
-              "token_type": "Bearer",
-              "expiry_date": 0
-            },
-            "oauth2ClientSettings": {
-              "clientId": "${CLASP_CLIENT_ID}",
-              "clientSecret": "${CLASP_CLIENT_SECRET}",
-              "redirectUri": "http://localhost"
-            },
-            "isLocalCreds": false
-          }
-          JSON
 
-      - name: Configure script binding
-        run: |
-          cat > .clasp.json <<JSON
-          {
-            "scriptId": "${SCRIPT_ID}",
-            "rootDir": "apps_script_tools"
-          }
-          JSON
+      - name: Setup clasp auth and binding
+        uses: ./.github/actions/setup-clasp
+        with:
+          script-id: ${{ env.SCRIPT_ID }}
+          root-dir: apps_script_tools
+          clasp-client-id: ${{ env.CLASP_CLIENT_ID }}
+          clasp-client-secret: ${{ env.CLASP_CLIENT_SECRET }}
+          clasp-refresh-token: ${{ env.CLASP_REFRESH_TOKEN }}
 
       - name: Push and execute GitHub live smoke
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,14 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install Node dependencies (lockfile-aware)
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci --ignore-scripts
+          else
+            npm install --ignore-scripts --no-audit --no-fund
+          fi
+
       - name: Run lint and local tests
         run: |
           npm run lint
@@ -74,7 +82,7 @@ jobs:
           name: ${{ steps.resolve_tag.outputs.tag }}
           generate_release_notes: true
           body: |
-            Script ID: `1gZ_6DiLeDhh-a4qcezluTFDshw4OEhTXbeD3wthl_UdHEAFkXf6i6Ho_`
+            Script ID: `${{ vars.GAS_SCRIPT_ID }}`
             Library identifier: `AST`
             Docs: https://joe-broadhead.github.io/apps-script-tools/
 

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -38,6 +38,11 @@ Core library vs cookbook projects:
 - Cookbook apps under `cookbooks/` should use their own local `.clasp.json` (`rootDir=src`) and isolated deployment lifecycle.
 - Keep cookbook-specific UI/workflow code out of `apps_script_tools/` unless promoting reusable library functionality.
 
+CI workflow config:
+
+- Set repository variable `GAS_SCRIPT_ID` for GitHub Actions integration workflows.
+- Set repository secrets: `CLASP_CLIENT_ID`, `CLASP_CLIENT_SECRET`, `CLASP_REFRESH_TOKEN`.
+
 Consumer validation (recommended):
 
 - install library in a clean Apps Script project

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -63,6 +63,11 @@ Run via reusable workflow:
 
 PR CI runs `suite=functional` through the `gas-functional` job (internal PRs and branch pushes) when clasp secrets are configured.
 
+Required repository settings for integration workflows:
+
+- variable: `GAS_SCRIPT_ID`
+- secrets: `CLASP_CLIENT_ID`, `CLASP_CLIENT_SECRET`, `CLASP_REFRESH_TOKEN`
+
 Dispatch options:
 
 - `suite=functional` -> runs `runAllTests`


### PR DESCRIPTION
## Summary
This PR completes #131 (A6 CI workflow hardening) by tightening workflow defaults and removing duplicated integration setup logic.

Closes #131

## What Changed
1. Added lockfile-aware dependency bootstrap to Node jobs.
   - Updated `.github/workflows/ci.yml` and `.github/workflows/release.yml` to run dependency install before Node-based scripts (`npm ci` when lockfile exists, otherwise `npm install --ignore-scripts --no-audit --no-fund`).
   - Added the same lockfile-aware bootstrap in integration workflows so runtime behavior is consistent across manual and reusable jobs.

2. Deduplicated clasp auth/script-binding setup via reusable composite action.
   - Added `.github/actions/setup-clasp/action.yml`.
   - Replaced repeated inline clasp auth and `.clasp.json` generation blocks in:
     - `.github/workflows/integration-gas.yml`
     - `.github/workflows/integration-ai-live.yml`
     - `.github/workflows/integration-github-live.yml`

3. Centralized Script ID configuration.
   - Replaced hardcoded Script ID values in integration workflows with repository variable `vars.GAS_SCRIPT_ID`.
   - Updated release notes template in `.github/workflows/release.yml` to render Script ID from the same repository variable.

4. Added explicit least-privilege workflow permissions where missing.
   - Added `permissions: contents: read` to integration workflows.
   - Added top-level `permissions: contents: read` in `ci.yml` for consistency.

5. Fixed docs workflow cache key invalidation.
   - Updated `.github/workflows/docs.yml` to hash `docs/requirements.txt` in the pip cache key.

6. Documentation updates for operator setup.
   - Updated `docs/development/release.md` and `docs/operations/testing.md` with required repository variable/secrets for integration workflows.

## Validation
- `npm run lint`
- `npm run test:local`
- `npm run test:perf:check`
- `mkdocs build --strict`