### PR TITLE
feat(rag): add pluggable reranker registry and direct rerank API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,11 @@
   - `enqueueMany(request)` for bounded fan-out plans
   - `mapReduce(request)` for bounded map + reduce plans
   - helper responses include `orchestration` parent/child/stage status summaries
+- `AST.RAG` reranking now supports a pluggable reranker registry:
+  - new APIs: `rerank(...)`, `rerankers()`, `registerReranker(...)`, `unregisterReranker(...)`
+  - built-in reranker: `heuristic`
+  - retrieval rerank config now includes `rerank.provider` (default: `heuristic`)
+  - reranked results include deterministic `rerankScoreNormalized` and stable tie ordering
 
 ## v0.0.4 - 2026-02-25
 

--- a/apps_script_tools/rag/RAG.js
+++ b/apps_script_tools/rag/RAG.js
@@ -6,6 +6,7 @@ function astRagEnsureInitialized() {
   }
 
   astRagRegisterBuiltInEmbeddingProviders();
+  astRagRegisterBuiltInRerankers();
   AST_RAG_IS_INITIALIZED = true;
 }
 
@@ -37,6 +38,11 @@ function astRagApiPreviewSources(request = {}) {
 function astRagApiAnswer(request = {}) {
   astRagEnsureInitialized();
   return astRagAnswerCore(request);
+}
+
+function astRagApiRerank(request = {}) {
+  astRagEnsureInitialized();
+  return astRagRerankCore(request);
 }
 
 function astRagApiEvaluate(request = {}) {
@@ -73,6 +79,21 @@ function astRagApiRegisterEmbeddingProvider(name, adapter, options = {}) {
 function astRagApiUnregisterEmbeddingProvider(name) {
   astRagEnsureInitialized();
   return astRagUnregisterEmbeddingProvider(name);
+}
+
+function astRagApiRegisterReranker(name, adapter, options = {}) {
+  astRagEnsureInitialized();
+  return astRagRegisterReranker(name, adapter, options);
+}
+
+function astRagApiUnregisterReranker(name) {
+  astRagEnsureInitialized();
+  return astRagUnregisterReranker(name);
+}
+
+function astRagApiRerankers() {
+  astRagEnsureInitialized();
+  return astRagListRerankers();
 }
 
 function astRagApiBuildRetrievalCacheKey(args = {}) {
@@ -144,6 +165,7 @@ const AST_RAG = Object.freeze({
   search: astRagApiSearch,
   previewSources: astRagApiPreviewSources,
   answer: astRagApiAnswer,
+  rerank: astRagApiRerank,
   evaluate: astRagApiEvaluate,
   compareRuns: astRagApiCompareRuns,
   inspectIndex: astRagApiInspectIndex,
@@ -166,5 +188,8 @@ const AST_RAG = Object.freeze({
   embeddingProviders: astRagApiEmbeddingProviders,
   embeddingCapabilities: astRagApiEmbeddingCapabilities,
   registerEmbeddingProvider: astRagApiRegisterEmbeddingProvider,
-  unregisterEmbeddingProvider: astRagApiUnregisterEmbeddingProvider
+  unregisterEmbeddingProvider: astRagApiUnregisterEmbeddingProvider,
+  registerReranker: astRagApiRegisterReranker,
+  unregisterReranker: astRagApiUnregisterReranker,
+  rerankers: astRagApiRerankers
 });

--- a/apps_script_tools/rag/general/answerWithRag.js
+++ b/apps_script_tools/rag/general/answerWithRag.js
@@ -35,6 +35,8 @@ function astRagBuildAnswerDiagnostics(cacheConfig = {}, timeoutMs = null) {
     retrieval: {
       source: null,
       ms: 0,
+      reranker: null,
+      rerankTopN: 0,
       rawSources: 0,
       usableSources: 0,
       lexicalPrefilterTopN: 0,
@@ -344,6 +346,17 @@ function astRagAnswerCore(request = {}) {
     const diagnostics = astRagBuildAnswerDiagnostics(cacheConfig, retrievalTimeoutMs);
     diagnostics.timings.validationMs = Math.max(0, astRagNowMs() - validationStartMs);
     diagnostics.retrieval.lexicalPrefilterTopN = normalizedRequest.retrieval.lexicalPrefilterTopN || 0;
+    if (
+      normalizedRequest.retrieval &&
+      normalizedRequest.retrieval.rerank &&
+      normalizedRequest.retrieval.rerank.enabled === true
+    ) {
+      diagnostics.retrieval.reranker = astRagNormalizeString(
+        normalizedRequest.retrieval.rerank.provider,
+        AST_RAG_DEFAULT_RETRIEVAL.rerank.provider
+      );
+      diagnostics.retrieval.rerankTopN = normalizedRequest.retrieval.rerank.topN;
+    }
     const retrievalBudgetStartedAtMs = astRagNowMs();
 
     const indexLoadStartMs = astRagNowMs();

--- a/apps_script_tools/rag/general/constants.js
+++ b/apps_script_tools/rag/general/constants.js
@@ -45,7 +45,8 @@ const AST_RAG_DEFAULT_RETRIEVAL = Object.freeze({
   }),
   rerank: Object.freeze({
     enabled: false,
-    topN: 20
+    topN: 20,
+    provider: 'heuristic'
   })
 });
 

--- a/apps_script_tools/rag/general/rerankResults.js
+++ b/apps_script_tools/rag/general/rerankResults.js
@@ -30,42 +30,289 @@ function astRagComputeRerankScore(query, result) {
   return baseScore + (coverage * 0.25) + phraseBonus;
 }
 
-function astRagRerankResults(query, scoredResults = [], rerank = {}) {
+function astRagNormalizeRerankScoreOutput(output, candidates) {
+  if (Array.isArray(output)) {
+    if (
+      output.length === candidates.length &&
+      output.every(value => typeof value === 'number' && isFinite(value))
+    ) {
+      return output.map((score, idx) => ({
+        chunkId: candidates[idx].chunkId,
+        score
+      }));
+    }
+
+    return output.map(item => {
+      if (!astRagIsPlainObject(item)) {
+        throw new AstRagValidationError('Reranker output array items must be score objects', {
+          field: 'reranker.output'
+        });
+      }
+      return {
+        chunkId: astRagNormalizeString(item.chunkId, null),
+        score: item.score
+      };
+    });
+  }
+
+  if (astRagIsPlainObject(output)) {
+    return Object.keys(output).map(chunkId => ({
+      chunkId,
+      score: output[chunkId]
+    }));
+  }
+
+  throw new AstRagValidationError('Reranker output must be an array or object map', {
+    field: 'reranker.output'
+  });
+}
+
+function astRagBuildRerankAssignmentMap(rawAssignments, candidates, rerankerName) {
+  const assignments = astRagNormalizeRerankScoreOutput(rawAssignments, candidates);
+  const assignmentMap = {};
+
+  assignments.forEach(item => {
+    if (!item || !item.chunkId) {
+      return;
+    }
+    if (typeof item.score !== 'number' || !isFinite(item.score)) {
+      throw new AstRagValidationError('Reranker score must be a finite number', {
+        reranker: rerankerName,
+        chunkId: item.chunkId
+      });
+    }
+    assignmentMap[item.chunkId] = item.score;
+  });
+
+  return assignmentMap;
+}
+
+function astRagNormalizeRerankScores(results = []) {
+  if (!Array.isArray(results) || results.length === 0) {
+    return [];
+  }
+
+  let minScore = Infinity;
+  let maxScore = -Infinity;
+  results.forEach(result => {
+    const score = typeof result.rerankScore === 'number' && isFinite(result.rerankScore)
+      ? result.rerankScore
+      : 0;
+    if (score < minScore) {
+      minScore = score;
+    }
+    if (score > maxScore) {
+      maxScore = score;
+    }
+  });
+
+  const spread = maxScore - minScore;
+  return results.map(result => {
+    const score = typeof result.rerankScore === 'number' && isFinite(result.rerankScore)
+      ? result.rerankScore
+      : 0;
+    const rerankScoreNormalized = spread <= 0
+      ? 1
+      : (score - minScore) / spread;
+    return Object.assign({}, result, {
+      rerankScore: score,
+      rerankScoreNormalized
+    });
+  });
+}
+
+function astRagHeuristicRerank(request = {}) {
+  const query = astRagNormalizeString(request.query, '');
+  const candidates = Array.isArray(request.candidates) ? request.candidates : [];
+  return candidates.map(candidate => ({
+    chunkId: candidate.chunkId,
+    score: astRagComputeRerankScore(query, candidate)
+  }));
+}
+
+function astRagRunRegisteredReranker(query, headCandidates, rerankConfig = {}) {
+  const rerankerName = astRagNormalizeString(
+    rerankConfig.provider,
+    AST_RAG_DEFAULT_RETRIEVAL.rerank.provider
+  ).toLowerCase();
+  const reranker = astRagGetReranker(rerankerName);
+
+  let rawOutput = null;
+  try {
+    rawOutput = reranker.adapter.rerank({
+      query,
+      candidates: headCandidates.map(candidate => astRagCloneObject(candidate)),
+      topN: headCandidates.length,
+      rerank: astRagCloneObject(rerankConfig)
+    });
+  } catch (error) {
+    throw new AstRagError('Reranker execution failed', {
+      reranker: rerankerName,
+      cause: error && error.message ? String(error.message) : String(error)
+    });
+  }
+
+  const assignmentMap = astRagBuildRerankAssignmentMap(rawOutput, headCandidates, rerankerName);
+  const scoredHead = headCandidates.map(candidate => Object.assign({}, candidate, {
+    rerankProvider: rerankerName,
+    rerankScore: Object.prototype.hasOwnProperty.call(assignmentMap, candidate.chunkId)
+      ? assignmentMap[candidate.chunkId]
+      : 0
+  }));
+  return astRagNormalizeRerankScores(scoredHead);
+}
+
+function astRagSortRerankedHead(results = []) {
+  return results.slice().sort((left, right) => {
+    const normDiff = (right.rerankScoreNormalized || 0) - (left.rerankScoreNormalized || 0);
+    if (normDiff !== 0) {
+      return normDiff;
+    }
+
+    const rerankDiff = (right.rerankScore || 0) - (left.rerankScore || 0);
+    if (rerankDiff !== 0) {
+      return rerankDiff;
+    }
+
+    const finalDiff = (right.finalScore || 0) - (left.finalScore || 0);
+    if (finalDiff !== 0) {
+      return finalDiff;
+    }
+    const vectorDiff = (right.vectorScore || 0) - (left.vectorScore || 0);
+    if (vectorDiff !== 0) {
+      return vectorDiff;
+    }
+    const lexicalDiff = (right.lexicalScore || 0) - (left.lexicalScore || 0);
+    if (lexicalDiff !== 0) {
+      return lexicalDiff;
+    }
+    const leftId = astRagNormalizeString(left.chunkId, '');
+    const rightId = astRagNormalizeString(right.chunkId, '');
+    return leftId < rightId ? -1 : (leftId > rightId ? 1 : 0);
+  });
+}
+
+function astRagRerankResults(query, scoredResults = [], rerank = {}, runtime = {}) {
   if (!rerank || rerank.enabled !== true || scoredResults.length <= 1) {
     return scoredResults.slice();
   }
 
+  const diagnostics = astRagIsPlainObject(runtime) ? runtime.diagnostics : null;
+  const rerankStartedAtMs = new Date().getTime();
   const topN = Math.min(
     scoredResults.length,
     astRagNormalizePositiveInt(rerank.topN, AST_RAG_DEFAULT_RETRIEVAL.rerank.topN, 1)
   );
-  const head = scoredResults
-    .slice(0, topN)
-    .map(result => Object.assign({}, result, {
-      rerankScore: astRagComputeRerankScore(query, result)
-    }))
-    .sort((left, right) => {
-      const rerankDiff = (right.rerankScore || 0) - (left.rerankScore || 0);
-      if (rerankDiff !== 0) {
-        return rerankDiff;
-      }
+  const headCandidates = scoredResults.slice(0, topN);
+  const rerankedHead = astRagSortRerankedHead(
+    astRagRunRegisteredReranker(query, headCandidates, rerank)
+  );
 
-      const finalDiff = (right.finalScore || 0) - (left.finalScore || 0);
-      if (finalDiff !== 0) {
-        return finalDiff;
-      }
-      const vectorDiff = (right.vectorScore || 0) - (left.vectorScore || 0);
-      if (vectorDiff !== 0) {
-        return vectorDiff;
-      }
-      const lexicalDiff = (right.lexicalScore || 0) - (left.lexicalScore || 0);
-      if (lexicalDiff !== 0) {
-        return lexicalDiff;
-      }
-      const leftId = astRagNormalizeString(left.chunkId, '');
-      const rightId = astRagNormalizeString(right.chunkId, '');
-      return leftId < rightId ? -1 : (leftId > rightId ? 1 : 0);
+  if (astRagIsPlainObject(diagnostics)) {
+    if (!astRagIsPlainObject(diagnostics.timings)) {
+      diagnostics.timings = {};
+    }
+    if (!astRagIsPlainObject(diagnostics.retrieval)) {
+      diagnostics.retrieval = {};
+    }
+    diagnostics.timings.rerankMs = (
+      diagnostics.timings.rerankMs || 0
+    ) + Math.max(0, new Date().getTime() - rerankStartedAtMs);
+    diagnostics.retrieval.reranker = astRagNormalizeString(
+      rerank.provider,
+      AST_RAG_DEFAULT_RETRIEVAL.rerank.provider
+    );
+    diagnostics.retrieval.rerankTopN = topN;
+  }
+
+  return rerankedHead.concat(scoredResults.slice(topN));
+}
+
+function astRagValidateDirectRerankRequest(request = {}) {
+  if (!astRagIsPlainObject(request)) {
+    throw new AstRagValidationError('rerank request must be an object');
+  }
+
+  const query = astRagNormalizeString(request.query, '');
+  const inputResults = Array.isArray(request.results)
+    ? request.results
+    : (Array.isArray(request.candidates) ? request.candidates : []);
+  if (inputResults.length === 0) {
+    throw new AstRagValidationError('rerank request requires a non-empty results array');
+  }
+
+  const normalizedResults = inputResults.map((result, idx) => {
+    if (!astRagIsPlainObject(result)) {
+      throw new AstRagValidationError('rerank results must contain objects', {
+        index: idx
+      });
+    }
+    const chunkId = astRagNormalizeString(result.chunkId, null);
+    if (!chunkId) {
+      throw new AstRagValidationError('rerank result is missing chunkId', {
+        index: idx
+      });
+    }
+    return Object.assign({}, result, {
+      chunkId,
+      finalScore: typeof result.finalScore === 'number' && isFinite(result.finalScore)
+        ? result.finalScore
+        : (
+          typeof result.score === 'number' && isFinite(result.score)
+            ? result.score
+            : 0
+        ),
+      lexicalScore: typeof result.lexicalScore === 'number' && isFinite(result.lexicalScore)
+        ? result.lexicalScore
+        : 0,
+      vectorScore: typeof result.vectorScore === 'number' && isFinite(result.vectorScore)
+        ? result.vectorScore
+        : 0
     });
+  });
 
-  return head.concat(scoredResults.slice(topN));
+  const rerankInput = astRagIsPlainObject(request.rerank)
+    ? astRagCloneObject(request.rerank)
+    : {};
+  if (typeof rerankInput.enabled === 'undefined') {
+    rerankInput.enabled = astRagNormalizeBoolean(request.enabled, true);
+  }
+  if (typeof rerankInput.topN === 'undefined') {
+    rerankInput.topN = request.topN;
+  }
+  if (typeof rerankInput.provider === 'undefined') {
+    rerankInput.provider = request.provider;
+  }
+
+  const rerankDefaults = Object.assign({}, AST_RAG_DEFAULT_RETRIEVAL.rerank, {
+    enabled: true
+  });
+  const rerankConfig = astRagNormalizeRetrievalRerank(
+    rerankInput,
+    rerankDefaults,
+    'rerank'
+  );
+
+  return {
+    query,
+    results: normalizedResults,
+    rerank: rerankConfig
+  };
+}
+
+function astRagRerankCore(request = {}) {
+  const normalized = astRagValidateDirectRerankRequest(request);
+  const reranked = astRagRerankResults(
+    normalized.query,
+    normalized.results,
+    normalized.rerank
+  );
+  return {
+    status: 'ok',
+    query: normalized.query,
+    rerank: normalized.rerank,
+    totalCandidates: normalized.results.length,
+    returned: reranked.length,
+    results: reranked
+  };
 }

--- a/apps_script_tools/rag/general/rerankerRegistry.js
+++ b/apps_script_tools/rag/general/rerankerRegistry.js
@@ -1,0 +1,93 @@
+const AST_RAG_RERANKER_REGISTRY = {};
+
+function astRagNormalizeRerankerName(name) {
+  const normalized = astRagNormalizeString(name, null);
+  if (!normalized) {
+    throw new AstRagValidationError('Reranker name is required');
+  }
+  return normalized.toLowerCase();
+}
+
+function astRagValidateRerankerAdapter(adapter = {}, rerankerName) {
+  if (!astRagIsPlainObject(adapter)) {
+    throw new AstRagValidationError('Reranker adapter must be an object', {
+      reranker: rerankerName
+    });
+  }
+
+  if (typeof adapter.rerank !== 'function') {
+    throw new AstRagValidationError('Reranker adapter requires rerank(request) function', {
+      reranker: rerankerName
+    });
+  }
+}
+
+function astRagRegisterReranker(name, adapter, options = {}) {
+  const rerankerName = astRagNormalizeRerankerName(name);
+  astRagValidateRerankerAdapter(adapter, rerankerName);
+
+  const allowOverwrite = astRagIsPlainObject(options) && options.overwrite === true;
+  if (AST_RAG_RERANKER_REGISTRY[rerankerName] && !allowOverwrite) {
+    throw new AstRagValidationError('Reranker is already registered', {
+      reranker: rerankerName
+    });
+  }
+
+  AST_RAG_RERANKER_REGISTRY[rerankerName] = {
+    name: rerankerName,
+    adapter,
+    isBuiltIn: astRagIsPlainObject(options) ? options.builtIn === true : false
+  };
+
+  return astRagListRerankers();
+}
+
+function astRagUnregisterReranker(name) {
+  const rerankerName = astRagNormalizeRerankerName(name);
+  const entry = AST_RAG_RERANKER_REGISTRY[rerankerName];
+  if (!entry) {
+    return false;
+  }
+
+  if (entry.isBuiltIn) {
+    throw new AstRagValidationError('Cannot unregister built-in reranker', {
+      reranker: rerankerName
+    });
+  }
+
+  delete AST_RAG_RERANKER_REGISTRY[rerankerName];
+  return true;
+}
+
+function astRagGetReranker(name) {
+  const rerankerName = astRagNormalizeRerankerName(name);
+  const entry = AST_RAG_RERANKER_REGISTRY[rerankerName];
+  if (!entry) {
+    throw new AstRagValidationError('Reranker is not registered', {
+      reranker: rerankerName
+    });
+  }
+  return entry;
+}
+
+function astRagHasReranker(name) {
+  const normalized = astRagNormalizeString(name, null);
+  if (!normalized) {
+    return false;
+  }
+  return Boolean(AST_RAG_RERANKER_REGISTRY[normalized.toLowerCase()]);
+}
+
+function astRagListRerankers() {
+  return Object.keys(AST_RAG_RERANKER_REGISTRY).sort();
+}
+
+function astRagRegisterBuiltInRerankers() {
+  if (!astRagHasReranker(AST_RAG_DEFAULT_RETRIEVAL.rerank.provider)) {
+    astRagRegisterReranker(AST_RAG_DEFAULT_RETRIEVAL.rerank.provider, {
+      rerank: request => astRagHeuristicRerank(request)
+    }, {
+      builtIn: true
+    });
+  }
+}

--- a/apps_script_tools/rag/general/resolveRagConfig.js
+++ b/apps_script_tools/rag/general/resolveRagConfig.js
@@ -403,7 +403,8 @@ function astRagResolveRetrievalDefaults() {
     vectorWeight: AST_RAG_DEFAULT_RETRIEVAL.vectorWeight,
     rerank: {
       enabled: AST_RAG_DEFAULT_RETRIEVAL.rerank.enabled,
-      topN: AST_RAG_DEFAULT_RETRIEVAL.rerank.topN
+      topN: AST_RAG_DEFAULT_RETRIEVAL.rerank.topN,
+      provider: AST_RAG_DEFAULT_RETRIEVAL.rerank.provider
     },
     defaultFolderId
   };

--- a/apps_script_tools/rag/general/retrievalEngine.js
+++ b/apps_script_tools/rag/general/retrievalEngine.js
@@ -161,7 +161,12 @@ function astRagRetrieveRankedChunks(indexDocument, query, queryVector, retrieval
     .filter(item => item.finalScore >= retrieval.minScore);
   const selectionLimit = astRagResolveRetrievalSelectionLimit(retrieval);
   const selectedForRerank = astRagSelectTopScoredResults(fused, selectionLimit);
-  const reranked = astRagRerankResults(query, selectedForRerank, retrieval.rerank || {});
+  const reranked = astRagRerankResults(
+    query,
+    selectedForRerank,
+    retrieval.rerank || {},
+    { diagnostics }
+  );
   const returned = reranked
     .slice(0, retrieval.topK)
     .map(item => Object.assign({}, item, {

--- a/apps_script_tools/rag/general/searchRagIndex.js
+++ b/apps_script_tools/rag/general/searchRagIndex.js
@@ -32,6 +32,23 @@ function astRagBuildSearchDiagnostics(normalizedRequest, cacheConfig = {}) {
       mode: normalizedRequest.retrieval.mode,
       topK: normalizedRequest.retrieval.topK,
       minScore: normalizedRequest.retrieval.minScore,
+      reranker: (
+        normalizedRequest.retrieval &&
+        normalizedRequest.retrieval.rerank &&
+        normalizedRequest.retrieval.rerank.enabled === true
+      )
+        ? astRagNormalizeString(
+          normalizedRequest.retrieval.rerank.provider,
+          AST_RAG_DEFAULT_RETRIEVAL.rerank.provider
+        )
+        : null,
+      rerankTopN: (
+        normalizedRequest.retrieval &&
+        normalizedRequest.retrieval.rerank &&
+        normalizedRequest.retrieval.rerank.enabled === true
+      )
+        ? normalizedRequest.retrieval.rerank.topN
+        : 0,
       lexicalPrefilterTopN: normalizedRequest.retrieval.lexicalPrefilterTopN || 0,
       partition: {
         enabled: normalizedRequest.retrieval.partition && normalizedRequest.retrieval.partition.enabled === true,

--- a/apps_script_tools/rag/general/validateRagRequest.js
+++ b/apps_script_tools/rag/general/validateRagRequest.js
@@ -484,7 +484,11 @@ function astRagNormalizeRetrievalRerank(rerank, defaults, fieldPath) {
   if (typeof rerank === 'undefined' || rerank === null) {
     return {
       enabled: defaults.enabled,
-      topN: defaults.topN
+      topN: defaults.topN,
+      provider: astRagNormalizeString(
+        defaults.provider,
+        AST_RAG_DEFAULT_RETRIEVAL.rerank.provider
+      ).toLowerCase()
     };
   }
 
@@ -492,9 +496,18 @@ function astRagNormalizeRetrievalRerank(rerank, defaults, fieldPath) {
     throw new AstRagValidationError(`${fieldPath} must be an object when provided`);
   }
 
+  const provider = astRagNormalizeString(
+    rerank.provider,
+    astRagNormalizeString(defaults.provider, AST_RAG_DEFAULT_RETRIEVAL.rerank.provider)
+  );
+  if (!provider) {
+    throw new AstRagValidationError(`${fieldPath}.provider is required when rerank is configured`);
+  }
+
   return {
     enabled: astRagNormalizeBoolean(rerank.enabled, defaults.enabled),
-    topN: astRagNormalizePositiveInt(rerank.topN, defaults.topN, 1)
+    topN: astRagNormalizePositiveInt(rerank.topN, defaults.topN, 1),
+    provider: provider.toLowerCase()
   };
 }
 

--- a/apps_script_tools/testing/rag/ragNamespace.js
+++ b/apps_script_tools/testing/rag/ragNamespace.js
@@ -13,6 +13,7 @@ RAG_NAMESPACE_TESTS = [
         'search',
         'previewSources',
         'answer',
+        'rerank',
         'inspectIndex',
         'buildRetrievalCacheKey',
         'putRetrievalPayload',
@@ -21,7 +22,10 @@ RAG_NAMESPACE_TESTS = [
         'embeddingProviders',
         'embeddingCapabilities',
         'registerEmbeddingProvider',
-        'unregisterEmbeddingProvider'
+        'unregisterEmbeddingProvider',
+        'registerReranker',
+        'unregisterReranker',
+        'rerankers'
       ];
 
       requiredMethods.forEach(method => {
@@ -48,6 +52,9 @@ RAG_NAMESPACE_TESTS = [
       const providers = AST.RAG.embeddingProviders();
       const expected = ['gemini', 'openai', 'openrouter', 'perplexity', 'vertex_gemini'];
       t.deepEqual(providers, expected, `Expected providers ${JSON.stringify(expected)}, got ${JSON.stringify(providers)}`);
+
+      const rerankers = AST.RAG.rerankers();
+      t.deepEqual(rerankers, ['heuristic'], `Expected rerankers [\"heuristic\"], got ${JSON.stringify(rerankers)}`);
     })
   },
   {

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -215,6 +215,7 @@ ASTX.RAG.syncIndex(request)
 ASTX.RAG.search(request)
 ASTX.RAG.previewSources(request)
 ASTX.RAG.answer(request)
+ASTX.RAG.rerank(request)
 ASTX.RAG.evaluate(request)
 ASTX.RAG.compareRuns(request)
 ASTX.RAG.inspectIndex({ indexFileId })
@@ -232,6 +233,9 @@ ASTX.RAG.embeddingProviders()
 ASTX.RAG.embeddingCapabilities(provider)
 ASTX.RAG.registerEmbeddingProvider(name, adapter, options)
 ASTX.RAG.unregisterEmbeddingProvider(name)
+ASTX.RAG.rerankers()
+ASTX.RAG.registerReranker(name, adapter, options)
+ASTX.RAG.unregisterReranker(name)
 ```
 
 Notes:

--- a/docs/api/rag-contracts.md
+++ b/docs/api/rag-contracts.md
@@ -17,6 +17,7 @@ ASTX.RAG.syncIndex(request)
 ASTX.RAG.search(request)
 ASTX.RAG.previewSources(request)
 ASTX.RAG.answer(request)
+ASTX.RAG.rerank(request)
 ASTX.RAG.evaluate(request)
 ASTX.RAG.compareRuns(request)
 ASTX.RAG.inspectIndex(request)
@@ -34,6 +35,9 @@ ASTX.RAG.embeddingProviders()
 ASTX.RAG.embeddingCapabilities(provider)
 ASTX.RAG.registerEmbeddingProvider(name, adapter, options)
 ASTX.RAG.unregisterEmbeddingProvider(name)
+ASTX.RAG.rerankers()
+ASTX.RAG.registerReranker(name, adapter, options)
+ASTX.RAG.unregisterReranker(name)
 ```
 
 ## `buildIndex(request)`
@@ -112,7 +116,8 @@ Notes:
     },
     rerank: {
       enabled: false,
-      topN: 20
+      topN: 20,
+      provider: 'heuristic'
     },
     access: {
       allowedFileIds: [],
@@ -167,7 +172,8 @@ Notes:
     lexicalWeight: 0.35, // hybrid only
     rerank: {
       enabled: false,
-      topN: 20
+      topN: 20,
+      provider: 'heuristic'
     },
     access: {
       allowedFileIds: [],
@@ -272,6 +278,52 @@ Notes:
       storageUri: 'optional'
     }
   }
+}
+```
+
+## `rerank(request)`
+
+```javascript
+{
+  query: 'required for heuristic reranker',
+  results: [
+    {
+      chunkId: 'required',
+      text: 'optional',
+      score: 0.71,       // optional fallback for finalScore
+      finalScore: 0.71,  // optional
+      vectorScore: 0.66, // optional
+      lexicalScore: 0.42 // optional
+    }
+  ],
+  // optional aliases:
+  // provider, topN, enabled
+  rerank: {
+    enabled: true,
+    topN: 20,
+    provider: 'heuristic|custom_name'
+  }
+}
+```
+
+Returns:
+
+```javascript
+{
+  status: 'ok',
+  query: '...',
+  rerank: { enabled: true, topN: 20, provider: 'heuristic' },
+  totalCandidates: 20,
+  returned: 20,
+  results: [
+    {
+      chunkId: '...',
+      finalScore: 0.42,
+      rerankProvider: 'heuristic',
+      rerankScore: 0.57,
+      rerankScoreNormalized: 0.91
+    }
+  ]
 }
 ```
 

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -324,7 +324,7 @@ ASTX.Cache.configure({
 - `retrieval.mode = 'hybrid'` (weighted vector + lexical fusion)
 - `retrieval.mode = 'lexical'` (BM25-only ranking; no embedding call)
 - `retrieval.lexicalPrefilterTopN` for optional lexical shortlist before vector scoring
-- `retrieval.rerank` for optional top-N reranking
+- `retrieval.rerank` for optional top-N reranking with pluggable provider selection
 - `retrieval.access` for source-level allow/deny constraints
 - `generation.maxContextChars` / `generation.maxContextTokensApprox` for bounded grounding context packing
 - optional request/runtime cache controls (`cache.enabled`, backend overrides, TTLs)
@@ -340,7 +340,7 @@ const answer = ASTX.RAG.answer({
     vectorWeight: 0.6,
     lexicalWeight: 0.4,
     lexicalPrefilterTopN: 100,
-    rerank: { enabled: true, topN: 12 },
+    rerank: { enabled: true, topN: 12, provider: 'heuristic' },
     access: {
       allowedFileIds: ['file_public_1', 'file_public_2'],
       deniedFileIds: ['file_sensitive_1']
@@ -950,6 +950,7 @@ Primary methods:
 - `ASTX.RAG.search(...)` for cosine-ranked retrieval over indexed chunks.
 - `ASTX.RAG.previewSources(...)` for citation-ready source cards and reusable retrieval payloads.
 - `ASTX.RAG.answer(...)` for grounded answering with strict citation mapping and abstention.
+- `ASTX.RAG.rerank(...)` for direct post-retrieval reranking over candidate chunks.
 - `ASTX.RAG.evaluate(...)` for deterministic retrieval/grounding/end-to-end scorecards.
 - `ASTX.RAG.compareRuns(...)` for baseline vs candidate metric deltas.
 - `ASTX.RAG.inspectIndex(...)` for index metadata/health checks.
@@ -959,6 +960,7 @@ Primary methods:
 - `ASTX.RAG.IndexManager.create(...)` for build/sync/fast-state orchestration.
 - `ASTX.RAG.embeddingProviders()` and `ASTX.RAG.embeddingCapabilities(...)`.
 - `ASTX.RAG.registerEmbeddingProvider(...)` and `ASTX.RAG.unregisterEmbeddingProvider(...)`.
+- `ASTX.RAG.rerankers()`, `ASTX.RAG.registerReranker(...)`, and `ASTX.RAG.unregisterReranker(...)`.
 
 Source support:
 

--- a/docs/getting-started/rag-quickstart.md
+++ b/docs/getting-started/rag-quickstart.md
@@ -213,3 +213,37 @@ function ragEvaluate() {
   Logger.log(JSON.stringify(out.metrics, null, 2));
 }
 ```
+
+## Register and use a custom reranker
+
+```javascript
+function ragCustomRerankerExample() {
+  const ASTX = ASTLib.AST || ASTLib;
+
+  ASTX.RAG.registerReranker('prefer_phrase', {
+    rerank: request => request.candidates.map(candidate => ({
+      chunkId: candidate.chunkId,
+      score: candidate.text && candidate.text.toLowerCase().includes(request.query.toLowerCase())
+        ? 10
+        : 1
+    }))
+  });
+
+  const out = ASTX.RAG.search({
+    indexFileId: 'YOUR_INDEX_FILE_ID',
+    query: 'critical launch checklist',
+    retrieval: {
+      topK: 6,
+      minScore: 0.1,
+      rerank: {
+        enabled: true,
+        topN: 12,
+        provider: 'prefer_phrase'
+      }
+    }
+  });
+
+  Logger.log(out.results[0]);
+  ASTX.RAG.unregisterReranker('prefer_phrase');
+}
+```


### PR DESCRIPTION
## Summary
- add a first-class reranker registry for `AST.RAG` with built-in `heuristic` provider
- add direct reranking API methods: `AST.RAG.rerank`, `AST.RAG.rerankers`, `AST.RAG.registerReranker`, `AST.RAG.unregisterReranker`
- extend retrieval/rerank contracts with explicit `rerank.provider` and stable score normalization
- integrate reranker diagnostics into search/answer flows and keep deterministic sort behavior
- add local + GAS namespace coverage and docs/changelog updates

## Why
Issue #194 requires a pluggable reranker architecture that can be used both in retrieval pipelines and as a standalone API with deterministic output semantics.

## Validation
- `npm run lint`
- `npm run test:local`
- `npm run test:perf:check`

Closes #194