### PR TITLE
feat(ai): token budget + prompt template utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,10 @@
   - optional repair modes (`json_repair`, `llm_repair`)
   - deterministic diagnostics on failure (`AstAiResponseParseError.details.attempts`)
 - New `AST.AI.OutputRepair.continueIfTruncated(...)` helper for bounded continuation repair of partial/truncated text outputs.
+- New AI prompt construction utilities:
+  - `AST.AI.estimateTokens(...)` for provider-aware heuristic token budgeting
+  - `AST.AI.truncateMessages(...)` for deterministic `tail` / `head` / `semantic_blocks` input truncation
+  - `AST.AI.renderPromptTemplate(...)` for strict `{{token}}` rendering with missing/unused variable checks
 - New `AST.Telemetry` namespace with:
   - `configure`, `getConfig`, `clearConfig`
   - `startSpan`, `endSpan`, `recordEvent`, `getTrace`

--- a/apps_script_tools/ai/AI.js
+++ b/apps_script_tools/ai/AI.js
@@ -24,6 +24,18 @@ function astAiStream(request = {}) {
   }));
 }
 
+function astAiEstimateTokensApi(request = {}) {
+  return astAiEstimateTokens(request);
+}
+
+function astAiTruncateMessagesApi(request = {}) {
+  return astAiTruncateMessages(request);
+}
+
+function astAiRenderPromptTemplateApi(request = {}) {
+  return astAiRenderPromptTemplate(request);
+}
+
 function astAiProviders() {
   return AST_AI_PROVIDERS.slice();
 }
