### PR TITLE
docs(readme): slim README and remove clutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,12 @@ Module quickstarts:
 - DBT: <https://joe-broadhead.github.io/apps-script-tools/getting-started/dbt-manifest-quickstart/>
 - Storage: <https://joe-broadhead.github.io/apps-script-tools/getting-started/storage-quickstart/>
 - GitHub: <https://joe-broadhead.github.io/apps-script-tools/getting-started/github-quickstart/>
-- Secrets / Cache / Jobs / Triggers / Chat / Telemetry:
-  <https://joe-broadhead.github.io/apps-script-tools/getting-started/>
+- Secrets: <https://joe-broadhead.github.io/apps-script-tools/getting-started/secrets-quickstart/>
+- Cache: <https://joe-broadhead.github.io/apps-script-tools/getting-started/cache-quickstart/>
+- Jobs: <https://joe-broadhead.github.io/apps-script-tools/getting-started/jobs-quickstart/>
+- Triggers: <https://joe-broadhead.github.io/apps-script-tools/getting-started/triggers-quickstart/>
+- Chat: <https://joe-broadhead.github.io/apps-script-tools/getting-started/chat-quickstart/>
+- Telemetry: <https://joe-broadhead.github.io/apps-script-tools/getting-started/telemetry-quickstart/>
 
 ## Cookbooks
 


### PR DESCRIPTION
## Summary
- trim README to a concise overview while preserving the ASCII banner
- remove bloated inline examples and release-note detail from README
- keep install, one quick-start example, docs links, cookbook/dev/release pointers

## Why
The README had grown too large and duplicated content that already lives in docs/changelog. This makes first-read onboarding clearer and faster.

## Validation
- manual README review
- single-file docs-only change