@@ -73,6 +85,9 @@ const AST_AI = Object.freeze({
   tools: astAiTools,
   image: astAiImage,
   stream: astAiStream,
+  estimateTokens: astAiEstimateTokensApi,
+  truncateMessages: astAiTruncateMessagesApi,
+  renderPromptTemplate: astAiRenderPromptTemplateApi,
   providers: astAiProviders,
   capabilities: astAiCapabilities,
   configure: astAiConfigure,

--- a/apps_script_tools/ai/general/promptBudget.js
+++ b/apps_script_tools/ai/general/promptBudget.js
@@ -1,0 +1,727 @@
+const AST_AI_PROMPT_TEMPLATE_TOKEN_REGEX = /\{\{\s*([A-Za-z_][A-Za-z0-9_.-]*)\s*\}\}/g;
+
+const AST_AI_TOKEN_HEURISTICS = Object.freeze({
+  openai: Object.freeze({
+    charsPerToken: 4.0,
+    messageOverhead: 4,
+    toolCharsPerToken: 3.6,
+    schemaCharsPerToken: 3.8
+  }),
+  openrouter: Object.freeze({
+    charsPerToken: 4.0,
+    messageOverhead: 4,
+    toolCharsPerToken: 3.6,
+    schemaCharsPerToken: 3.8
+  }),
+  gemini: Object.freeze({
+    charsPerToken: 4.2,
+    messageOverhead: 3,
+    toolCharsPerToken: 3.8,
+    schemaCharsPerToken: 4.0
+  }),
+  vertex_gemini: Object.freeze({
+    charsPerToken: 4.2,
+    messageOverhead: 3,
+    toolCharsPerToken: 3.8,
+    schemaCharsPerToken: 4.0
+  }),
+  perplexity: Object.freeze({
+    charsPerToken: 4.1,
+    messageOverhead: 4,
+    toolCharsPerToken: 3.7,
+    schemaCharsPerToken: 3.9
+  })
+});
+
+const AST_AI_TRUNCATION_STRATEGIES = Object.freeze([
+  'tail',
+  'head',
+  'semantic_blocks'
+]);
+
+function astAiPromptIsPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function astAiPromptNormalizeString(value, fallback = '') {
+  return typeof value === 'string'
+    ? value
+    : fallback;
+}
+
+function astAiPromptNormalizeProvider(request = {}) {
+  const routing = astAiPromptIsPlainObject(request.routing)
+    ? request.routing
+    : {};
+  const routingCandidates = Array.isArray(routing.candidates)
+    ? routing.candidates
+    : [];
+
+  const firstRoutingProvider = routingCandidates.length > 0 && astAiPromptIsPlainObject(routingCandidates[0])
+    ? astAiPromptNormalizeString(routingCandidates[0].provider, '')
+    : '';
+  const providerRaw = astAiPromptNormalizeString(request.provider, firstRoutingProvider || 'openai')
+    .trim()
+    .toLowerCase();
+
+  if (!Object.prototype.hasOwnProperty.call(AST_AI_TOKEN_HEURISTICS, providerRaw)) {
+    throw new AstAiValidationError(
+      'estimate/truncate provider must be one of: openai, gemini, vertex_gemini, openrouter, perplexity',
+      { provider: providerRaw }
+    );
+  }
+
+  return providerRaw;
+}
+
+function astAiPromptNormalizeModel(request = {}) {
+  const modelValue = astAiPromptNormalizeString(request.model, '').trim();
+  if (modelValue) {
+    return modelValue;
+  }
+
+  const routing = astAiPromptIsPlainObject(request.routing)
+    ? request.routing
+    : {};
+  const candidates = Array.isArray(routing.candidates)
+    ? routing.candidates
+    : [];
+  if (candidates.length === 0 || !astAiPromptIsPlainObject(candidates[0])) {
+    return null;
+  }
+
+  const routedModel = astAiPromptNormalizeString(candidates[0].model, '').trim();
+  return routedModel || null;
+}
+
+function astAiPromptValueToString(value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (value == null) {
+    return '';
+  }
+  try {
+    return JSON.stringify(value);
+  } catch (_error) {
+    return String(value);
+  }
+}
+
+function astAiPromptEstimateChars(value) {
+  return astAiPromptValueToString(value).length;
+}
+
+function astAiPromptEstimateTokensFromChars(chars, charsPerToken) {
+  if (!Number.isFinite(charsPerToken) || charsPerToken <= 0) {
+    return 0;
+  }
+  if (!Number.isFinite(chars) || chars <= 0) {
+    return 0;
+  }
+  return Math.ceil(chars / charsPerToken);
+}
+
+function astAiPromptNormalizeRole(role) {
+  const normalized = astAiPromptNormalizeString(role, '').trim().toLowerCase();
+  if (!normalized) {
+    throw new AstAiValidationError('Message role is required');
+  }
+  if (!['system', 'user', 'assistant', 'tool'].includes(normalized)) {
+    throw new AstAiValidationError('Message role is not supported', { role: normalized });
+  }
+  return normalized;
+}
+
+function astAiPromptNormalizeMessage(message, index) {
+  if (!astAiPromptIsPlainObject(message)) {
+    throw new AstAiValidationError('Each message must be an object', { index });
+  }
+
+  const role = astAiPromptNormalizeRole(message.role);
+  const normalized = {
+    role,
+    content: Object.prototype.hasOwnProperty.call(message, 'content') ? message.content : ''
+  };
+
+  if (role === 'assistant' && Array.isArray(message.toolCalls)) {
+    normalized.toolCalls = message.toolCalls.slice();
+  }
+
+  if (role === 'tool') {
+    if (typeof message.name === 'string' && message.name.trim().length > 0) {
+      normalized.name = message.name.trim();
+    }
+    if (typeof message.toolCallId === 'string' && message.toolCallId.trim().length > 0) {
+      normalized.toolCallId = message.toolCallId.trim();
+    }
+  }
+
+  return normalized;
+}
+
+function astAiPromptNormalizeMessagesRequest(request = {}) {
+  if (!astAiPromptIsPlainObject(request)) {
+    throw new AstAiValidationError('AI prompt utility request must be an object');
+  }
+
+  const messages = [];
+  if (Array.isArray(request.messages)) {
+    if (request.messages.length === 0) {
+      throw new AstAiValidationError('messages array must be non-empty');
+    }
+    request.messages.forEach((message, index) => {
+      messages.push(astAiPromptNormalizeMessage(message, index));
+    });
+  } else if (typeof request.input === 'string') {
+    if (!request.input.trim()) {
+      throw new AstAiValidationError('input string must be non-empty');
+    }
+    messages.push({
+      role: 'user',
+      content: request.input
+    });
+  } else if (Array.isArray(request.input)) {
+    if (request.input.length === 0) {
+      throw new AstAiValidationError('input messages array must be non-empty');
+    }
+    request.input.forEach((message, index) => {
+      messages.push(astAiPromptNormalizeMessage(message, index));
+    });
+  } else {
+    throw new AstAiValidationError('Request requires either messages[] or input');
+  }
+
+  const system = astAiPromptNormalizeString(request.system, '').trim();
+  if (system) {
+    const hasSystem = messages.some(message => message.role === 'system');
+    if (!hasSystem) {
+      messages.unshift({
+        role: 'system',
+        content: system
+      });
+    }
+  }
+
+  return messages;
+}
+
+function astAiPromptEstimateMessageTokens(messages, heuristic) {
+  const rows = [];
+  let totalTokens = 0;
+  let totalChars = 0;
+  let systemTokens = 0;
+
+  messages.forEach((message, index) => {
+    const contentChars = astAiPromptEstimateChars(message.content);
+    const contentTokens = astAiPromptEstimateTokensFromChars(contentChars, heuristic.charsPerToken);
+    const nameChars = astAiPromptEstimateChars(message.name || '');
+    const nameTokens = astAiPromptEstimateTokensFromChars(nameChars, heuristic.charsPerToken);
+    const toolCallChars = Array.isArray(message.toolCalls) ? astAiPromptEstimateChars(message.toolCalls) : 0;
+    const toolCallTokens = astAiPromptEstimateTokensFromChars(toolCallChars, heuristic.charsPerToken);
+
+    const roleOverhead = heuristic.messageOverhead;
+    const tokens = roleOverhead + contentTokens + nameTokens + toolCallTokens;
+    const chars = contentChars + nameChars + toolCallChars;
+
+    rows.push({
+      index,
+      role: message.role,
+      chars,
+      tokens
+    });
+
+    totalChars += chars;
+    totalTokens += tokens;
+    if (message.role === 'system') {
+      systemTokens += tokens;
+    }
+  });
+
+  return {
+    rows,
+    totalTokens,
+    totalChars,
+    systemTokens
+  };
+}
+
+function astAiPromptEstimateToolsTokens(tools, heuristic) {
+  if (!Array.isArray(tools) || tools.length === 0) {
+    return 0;
+  }
+  let chars = 0;
+  tools.forEach(tool => {
+    chars += astAiPromptEstimateChars(tool);
+  });
+  return astAiPromptEstimateTokensFromChars(chars, heuristic.toolCharsPerToken);
+}
+
+function astAiPromptEstimateSchemaTokens(schema, heuristic) {
+  if (!astAiPromptIsPlainObject(schema)) {
+    return 0;
+  }
+  const chars = astAiPromptEstimateChars(schema);
+  return astAiPromptEstimateTokensFromChars(chars, heuristic.schemaCharsPerToken);
+}
+
+function astAiPromptNormalizePositiveInt(value, fallback = null) {
+  if (typeof value === 'undefined' || value === null || value === '') {
+    return fallback;
+  }
+  const asNumber = Number(value);
+  if (!Number.isFinite(asNumber) || asNumber < 1) {
+    throw new AstAiValidationError('Expected a positive integer value', { value });
+  }
+  return Math.floor(asNumber);
+}
+
+function astAiEstimateTokens(request = {}) {
+  if (!astAiPromptIsPlainObject(request)) {
+    throw new AstAiValidationError('estimateTokens request must be an object');
+  }
+
+  const provider = astAiPromptNormalizeProvider(request);
+  const model = astAiPromptNormalizeModel(request);
+  const heuristic = AST_AI_TOKEN_HEURISTICS[provider];
+  const messages = astAiPromptNormalizeMessagesRequest(request);
+  const messageEstimate = astAiPromptEstimateMessageTokens(messages, heuristic);
+
+  const toolsTokens = astAiPromptEstimateToolsTokens(request.tools, heuristic);
+  const schemaTokens = astAiPromptEstimateSchemaTokens(request.schema, heuristic);
+  const options = astAiPromptIsPlainObject(request.options)
+    ? request.options
+    : {};
+  const reservedOutputTokens = astAiPromptNormalizePositiveInt(
+    typeof request.maxOutputTokens !== 'undefined' ? request.maxOutputTokens : options.maxOutputTokens,
+    0
+  );
+  const maxTotalTokens = astAiPromptNormalizePositiveInt(
+    typeof request.maxTotalTokens !== 'undefined' ? request.maxTotalTokens : options.maxTotalTokens,
+    null
+  );
+
+  const inputTokens = messageEstimate.totalTokens + toolsTokens + schemaTokens;
+  const totalTokens = inputTokens + reservedOutputTokens;
+  const exceedsBudget = maxTotalTokens != null
+    ? totalTokens > maxTotalTokens
+    : false;
+  const remainingTokens = maxTotalTokens != null
+    ? Math.max(0, maxTotalTokens - totalTokens)
+    : null;
+
+  return {
+    status: 'ok',
+    provider,
+    model,
+    approximation: {
+      method: 'heuristic_char_length',
+      charsPerToken: heuristic.charsPerToken,
+      messageOverhead: heuristic.messageOverhead,
+      limitations: [
+        'Estimated counts only; provider tokenizer behavior may differ.',
+        'Tool/schema payloads are approximated using JSON string length.'
+      ]
+    },
+    input: {
+      messageCount: messages.length,
+      charCount: messageEstimate.totalChars,
+      tokens: inputTokens,
+      systemTokens: messageEstimate.systemTokens,
+      toolsTokens,
+      schemaTokens,
+      messageBreakdown: messageEstimate.rows
+    },
+    output: {
+      reservedTokens: reservedOutputTokens
+    },
+    totalTokens,
+    budget: {
+      maxTotalTokens,
+      exceedsBudget,
+      remainingTokens
+    },
+    warnings: []
+  };
+}
+
+function astAiPromptNormalizeTruncationStrategy(request = {}) {
+  const options = astAiPromptIsPlainObject(request.options)
+    ? request.options
+    : {};
+  const inputStrategy = typeof request.strategy !== 'undefined'
+    ? request.strategy
+    : options.strategy;
+  const normalized = astAiPromptNormalizeString(inputStrategy, 'tail').trim().toLowerCase();
+  if (normalized === 'semantic') {
+    return 'semantic_blocks';
+  }
+  if (!AST_AI_TRUNCATION_STRATEGIES.includes(normalized)) {
+    throw new AstAiValidationError('truncateMessages strategy must be one of: tail, head, semantic_blocks', {
+      strategy: normalized
+    });
+  }
+  return normalized;
+}
+
+function astAiPromptKeepHeadIndexes(indexes, rows, budget, startTokens) {
+  let used = startTokens;
+  const kept = [];
+  for (let index = 0; index < indexes.length; index += 1) {
+    const candidate = indexes[index];
+    const row = rows[candidate];
+    if (used + row.tokens > budget) {
+      break;
+    }
+    kept.push(candidate);
+    used += row.tokens;
+  }
+  return {
+    indexes: kept,
+    usedTokens: used
+  };
+}
+
+function astAiPromptKeepTailIndexes(indexes, rows, budget, startTokens) {
+  let used = startTokens;
+  const kept = [];
+  for (let cursor = indexes.length - 1; cursor >= 0; cursor -= 1) {
+    const candidate = indexes[cursor];
+    const row = rows[candidate];
+    if (used + row.tokens > budget) {
+      break;
+    }
+    kept.push(candidate);
+    used += row.tokens;
+  }
+  kept.sort((left, right) => left - right);
+  return {
+    indexes: kept,
+    usedTokens: used
+  };
+}
+
+function astAiPromptGroupSemanticBlocks(nonSystemIndexes, rows) {
+  const blocks = [];
+  let current = [];
+
+  for (let i = 0; i < nonSystemIndexes.length; i += 1) {
+    const messageIndex = nonSystemIndexes[i];
+    const row = rows[messageIndex];
+    if (row.role === 'user' && current.length > 0) {
+      blocks.push(current);
+      current = [messageIndex];
+    } else {
+      current.push(messageIndex);
+    }
+  }
+
+  if (current.length > 0) {
+    blocks.push(current);
+  }
+
+  return blocks;
+}
+
+function astAiPromptKeepSemanticBlocks(nonSystemIndexes, rows, budget, startTokens) {
+  const blocks = astAiPromptGroupSemanticBlocks(nonSystemIndexes, rows);
+  let used = startTokens;
+  const keptBlocks = [];
+
+  for (let cursor = blocks.length - 1; cursor >= 0; cursor -= 1) {
+    const block = blocks[cursor];
+    let blockTokens = 0;
+    for (let i = 0; i < block.length; i += 1) {
+      blockTokens += rows[block[i]].tokens;
+    }
+
+    if (used + blockTokens > budget) {
+      break;
+    }
+
+    keptBlocks.push(block);
+    used += blockTokens;
+  }
+
+  const keptIndexes = [];
+  keptBlocks.reverse().forEach(block => {
+    block.forEach(index => keptIndexes.push(index));
+  });
+
+  return {
+    indexes: keptIndexes,
+    usedTokens: used
+  };
+}
+
+function astAiTruncateMessages(request = {}) {
+  if (!astAiPromptIsPlainObject(request)) {
+    throw new AstAiValidationError('truncateMessages request must be an object');
+  }
+
+  const provider = astAiPromptNormalizeProvider(request);
+  const model = astAiPromptNormalizeModel(request);
+  const heuristic = AST_AI_TOKEN_HEURISTICS[provider];
+  const strategy = astAiPromptNormalizeTruncationStrategy(request);
+  const options = astAiPromptIsPlainObject(request.options)
+    ? request.options
+    : {};
+  const maxInputTokens = astAiPromptNormalizePositiveInt(
+    typeof request.maxInputTokens !== 'undefined' ? request.maxInputTokens : options.maxInputTokens,
+    null
+  );
+  if (maxInputTokens == null) {
+    throw new AstAiValidationError('truncateMessages requires maxInputTokens');
+  }
+
+  const preserveSystem = typeof request.preserveSystem === 'undefined'
+    ? true
+    : Boolean(request.preserveSystem);
+
+  const messages = astAiPromptNormalizeMessagesRequest(request);
+  const estimate = astAiPromptEstimateMessageTokens(messages, heuristic);
+  const beforeTokens = estimate.totalTokens;
+
+  if (beforeTokens <= maxInputTokens) {
+    return {
+      status: 'ok',
+      provider,
+      model,
+      strategy,
+      maxInputTokens,
+      truncated: false,
+      before: {
+        messageCount: messages.length,
+        inputTokens: beforeTokens
+      },
+      after: {
+        messageCount: messages.length,
+        inputTokens: beforeTokens
+      },
+      dropped: {
+        count: 0,
+        indexes: [],
+        roles: []
+      },
+      messages: messages.slice(),
+      approximation: {
+        method: 'heuristic_char_length',
+        charsPerToken: heuristic.charsPerToken
+      },
+      warnings: []
+    };
+  }
+
+  const rows = estimate.rows;
+  const systemIndexes = [];
+  const nonSystemIndexes = [];
+  rows.forEach((row, index) => {
+    if (row.role === 'system') {
+      systemIndexes.push(index);
+    } else {
+      nonSystemIndexes.push(index);
+    }
+  });
+
+  let selectedSystemIndexes = [];
+  let usedTokens = 0;
+  if (preserveSystem && systemIndexes.length > 0) {
+    const selected = strategy === 'tail'
+      ? astAiPromptKeepTailIndexes(systemIndexes, rows, maxInputTokens, 0)
+      : astAiPromptKeepHeadIndexes(systemIndexes, rows, maxInputTokens, 0);
+    selectedSystemIndexes = selected.indexes;
+    usedTokens = selected.usedTokens;
+  }
+
+  let selectedNonSystem = [];
+  if (strategy === 'head') {
+    selectedNonSystem = astAiPromptKeepHeadIndexes(nonSystemIndexes, rows, maxInputTokens, usedTokens);
+  } else if (strategy === 'tail') {
+    selectedNonSystem = astAiPromptKeepTailIndexes(nonSystemIndexes, rows, maxInputTokens, usedTokens);
+  } else {
+    selectedNonSystem = astAiPromptKeepSemanticBlocks(nonSystemIndexes, rows, maxInputTokens, usedTokens);
+  }
+
+  const selectedIndexes = selectedSystemIndexes
+    .concat(selectedNonSystem.indexes)
+    .sort((left, right) => left - right);
+  const selectedSet = new Set(selectedIndexes);
+  const nextMessages = selectedIndexes.map(index => messages[index]);
+  const afterEstimate = astAiPromptEstimateMessageTokens(nextMessages, heuristic);
+  const droppedIndexes = [];
+  const droppedRoles = [];
+  rows.forEach(row => {
+    if (!selectedSet.has(row.index)) {
+      droppedIndexes.push(row.index);
+      droppedRoles.push(row.role);
+    }
+  });
+
+  const warnings = [];
+  if (preserveSystem && selectedSystemIndexes.length < systemIndexes.length) {
+    warnings.push('Some system messages were dropped to satisfy maxInputTokens');
+  }
+  if (selectedIndexes.length === 0 && messages.length > 0) {
+    warnings.push('No messages fit within maxInputTokens');
+  }
+
+  return {
+    status: 'ok',
+    provider,
+    model,
+    strategy,
+    maxInputTokens,
+    truncated: true,
+    before: {
+      messageCount: messages.length,
+      inputTokens: beforeTokens
+    },
+    after: {
+      messageCount: nextMessages.length,
+      inputTokens: afterEstimate.totalTokens
+    },
+    dropped: {
+      count: droppedIndexes.length,
+      indexes: droppedIndexes,
+      roles: droppedRoles
+    },
+    messages: nextMessages,
+    approximation: {
+      method: 'heuristic_char_length',
+      charsPerToken: heuristic.charsPerToken
+    },
+    warnings
+  };
+}
+
+function astAiPromptIsBlockedTemplatePathSegment(segment) {
+  return segment === '__proto__'
+    || segment === 'prototype'
+    || segment === 'constructor';
+}
+
+function astAiPromptResolveTemplatePath(params, tokenPath) {
+  const segments = tokenPath.split('.');
+  let cursor = params;
+  for (let i = 0; i < segments.length; i += 1) {
+    const segment = segments[i];
+    if (!segment || astAiPromptIsBlockedTemplatePathSegment(segment)) {
+      return {
+        hasValue: false
+      };
+    }
+    if (!astAiPromptIsPlainObject(cursor) || !Object.prototype.hasOwnProperty.call(cursor, segment)) {
+      return {
+        hasValue: false
+      };
+    }
+    cursor = cursor[segment];
+  }
+
+  return {
+    hasValue: true,
+    value: cursor
+  };
+}
+
+function astAiPromptCollectTemplatePaths(value) {
+  if (!astAiPromptIsPlainObject(value)) {
+    return [];
+  }
+
+  return Object.keys(value).filter(key => !astAiPromptIsBlockedTemplatePathSegment(key));
+}
+
+function astAiPromptNormalizeTemplateOptions(options = {}) {
+  if (typeof options === 'undefined' || options === null) {
+    return {
+      strict: true,
+      failOnUnused: false,
+      missingBehavior: 'error'
+    };
+  }
+
+  if (!astAiPromptIsPlainObject(options)) {
+    throw new AstAiValidationError('renderPromptTemplate options must be an object');
+  }
+
+  const strict = typeof options.strict === 'undefined'
+    ? true
+    : Boolean(options.strict);
+  const failOnUnused = Boolean(options.failOnUnused);
+  const missingBehaviorRaw = astAiPromptNormalizeString(options.missingBehavior, strict ? 'error' : 'empty')
+    .trim()
+    .toLowerCase();
+  if (!['error', 'empty', 'keep'].includes(missingBehaviorRaw)) {
+    throw new AstAiValidationError('renderPromptTemplate missingBehavior must be one of: error, empty, keep');
+  }
+
+  return {
+    strict,
+    failOnUnused,
+    missingBehavior: missingBehaviorRaw
+  };
+}
+
+function astAiRenderPromptTemplate(request = {}) {
+  if (!astAiPromptIsPlainObject(request)) {
+    throw new AstAiValidationError('renderPromptTemplate request must be an object');
+  }
+
+  const template = astAiPromptNormalizeString(request.template, '');
+  if (!template) {
+    throw new AstAiValidationError('renderPromptTemplate requires a non-empty template string');
+  }
+
+  const variables = astAiPromptIsPlainObject(request.variables)
+    ? request.variables
+    : {};
+  const options = astAiPromptNormalizeTemplateOptions(request.options || {});
+
+  const missing = new Set();
+  const used = new Set();
+  const rendered = template.replace(AST_AI_PROMPT_TEMPLATE_TOKEN_REGEX, (match, tokenPath) => {
+    const resolution = astAiPromptResolveTemplatePath(variables, tokenPath);
+    if (!resolution.hasValue) {
+      missing.add(tokenPath);
+      if (options.missingBehavior === 'keep') {
+        return match;
+      }
+      return '';
+    }
+
+    used.add(tokenPath);
+    return astAiPromptValueToString(resolution.value);
+  });
+
+  const missingVariables = Array.from(missing.values()).sort();
+  if ((options.strict || options.missingBehavior === 'error') && missingVariables.length > 0) {
+    throw new AstAiValidationError('Template references missing variables', {
+      missingVariables
+    });
+  }
+
+  const knownVariablePaths = astAiPromptCollectTemplatePaths(variables);
+  const usedTopLevel = new Set(Array.from(used.values()).map(path => path.split('.')[0]));
+  const unusedVariables = knownVariablePaths
+    .filter(path => !usedTopLevel.has(path))
+    .sort();
+
+  if (options.failOnUnused && unusedVariables.length > 0) {
+    throw new AstAiValidationError('Template variables include unused values', {
+      unusedVariables
+    });
+  }
+
+  return {
+    status: 'ok',
+    text: rendered,
+    template,
+    usedVariables: Array.from(used.values()).sort(),
+    missingVariables,
+    unusedVariables
+  };
+}

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -306,6 +306,9 @@ ASTX.AI.structured(request)
 ASTX.AI.tools(request)
 ASTX.AI.image(request)
 ASTX.AI.stream(request)
+ASTX.AI.estimateTokens(request)
+ASTX.AI.truncateMessages(request)
+ASTX.AI.renderPromptTemplate(request)
 ASTX.AI.providers()
 ASTX.AI.capabilities(provider)
 ASTX.AI.configure(config, options)
@@ -552,6 +555,9 @@ ASTX.GitHub.clearConfig()
 - unsupported AI provider/operation combinations throw typed capability errors.
 - `ASTX.AI.stream(...)` emits `start`, `token`, `tool_call`, `tool_result`, `done`, and `error` events via `onEvent`.
 - `ASTX.AI.OutputRepair.continueIfTruncated(...)` can continue truncated answers with bounded follow-up passes.
+- `ASTX.AI.estimateTokens(...)` provides deterministic heuristic budget estimates with documented approximation limits.
+- `ASTX.AI.truncateMessages(...)` supports `tail`, `head`, and `semantic_blocks` truncation strategies.
+- `ASTX.AI.renderPromptTemplate(...)` enforces strict placeholder validation by default (missing vars throw typed validation errors).
 - `RAG.answer(...)` supports retrieval recovery policy (`retrieval.recovery.*`) before generation.
 - `RAG.answer(...)` supports deterministic fallback controls (`fallback.onRetrievalError`, `fallback.onRetrievalEmpty`).
 - `RAG.search(...)` and `RAG.answer(...)` support retrieval budgets via `options.maxRetrievalMs`.

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -844,6 +844,9 @@ Primary methods:
 - `ASTX.AI.tools(request)` for bounded auto tool execution.
 - `ASTX.AI.image(request)` for image generation paths.
 - `ASTX.AI.stream(request)` for callback-based token/tool event streaming.
+- `ASTX.AI.estimateTokens(request)` for heuristic token budget preflight.
+- `ASTX.AI.truncateMessages(request)` for deterministic message-budget truncation.
+- `ASTX.AI.renderPromptTemplate(request)` for strict variable-safe prompt rendering.
 - `ASTX.AI.OutputRepair.continueIfTruncated(request)` for bounded continuation repair.
 - `ASTX.AI.providers()` and `ASTX.AI.capabilities(provider)` for runtime checks.
 - `ASTX.AI.configure(config)` to set runtime defaults (for example from consumer script properties).
@@ -859,6 +862,9 @@ High-signal behavior:
 - optional `routing` supports provider fallback using `priority`, `fastest`, or `cost_first` strategies.
 - deterministic provider `4xx` errors only fail over when `routing.retryOn.providerErrors=true`.
 - response metadata includes `response.route.attempts` with per-provider attempt status and retryability.
+- token preflight includes provider-aware heuristic metadata and budget overflow diagnostics.
+- truncation strategies: `tail`, `head`, `semantic_blocks`.
+- prompt template rendering throws `AstAiValidationError` on missing placeholders by default.
 - structured mode has bounded reliability controls via `options.reliability`:
   - `maxSchemaRetries`
   - `repairMode` (`none`, `json_repair`, `llm_repair`)

--- a/tests/local/ai-token-budget-template.test.mjs
+++ b/tests/local/ai-token-budget-template.test.mjs
@@ -1,0 +1,200 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createGasContext } from './helpers.mjs';
+import { loadAiScripts } from './ai-helpers.mjs';
+
+function createContext() {
+  const context = createGasContext();
+  loadAiScripts(context, { includeAst: true });
+  return context;
+}
+
+test('AST.AI.estimateTokens returns provider-aware budget diagnostics', () => {
+  const context = createContext();
+
+  const openAiEstimate = context.AST.AI.estimateTokens({
+    provider: 'openai',
+    system: 'You are concise.',
+    input: 'Summarize customer churn risks and mitigations.',
+    options: {
+      maxOutputTokens: 300,
+      maxTotalTokens: 320
+    }
+  });
+
+  const geminiEstimate = context.AST.AI.estimateTokens({
+    provider: 'gemini',
+    system: 'You are concise.',
+    input: 'Summarize customer churn risks and mitigations.',
+    options: {
+      maxOutputTokens: 300,
+      maxTotalTokens: 320
+    }
+  });
+
+  assert.equal(openAiEstimate.status, 'ok');
+  assert.equal(openAiEstimate.provider, 'openai');
+  assert.equal(openAiEstimate.budget.maxTotalTokens, 320);
+  assert.equal(openAiEstimate.totalTokens > 0, true);
+  assert.equal(openAiEstimate.budget.exceedsBudget, openAiEstimate.totalTokens > 320);
+
+  assert.equal(geminiEstimate.status, 'ok');
+  assert.equal(geminiEstimate.provider, 'gemini');
+  assert.notEqual(
+    openAiEstimate.approximation.charsPerToken,
+    geminiEstimate.approximation.charsPerToken
+  );
+});
+
+test('AST.AI.truncateMessages applies tail strategy deterministically', () => {
+  const context = createContext();
+
+  const response = context.AST.AI.truncateMessages({
+    provider: 'openai',
+    messages: [
+      { role: 'system', content: 'Always cite evidence.' },
+      { role: 'user', content: 'Question one with lots of context 1111111111111111111111111111' },
+      { role: 'assistant', content: 'Answer one with details 22222222222222222222222222222222' },
+      { role: 'user', content: 'Question two with lots of context 3333333333333333333333333333' },
+      { role: 'assistant', content: 'Answer two with details 44444444444444444444444444444444' }
+    ],
+    maxInputTokens: 35,
+    strategy: 'tail'
+  });
+
+  assert.equal(response.status, 'ok');
+  assert.equal(response.strategy, 'tail');
+  assert.equal(response.truncated, true);
+  assert.equal(response.after.inputTokens <= 35, true);
+  assert.equal(response.messages[0].role, 'system');
+  assert.equal(response.messages[response.messages.length - 1].content.includes('4444'), true);
+});
+
+test('AST.AI.truncateMessages semantic_blocks keeps complete turn blocks', () => {
+  const context = createContext();
+
+  const response = context.AST.AI.truncateMessages({
+    provider: 'openai',
+    messages: [
+      { role: 'system', content: 'Return grounded answers only.' },
+      { role: 'user', content: 'turn1 user 111111111111111111111111111111111111111' },
+      { role: 'assistant', content: 'turn1 assistant 111111111111111111111111111111111' },
+      { role: 'user', content: 'turn2 user 222222222222222222222222222222222222222' },
+      { role: 'assistant', content: 'turn2 assistant 222222222222222222222222222222222' },
+      { role: 'user', content: 'turn3 user 333333333333333333333333333333333333333' }
+    ],
+    maxInputTokens: 45,
+    strategy: 'semantic_blocks'
+  });
+
+  const containsTurn2User = response.messages.some(msg => typeof msg.content === 'string' && msg.content.includes('turn2 user'));
+  const containsTurn2Assistant = response.messages.some(msg => typeof msg.content === 'string' && msg.content.includes('turn2 assistant'));
+
+  assert.equal(response.status, 'ok');
+  assert.equal(response.strategy, 'semantic_blocks');
+  assert.equal(response.after.inputTokens <= 45, true);
+  assert.equal(containsTurn2User, containsTurn2Assistant);
+});
+
+test('AST.AI.truncateMessages rejects unsupported strategy', () => {
+  const context = createContext();
+
+  assert.throws(
+    () => context.AST.AI.truncateMessages({
+      provider: 'openai',
+      input: 'hello',
+      maxInputTokens: 20,
+      strategy: 'middle'
+    }),
+    /strategy must be one of/
+  );
+});
+
+test('AST.AI.renderPromptTemplate fails on missing variables in strict mode', () => {
+  const context = createContext();
+
+  assert.throws(
+    () => context.AST.AI.renderPromptTemplate({
+      template: 'Hello {{ user.name }}, ticket {{ ticket.id }} is {{ ticket.status }}.',
+      variables: {
+        user: { name: 'Alex' },
+        ticket: { id: 'INC-42' }
+      }
+    }),
+    /missing variables/
+  );
+});
+
+test('AST.AI.renderPromptTemplate supports strict unused checks', () => {
+  const context = createContext();
+
+  assert.throws(
+    () => context.AST.AI.renderPromptTemplate({
+      template: 'Owner {{ owner }}',
+      variables: {
+        owner: 'team-a',
+        extra: 'unused'
+      },
+      options: {
+        failOnUnused: true
+      }
+    }),
+    /unused values/
+  );
+});
+
+test('AST.AI.renderPromptTemplate failOnUnused ignores nested leaf paths when parent is used', () => {
+  const context = createContext();
+
+  const response = context.AST.AI.renderPromptTemplate({
+    template: 'Owner {{ owner }}',
+    variables: {
+      owner: {
+        team: 'revops'
+      }
+    },
+    options: {
+      failOnUnused: true
+    }
+  });
+
+  assert.equal(response.status, 'ok');
+  assert.equal(response.text.includes('"team":"revops"'), true);
+});
+
+test('AST.AI.renderPromptTemplate missingBehavior=error throws even when strict=false', () => {
+  const context = createContext();
+
+  assert.throws(
+    () => context.AST.AI.renderPromptTemplate({
+      template: 'Hello {{name}} {{missing}}',
+      variables: { name: 'AST' },
+      options: {
+        strict: false,
+        missingBehavior: 'error'
+      }
+    }),
+    /missing variables/
+  );
+});
+
+test('AST.AI.renderPromptTemplate can keep missing placeholders when configured', () => {
+  const context = createContext();
+
+  const response = context.AST.AI.renderPromptTemplate({
+    template: 'Hello {{ name }}, status={{ status }}.',
+    variables: {
+      name: 'Taylor'
+    },
+    options: {
+      strict: false,
+      missingBehavior: 'keep'
+    }
+  });
+
+  assert.equal(response.status, 'ok');
+  assert.equal(response.text, 'Hello Taylor, status={{ status }}.');
+  assert.equal(JSON.stringify(response.missingVariables), JSON.stringify(['status']));
+  assert.equal(JSON.stringify(response.usedVariables), JSON.stringify(['name']));
+});

--- a/tests/local/ai-validation.test.mjs
+++ b/tests/local/ai-validation.test.mjs
@@ -187,6 +187,9 @@ test('AST exposes AI surface and helper methods', () => {
   assert.equal(typeof context.AST.AI.tools, 'function');
   assert.equal(typeof context.AST.AI.image, 'function');
   assert.equal(typeof context.AST.AI.stream, 'function');
+  assert.equal(typeof context.AST.AI.estimateTokens, 'function');
+  assert.equal(typeof context.AST.AI.truncateMessages, 'function');
+  assert.equal(typeof context.AST.AI.renderPromptTemplate, 'function');
   assert.equal(typeof context.AST.AI.providers, 'function');
   assert.equal(typeof context.AST.AI.capabilities, 'function');
   assert.equal(typeof context.AST.AI.configure, 'function');


### PR DESCRIPTION
## Summary
- Implements roadmap issue #175 by adding first-class prompt construction utilities to `AST.AI`
- Adds deterministic token estimation, message truncation policies, and strict prompt template rendering
- Updates local/GAS tests and AI docs to cover the new contracts

Closes #175

## API additions
- `AST.AI.estimateTokens(request)`
- `AST.AI.truncateMessages(request)`
- `AST.AI.renderPromptTemplate(request)`

## Implementation details
- New module: `apps_script_tools/ai/general/promptBudget.js`
  - provider-aware heuristic token estimates with budget diagnostics
  - truncation strategies: `tail`, `head`, `semantic_blocks`
  - strict template rendering with nested token support (`{{owner.team}}`)
  - prototype-path hardening (`__proto__`, `constructor`, `prototype`)
- Exposed methods through `apps_script_tools/ai/AI.js`
- Added local tests for overflow/truncation and template failure modes
- Added GAS namespace/smoke assertions for the new AI methods
- Added docs and changelog updates

## Validation
- `npm run lint`
- `npm run test:local`
- `npm run test:perf:check`
- `mkdocs build --strict`
- `clasp push`
- `clasp run runAllTests`
