### PR TITLE
feat(dbt): add compareArtifacts API for artifact drift analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 - New `AST.DBT` namespace with:
   - `run`, `loadManifest`, `loadArtifact`, `inspectManifest`, `inspectArtifact`
   - `listEntities`, `search`, `getEntity`, `getColumn`, `lineage`
-  - `diffEntities`, `impact`, `qualityReport`, `testCoverage`, `owners`
+  - `diffEntities`, `compareArtifacts`, `impact`, `qualityReport`, `testCoverage`, `owners`
   - `providers`, `capabilities`
   - `validateManifest`, `configure`, `getConfig`, `clearConfig`
 - dbt manifest source loading support for:

--- a/apps_script_tools/dbt/DBT.js
+++ b/apps_script_tools/dbt/DBT.js
@@ -24,6 +24,8 @@ function astDbtRun(request = {}) {
       return astDbtValidateManifestCore(normalized);
     case 'diff_entities':
       return astDbtDiffEntitiesCore(normalized);
+    case 'compare_artifacts':
+      return astDbtCompareArtifactsCore(normalized);
     case 'impact':
       return astDbtImpactCore(normalized);
     case 'quality_report':
@@ -79,6 +81,10 @@ function astDbtDiffEntities(request = {}) {
 
 function astDbtImpact(request = {}) {
   return astDbtImpactCore(request);
+}
+
+function astDbtCompareArtifacts(request = {}) {
+  return astDbtCompareArtifactsCore(request);
 }
 
 function astDbtQualityReport(request = {}) {
@@ -172,6 +178,7 @@ const AST_DBT = Object.freeze({
   getColumn: astDbtGetColumn,
   lineage: astDbtLineage,
   diffEntities: astDbtDiffEntities,
+  compareArtifacts: astDbtCompareArtifacts,
   impact: astDbtImpact,
   qualityReport: astDbtQualityReport,
   testCoverage: astDbtTestCoverage,

--- a/apps_script_tools/dbt/general/capabilities.js
+++ b/apps_script_tools/dbt/general/capabilities.js
@@ -23,6 +23,7 @@ const AST_DBT_RUN_OPERATIONS = Object.freeze([
   'lineage',
   'validate_manifest',
   'diff_entities',
+  'compare_artifacts',
   'impact',
   'quality_report',
   'test_coverage',

--- a/apps_script_tools/dbt/general/diffImpact.js
+++ b/apps_script_tools/dbt/general/diffImpact.js
@@ -330,6 +330,299 @@ function astDbtDiffEntitiesCore(request = {}) {
   return out;
 }
 
+function astDbtBuildArtifactComparableValue(artifactType, entry) {
+  if (!entry || !entry.uniqueId) {
+    return null;
+  }
+
+  if (artifactType === 'catalog') {
+    const rawColumns = astDbtIsPlainObject(entry.raw && entry.raw.columns)
+      ? entry.raw.columns
+      : {};
+    const columns = {};
+    Object.keys(rawColumns).sort().forEach(columnKey => {
+      const column = rawColumns[columnKey];
+      if (!astDbtIsPlainObject(column)) {
+        return;
+      }
+
+      const normalizedName = astDbtNormalizeString(column.name, columnKey);
+      const normalizedKey = normalizedName.toLowerCase();
+      columns[normalizedKey] = {
+        name: normalizedName,
+        dataType: astDbtNormalizeString(column.type || column.data_type, '')
+      };
+    });
+
+    return {
+      uniqueId: entry.uniqueId,
+      section: astDbtNormalizeString(entry.section, ''),
+      resourceType: astDbtNormalizeString(entry.resourceType, ''),
+      packageName: astDbtNormalizeString(entry.packageName, ''),
+      name: astDbtNormalizeString(entry.name, ''),
+      path: astDbtNormalizeString(entry.path, ''),
+      columnCount: Number(entry.columnCount || 0),
+      database: astDbtNormalizeString(entry.database, ''),
+      schema: astDbtNormalizeString(entry.schema, ''),
+      alias: astDbtNormalizeString(entry.alias, ''),
+      identifier: astDbtNormalizeString(entry.identifier, ''),
+      relationName: astDbtNormalizeString(entry.relationName, ''),
+      columns
+    };
+  }
+
+  if (artifactType === 'run_results') {
+    return {
+      uniqueId: entry.uniqueId,
+      status: astDbtNormalizeString(entry.status, ''),
+      executionTime: Number(entry.executionTime || 0),
+      threadId: astDbtNormalizeString(entry.threadId, ''),
+      message: astDbtNormalizeString(entry.message, ''),
+      failures: Number(entry.failures || 0),
+      timing: Array.isArray(entry.timing) ? astDbtStableCopy(entry.timing) : []
+    };
+  }
+
+  if (artifactType === 'sources') {
+    return {
+      uniqueId: entry.uniqueId,
+      status: astDbtNormalizeString(entry.status, ''),
+      maxLoadedAt: astDbtNormalizeString(entry.maxLoadedAt, ''),
+      snapshottedAt: astDbtNormalizeString(entry.snapshottedAt, ''),
+      executionTime: Number(entry.executionTime || 0),
+      threadId: astDbtNormalizeString(entry.threadId, ''),
+      message: astDbtNormalizeString(entry.message, '')
+    };
+  }
+
+  return {
+    uniqueId: entry.uniqueId,
+    value: astDbtStableCopy(entry)
+  };
+}
+
+function astDbtBuildArtifactComparableSnapshot(bundle, artifactType) {
+  const snapshot = {};
+  const index = astDbtIsPlainObject(bundle && bundle.index)
+    ? bundle.index
+    : (astDbtIsPlainObject(bundle && bundle.artifact)
+      ? astDbtBuildArtifactIndex(artifactType, bundle.artifact)
+      : null);
+
+  if (!astDbtIsPlainObject(index) || !astDbtIsPlainObject(index.byUniqueId)) {
+    return snapshot;
+  }
+
+  const keys = Object.keys(index.byUniqueId).sort();
+  keys.forEach(key => {
+    const entry = index.byUniqueId[key];
+    const uniqueId = astDbtNormalizeString(entry && entry.uniqueId, '');
+    if (!uniqueId) {
+      return;
+    }
+
+    const comparable = astDbtBuildArtifactComparableValue(artifactType, entry);
+    snapshot[uniqueId] = {
+      value: comparable,
+      hash: astDbtDigestHex(astDbtStableStringify(comparable))
+    };
+  });
+
+  return snapshot;
+}
+
+function astDbtResolveCompareArtifactsSideBundle(side = {}, options = {}) {
+  if (!astDbtIsPlainObject(side)) {
+    throw new AstDbtValidationError('compareArtifacts side must be an object');
+  }
+
+  if (side.type === 'manifest') {
+    return astDbtEnsureBundle({
+      bundle: side.bundle,
+      manifest: side.manifest,
+      source: side.source,
+      uri: side.source && side.source.uri,
+      fileId: side.source && side.source.location && side.source.location.fileId,
+      provider: side.source && side.source.provider,
+      location: side.source && side.source.location,
+      auth: side.source && side.source.auth,
+      providerOptions: side.source && side.source.providerOptions,
+      options: Object.assign({}, options, side.options || {})
+    }, {
+      options: Object.assign({}, options, side.options || {})
+    });
+  }
+
+  return astDbtEnsureArtifactBundle({
+    bundle: side.bundle,
+    artifactType: side.type,
+    artifact: side.artifact,
+    source: side.source,
+    uri: side.source && side.source.uri,
+    fileId: side.source && side.source.location && side.source.location.fileId,
+    provider: side.source && side.source.provider,
+    location: side.source && side.source.location,
+    auth: side.source && side.source.auth,
+    providerOptions: side.source && side.source.providerOptions,
+    options: Object.assign({}, options, side.options || {})
+  }, side.type, {
+    options: Object.assign({}, options, side.options || {})
+  });
+}
+
+function astDbtBuildCompareArtifactsSnapshot(side = {}, options = {}, include = {}) {
+  const bundle = astDbtResolveCompareArtifactsSideBundle(side, options);
+  const type = side.type;
+
+  if (type === 'manifest') {
+    const index = bundle.index || astDbtBuildManifestIndexes(bundle.manifest);
+    return {
+      type,
+      bundle,
+      snapshot: astDbtBuildEntitySnapshot(index, {
+        meta: include.meta !== false,
+        columns: include.columns !== false
+      })
+    };
+  }
+
+  return {
+    type,
+    bundle,
+    snapshot: astDbtBuildArtifactComparableSnapshot(bundle, type)
+  };
+}
+
+function astDbtBuildCompareArtifactDiff(leftValue, rightValue) {
+  const leftKeys = leftValue && typeof leftValue === 'object' ? Object.keys(leftValue) : [];
+  const rightKeys = rightValue && typeof rightValue === 'object' ? Object.keys(rightValue) : [];
+  const keys = Array.from(new Set(leftKeys.concat(rightKeys))).sort();
+
+  const fieldChanges = [];
+  keys.forEach(key => {
+    if (key === 'uniqueId') {
+      return;
+    }
+
+    const leftSerialized = astDbtStableStringify(leftValue ? leftValue[key] : null);
+    const rightSerialized = astDbtStableStringify(rightValue ? rightValue[key] : null);
+    if (leftSerialized !== rightSerialized) {
+      fieldChanges.push(key);
+    }
+  });
+
+  return {
+    fieldChanges
+  };
+}
+
+function astDbtBuildCompareArtifactItem(uniqueId, leftComparable, rightComparable, include = {}) {
+  let changeType = 'unchanged';
+  if (!leftComparable && rightComparable) {
+    changeType = 'added';
+  } else if (leftComparable && !rightComparable) {
+    changeType = 'removed';
+  } else if (leftComparable && rightComparable && leftComparable.hash !== rightComparable.hash) {
+    changeType = 'changed';
+  }
+
+  const item = {
+    uniqueId,
+    changeType
+  };
+
+  if (include.left !== false && leftComparable) {
+    item.left = leftComparable.value;
+  }
+
+  if (include.right !== false && rightComparable) {
+    item.right = rightComparable.value;
+  }
+
+  if (changeType === 'changed' && include.diff !== false) {
+    item.diff = astDbtBuildCompareArtifactDiff(
+      leftComparable ? leftComparable.value : null,
+      rightComparable ? rightComparable.value : null
+    );
+  }
+
+  return item;
+}
+
+function astDbtCompareArtifactsCore(request = {}) {
+  const normalized = astDbtValidateCompareArtifactsRequest(request);
+  const startedAt = Date.now();
+
+  const leftResolved = astDbtBuildCompareArtifactsSnapshot(normalized.left, normalized.options, normalized.include);
+  const rightResolved = astDbtBuildCompareArtifactsSnapshot(normalized.right, normalized.options, normalized.include);
+
+  const leftSnapshot = leftResolved.snapshot || {};
+  const rightSnapshot = rightResolved.snapshot || {};
+  const allUniqueIds = Array.from(new Set(Object.keys(leftSnapshot).concat(Object.keys(rightSnapshot)))).sort();
+
+  const summary = {
+    artifactType: normalized.artifactType,
+    leftCount: Object.keys(leftSnapshot).length,
+    rightCount: Object.keys(rightSnapshot).length,
+    added: 0,
+    removed: 0,
+    changed: 0,
+    unchanged: 0
+  };
+
+  const items = [];
+  allUniqueIds.forEach(uniqueId => {
+    const item = astDbtBuildCompareArtifactItem(
+      uniqueId,
+      leftSnapshot[uniqueId] || null,
+      rightSnapshot[uniqueId] || null,
+      normalized.include
+    );
+
+    summary[item.changeType] += 1;
+
+    if (!normalized.includeUnchanged && item.changeType === 'unchanged') {
+      return;
+    }
+
+    if (normalized.changeTypes.indexOf(item.changeType) === -1) {
+      return;
+    }
+
+    items.push(item);
+  });
+
+  const total = items.length;
+  const offset = normalized.page.offset;
+  const limit = normalized.page.limit;
+  const pagedItems = items.slice(offset, offset + limit);
+
+  const response = {
+    status: 'ok',
+    artifactType: normalized.artifactType,
+    summary,
+    page: {
+      limit,
+      offset,
+      returned: pagedItems.length,
+      total,
+      hasMore: offset + pagedItems.length < total
+    },
+    leftSummary: leftResolved.bundle && leftResolved.bundle.summary ? leftResolved.bundle.summary : null,
+    rightSummary: rightResolved.bundle && rightResolved.bundle.summary ? rightResolved.bundle.summary : null,
+    items: pagedItems
+  };
+
+  if (normalized.include.stats !== false) {
+    response.stats = {
+      comparedEntities: allUniqueIds.length,
+      elapsedMs: Date.now() - startedAt
+    };
+  }
+
+  return response;
+}
+
 function astDbtResolveImpactArtifactBundle(descriptor = null, requestOptions = {}) {
   if (!astDbtIsPlainObject(descriptor)) {
     return null;

--- a/apps_script_tools/dbt/general/validateDbtRequest.js
+++ b/apps_script_tools/dbt/general/validateDbtRequest.js
@@ -34,6 +34,20 @@ const AST_DBT_DIFF_CHANGE_TYPES = Object.freeze([
   'unchanged'
 ]);
 
+const AST_DBT_COMPARE_ARTIFACT_TYPES = Object.freeze([
+  'manifest',
+  'catalog',
+  'run_results',
+  'sources'
+]);
+
+const AST_DBT_COMPARE_CHANGE_TYPES = Object.freeze([
+  'added',
+  'removed',
+  'changed',
+  'unchanged'
+]);
+
 function astDbtNormalizeBoolean(value, fallback = false) {
   if (typeof value === 'boolean') {
     return value;
@@ -445,6 +459,155 @@ function astDbtNormalizeDiffChangeTypes(changeTypes) {
   return output;
 }
 
+function astDbtNormalizeCompareArtifactType(value, fallback = '') {
+  const normalized = astDbtNormalizeString(value, fallback).toLowerCase().replace(/-/g, '_');
+  if (!normalized || AST_DBT_COMPARE_ARTIFACT_TYPES.indexOf(normalized) !== -1) {
+    return normalized;
+  }
+
+  throw new AstDbtValidationError(
+    `compareArtifacts side type must be one of: ${AST_DBT_COMPARE_ARTIFACT_TYPES.join(', ')}`,
+    { type: normalized }
+  );
+}
+
+function astDbtNormalizeCompareChangeTypes(changeTypes) {
+  if (typeof changeTypes === 'undefined' || changeTypes == null) {
+    return ['added', 'removed', 'changed'];
+  }
+
+  if (!Array.isArray(changeTypes)) {
+    throw new AstDbtValidationError('compareArtifacts changeTypes must be an array when provided');
+  }
+
+  const output = [];
+  const seen = {};
+
+  changeTypes.forEach(value => {
+    const normalized = astDbtNormalizeString(value, '').toLowerCase();
+    if (!normalized) {
+      return;
+    }
+
+    if (AST_DBT_COMPARE_CHANGE_TYPES.indexOf(normalized) === -1) {
+      throw new AstDbtValidationError(
+        `compareArtifacts changeTypes must be one of: ${AST_DBT_COMPARE_CHANGE_TYPES.join(', ')}`,
+        { changeType: normalized }
+      );
+    }
+
+    if (seen[normalized]) {
+      return;
+    }
+
+    seen[normalized] = true;
+    output.push(normalized);
+  });
+
+  return output;
+}
+
+function astDbtNormalizeCompareInclude(include = {}) {
+  if (!astDbtIsPlainObject(include)) {
+    throw new AstDbtValidationError('compareArtifacts include must be an object');
+  }
+
+  return {
+    left: astDbtNormalizeBoolean(include.left, true),
+    right: astDbtNormalizeBoolean(include.right, true),
+    diff: astDbtNormalizeBoolean(include.diff, true),
+    meta: astDbtNormalizeBoolean(include.meta, true),
+    columns: astDbtNormalizeBoolean(include.columns, true),
+    stats: astDbtNormalizeBoolean(include.stats, true)
+  };
+}
+
+function astDbtBuildCompareSideFromAliases(request = {}, sideName) {
+  const side = astDbtIsPlainObject(request[sideName]) ? request[sideName] : null;
+  if (side) {
+    return side;
+  }
+
+  const upper = sideName.charAt(0).toUpperCase() + sideName.slice(1);
+  const aliases = {
+    type: request[`${sideName}Type`] || request[`${sideName}ArtifactType`],
+    bundle: request[`${sideName}Bundle`],
+    manifest: request[`${sideName}Manifest`],
+    artifact: request[`${sideName}Artifact`],
+    source: request[`${sideName}Source`],
+    uri: request[`${sideName}Uri`],
+    fileId: request[`${sideName}FileId`],
+    provider: request[`${sideName}Provider`],
+    location: request[`${sideName}Location`],
+    auth: request[`${sideName}Auth`],
+    providerOptions: request[`${sideName}ProviderOptions`],
+    options: request[`${sideName}Options`]
+  };
+
+  if (sideName === 'left') {
+    aliases.bundle = aliases.bundle || request.bundleA;
+    aliases.manifest = aliases.manifest || request.manifestA;
+    aliases.artifact = aliases.artifact || request.artifactA;
+    aliases.type = aliases.type || request.typeA || request.artifactTypeA;
+  } else if (sideName === 'right') {
+    aliases.bundle = aliases.bundle || request.bundleB;
+    aliases.manifest = aliases.manifest || request.manifestB;
+    aliases.artifact = aliases.artifact || request.artifactB;
+    aliases.type = aliases.type || request.typeB || request.artifactTypeB;
+  }
+
+  const hasAliasValue = Object.keys(aliases).some(key => typeof aliases[key] !== 'undefined' && aliases[key] !== null);
+  if (!hasAliasValue) {
+    return null;
+  }
+
+  return aliases;
+}
+
+function astDbtNormalizeCompareSide(side = {}, sideName, defaultsManifest = {}, defaultsArtifact = {}) {
+  if (!astDbtIsPlainObject(side)) {
+    throw new AstDbtValidationError(`compareArtifacts ${sideName} side must be an object`);
+  }
+
+  const type = astDbtNormalizeCompareArtifactType(side.type || side.artifactType || side.kind, '');
+  if (!type) {
+    throw new AstDbtValidationError(`compareArtifacts ${sideName} side requires type`);
+  }
+
+  const sideDefaults = type === 'manifest' ? defaultsManifest : defaultsArtifact;
+  const options = astDbtNormalizeLoadOptions(side.options || {}, sideDefaults);
+  const bundle = astDbtIsPlainObject(side.bundle) ? side.bundle : null;
+  const manifest = type === 'manifest' && astDbtIsPlainObject(side.manifest) ? side.manifest : null;
+  const artifact = type !== 'manifest' && astDbtIsPlainObject(side.artifact) ? side.artifact : null;
+
+  const source = (bundle || manifest || artifact)
+    ? null
+    : astDbtNormalizeSourceObject({
+      source: side.source,
+      uri: side.uri,
+      fileId: side.fileId,
+      provider: side.provider,
+      location: side.location,
+      auth: side.auth,
+      providerOptions: side.providerOptions
+    }, sideDefaults);
+
+  if (!bundle && !manifest && !artifact && !source) {
+    throw new AstDbtValidationError(
+      `compareArtifacts ${sideName} side requires one of: bundle, manifest/artifact, or source locator`
+    );
+  }
+
+  return {
+    type,
+    bundle,
+    manifest,
+    artifact,
+    source,
+    options
+  };
+}
+
 function astDbtNormalizeImpactArtifactRef(descriptor = {}, artifactType, defaults = {}) {
   if (!astDbtIsPlainObject(descriptor)) {
     throw new AstDbtValidationError(`impact artifacts.${artifactType} must be an object when provided`);
@@ -791,6 +954,47 @@ function astDbtValidateImpactRequest(request = {}) {
   };
 }
 
+function astDbtValidateCompareArtifactsRequest(request = {}) {
+  if (!astDbtIsPlainObject(request)) {
+    throw new AstDbtValidationError('compareArtifacts request must be an object');
+  }
+
+  const manifestDefaults = astDbtResolveLoadDefaults(request);
+  const artifactDefaults = astDbtResolveArtifactDefaults(request);
+
+  const leftRaw = astDbtBuildCompareSideFromAliases(request, 'left');
+  const rightRaw = astDbtBuildCompareSideFromAliases(request, 'right');
+
+  if (!leftRaw || !rightRaw) {
+    throw new AstDbtValidationError('compareArtifacts requires both left and right side descriptors');
+  }
+
+  const left = astDbtNormalizeCompareSide(leftRaw, 'left', manifestDefaults, artifactDefaults);
+  const right = astDbtNormalizeCompareSide(rightRaw, 'right', manifestDefaults, artifactDefaults);
+
+  if (left.type !== right.type) {
+    throw new AstDbtValidationError(
+      'compareArtifacts requires left and right side types to match',
+      {
+        leftType: left.type,
+        rightType: right.type
+      }
+    );
+  }
+
+  return {
+    operation: 'compare_artifacts',
+    artifactType: left.type,
+    left,
+    right,
+    includeUnchanged: astDbtNormalizeBoolean(request.includeUnchanged, false),
+    changeTypes: astDbtNormalizeCompareChangeTypes(request.changeTypes),
+    include: astDbtNormalizeCompareInclude(request.include || {}),
+    page: astDbtNormalizeSearchPage(request.page || {}),
+    options: astDbtNormalizeLoadOptions(request.options || {}, manifestDefaults)
+  };
+}
+
 function astDbtNormalizeOwnerPaths(value, fallback = ['owner.team', 'owner']) {
   const source = Array.isArray(value) ? value : fallback;
   const normalized = astDbtNormalizeStringArray(source);
@@ -895,6 +1099,8 @@ function astDbtValidateRunRequest(request = {}) {
       return astDbtValidateValidateManifestRequest(request);
     case 'diff_entities':
       return astDbtValidateDiffEntitiesRequest(request);
+    case 'compare_artifacts':
+      return astDbtValidateCompareArtifactsRequest(request);
     case 'impact':
       return astDbtValidateImpactRequest(request);
     case 'quality_report':

--- a/apps_script_tools/testing/dbt/dbtNamespace.js
+++ b/apps_script_tools/testing/dbt/dbtNamespace.js
@@ -16,6 +16,7 @@ DBT_NAMESPACE_TESTS = [
         'getColumn',
         'lineage',
         'diffEntities',
+        'compareArtifacts',
         'impact',
         'qualityReport',
         'testCoverage',

--- a/docs/api/dbt-artifacts-impact.md
+++ b/docs/api/dbt-artifacts-impact.md
@@ -43,6 +43,21 @@ Logger.log(diff.summary);
 Logger.log(diff.items.slice(0, 5));
 ```
 
+## Compare two artifact snapshots
+
+```javascript
+const compared = ASTX.DBT.compareArtifacts({
+  left: { type: 'catalog', bundle: previousCatalog.bundle },
+  right: { type: 'catalog', bundle: latestCatalog.bundle },
+  includeUnchanged: false,
+  changeTypes: ['added', 'removed', 'changed'],
+  page: { limit: 100, offset: 0 }
+});
+
+Logger.log(compared.summary);
+Logger.log(compared.items.slice(0, 5));
+```
+
 ## Build impact view with artifact overlays
 
 ```javascript

--- a/docs/api/dbt-manifest-contracts.md
+++ b/docs/api/dbt-manifest-contracts.md
@@ -14,6 +14,7 @@ ASTX.DBT.getEntity(request)
 ASTX.DBT.getColumn(request)
 ASTX.DBT.lineage(request)
 ASTX.DBT.diffEntities(request)
+ASTX.DBT.compareArtifacts(request)
 ASTX.DBT.impact(request)
 ASTX.DBT.qualityReport(request)
 ASTX.DBT.testCoverage(request)
@@ -82,7 +83,7 @@ ASTX.DBT.clearConfig()
 }
 ```
 
-`bundle` is reusable for `search`, `getEntity`, `getColumn`, `lineage`, `diffEntities`, `impact`, `qualityReport`, `testCoverage`, and `owners`.
+`bundle` is reusable for `search`, `getEntity`, `getColumn`, `lineage`, `diffEntities`, `compareArtifacts`, `impact`, `qualityReport`, `testCoverage`, and `owners`.
 
 ## `loadArtifact(...)` request
 
@@ -184,6 +185,66 @@ Response is deterministic and pagination-safe:
 ```
 
 `impact(...)` returns lineage plus optional artifact overlays per node (`runResults`, `catalog`, `sources`).
+
+## `compareArtifacts(...)`
+
+```javascript
+{
+  left: {
+    type: 'manifest|catalog|run_results|sources',
+    bundle | manifest | artifact | source | uri | fileId | provider | location
+  },
+  right: {
+    type: 'manifest|catalog|run_results|sources',
+    bundle | manifest | artifact | source | uri | fileId | provider | location
+  },
+  includeUnchanged: false,
+  changeTypes: ['added', 'removed', 'changed'],
+  include: {
+    left: true,
+    right: true,
+    diff: true,
+    meta: true,    // manifest compare only
+    columns: true, // manifest compare only
+    stats: true
+  },
+  page: {
+    limit: 50,
+    offset: 0
+  }
+}
+```
+
+Response:
+
+```javascript
+{
+  status: 'ok',
+  artifactType: 'manifest|catalog|run_results|sources',
+  summary: {
+    artifactType,
+    leftCount,
+    rightCount,
+    added,
+    removed,
+    changed,
+    unchanged
+  },
+  page: { limit, offset, returned, total, hasMore },
+  leftSummary,
+  rightSummary,
+  items: [
+    {
+      uniqueId,
+      changeType: 'added|removed|changed|unchanged',
+      left,  // optional by include.left
+      right, // optional by include.right
+      diff   // optional by include.diff
+    }
+  ],
+  stats
+}
+```
 
 ## Governance/report operations
 

--- a/docs/api/quick-reference.md
+++ b/docs/api/quick-reference.md
@@ -261,6 +261,7 @@ ASTX.DBT.getEntity(request)
 ASTX.DBT.getColumn(request)
 ASTX.DBT.lineage(request)
 ASTX.DBT.diffEntities(request)
+ASTX.DBT.compareArtifacts(request)
 ASTX.DBT.impact(request)
 ASTX.DBT.qualityReport(request)
 ASTX.DBT.testCoverage(request)
@@ -618,6 +619,7 @@ ASTX.GitHub.clearConfig()
 - `ASTX.DBT.getEntity(...)` and `ASTX.DBT.getColumn(...)` provide deep model/column metadata retrieval from preindexed bundles.
 - `ASTX.DBT.lineage(...)` traverses `parent_map`/`child_map` with `depends_on.nodes` fallback when lineage maps are missing.
 - `ASTX.DBT.diffEntities(...)` compares two manifest snapshots deterministically with stable pagination and change typing (`added|removed|modified|unchanged`).
+- `ASTX.DBT.compareArtifacts(...)` compares two `manifest|catalog|run_results|sources` snapshots with normalized change typing (`added|removed|changed|unchanged`).
 - `ASTX.DBT.impact(...)` overlays lineage nodes with `run_results`, `catalog`, and `sources` artifact status when bundles/artifacts are supplied.
 - `ASTX.DBT.qualityReport(...)` returns documentation/ownership/test-coverage readiness metrics and top gap lists.
 - `ASTX.DBT.testCoverage(...)` reports per-entity test coverage with `uncoveredOnly` filtering.

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -1028,6 +1028,7 @@ Primary methods:
 - `ASTX.DBT.getColumn(request)`
 - `ASTX.DBT.lineage(request)`
 - `ASTX.DBT.diffEntities(request)`
+- `ASTX.DBT.compareArtifacts(request)`
 - `ASTX.DBT.impact(request)`
 - `ASTX.DBT.qualityReport(request)`
 - `ASTX.DBT.testCoverage(request)`
@@ -1108,6 +1109,21 @@ const impact = ASTX.DBT.impact({
 });
 
 Logger.log(impact.nodes);
+```
+
+Artifact comparison example:
+
+```javascript
+const compared = ASTX.DBT.compareArtifacts({
+  left: { type: 'run_results', bundle: priorRunResults.bundle },
+  right: { type: 'run_results', bundle: latestRunResults.bundle },
+  changeTypes: ['added', 'removed', 'changed'],
+  includeUnchanged: false,
+  page: { limit: 100, offset: 0 }
+});
+
+Logger.log(compared.summary);
+Logger.log(compared.items.slice(0, 10));
 ```
 
 Governance report example:

--- a/tests/local/dbt-artifacts-diff-impact.test.mjs
+++ b/tests/local/dbt-artifacts-diff-impact.test.mjs
@@ -11,6 +11,30 @@ import {
   createSourcesArtifactFixture
 } from './dbt-fixture.mjs';
 
+function createCatalogFixtureVariant() {
+  const next = JSON.parse(JSON.stringify(createCatalogFixture()));
+  next.nodes['model.demo.orders'].columns.amount.type = 'DECIMAL(18,2)';
+  next.nodes['model.demo.payments'] = {
+    unique_id: 'model.demo.payments',
+    resource_type: 'model',
+    package_name: 'demo',
+    name: 'payments',
+    original_file_path: 'models/marts/payments.sql',
+    database: 'analytics',
+    schema: 'marts',
+    alias: 'payments',
+    relation_name: 'analytics.marts.payments',
+    columns: {
+      payment_id: {
+        name: 'payment_id',
+        type: 'STRING'
+      }
+    }
+  };
+  delete next.sources['source.demo.raw_orders'];
+  return next;
+}
+
 test('AST.DBT.loadArtifact + inspectArtifact supports run_results artifact', () => {
   const context = createGasContext();
   loadDbtScripts(context, { includeStorage: false, includeAst: true });
@@ -246,4 +270,101 @@ test('AST.DBT.run routes new dbt artifact and diff/impact operations', () => {
 
   assert.equal(impact.status, 'ok');
   assert.equal(Array.isArray(impact.nodes), true);
+});
+
+test('AST.DBT.compareArtifacts compares manifest bundles with changed taxonomy', () => {
+  const context = createGasContext();
+  loadDbtScripts(context, { includeStorage: false, includeAst: true });
+
+  const leftBundle = context.AST.DBT.loadManifest({
+    manifest: createManifestFixture(),
+    options: {
+      validate: 'strict',
+      buildIndex: true
+    }
+  }).bundle;
+
+  const rightBundle = context.AST.DBT.loadManifest({
+    manifest: createManifestFixtureVariant(),
+    options: {
+      validate: 'strict',
+      buildIndex: true
+    }
+  }).bundle;
+
+  const compared = context.AST.DBT.compareArtifacts({
+    left: { type: 'manifest', bundle: leftBundle },
+    right: { type: 'manifest', bundle: rightBundle },
+    page: { limit: 100, offset: 0 },
+    includeUnchanged: false
+  });
+
+  assert.equal(compared.status, 'ok');
+  assert.equal(compared.artifactType, 'manifest');
+  assert.equal(compared.summary.added >= 1, true);
+  assert.equal(compared.summary.removed >= 1, true);
+  assert.equal(compared.summary.changed >= 1, true);
+  assert.equal(compared.items.some(item => item.changeType === 'changed'), true);
+});
+
+test('AST.DBT.compareArtifacts compares catalog artifacts deterministically', () => {
+  const context = createGasContext();
+  loadDbtScripts(context, { includeStorage: false, includeAst: true });
+
+  const compared = context.AST.DBT.compareArtifacts({
+    left: {
+      type: 'catalog',
+      artifact: createCatalogFixture()
+    },
+    right: {
+      type: 'catalog',
+      artifact: createCatalogFixtureVariant()
+    },
+    changeTypes: ['added', 'removed', 'changed'],
+    page: { limit: 100, offset: 0 }
+  });
+
+  assert.equal(compared.status, 'ok');
+  assert.equal(compared.artifactType, 'catalog');
+  assert.equal(compared.summary.added, 1);
+  assert.equal(compared.summary.removed, 1);
+  assert.equal(compared.summary.changed, 1);
+
+  const ordered = compared.items.map(item => item.uniqueId);
+  const sorted = ordered.slice().sort();
+  assert.deepEqual(ordered, sorted);
+});
+
+test('AST.DBT.run routes compare_artifacts operation', () => {
+  const context = createGasContext();
+  loadDbtScripts(context, { includeStorage: false, includeAst: true });
+
+  const response = context.AST.DBT.run({
+    operation: 'compare_artifacts',
+    left: {
+      type: 'run_results',
+      artifact: createRunResultsFixture()
+    },
+    right: {
+      type: 'run_results',
+      artifact: {
+        ...createRunResultsFixture(),
+        results: [
+          {
+            unique_id: 'model.demo.orders',
+            status: 'error',
+            execution_time: 4.2,
+            thread_id: 'Thread-1',
+            message: 'failed',
+            failures: 1
+          }
+        ]
+      }
+    }
+  });
+
+  assert.equal(response.status, 'ok');
+  assert.equal(response.artifactType, 'run_results');
+  assert.equal(response.summary.changed, 1);
+  assert.equal(response.summary.removed, 1);
 });

--- a/tests/local/dbt-errors.test.mjs
+++ b/tests/local/dbt-errors.test.mjs
@@ -38,6 +38,25 @@ test('AST.DBT.loadArtifact rejects unsupported artifactType', () => {
   );
 });
 
+test('AST.DBT.compareArtifacts rejects mismatched side types', () => {
+  const context = createGasContext();
+  loadDbtScripts(context, { includeStorage: false, includeAst: true });
+
+  assert.throws(
+    () => context.AST.DBT.compareArtifacts({
+      left: {
+        type: 'manifest',
+        manifest: createManifestFixture()
+      },
+      right: {
+        type: 'catalog',
+        artifact: {}
+      }
+    }),
+    /left and right side types to match/
+  );
+});
+
 test('AST.DBT.getEntity/getColumn throws typed not-found errors', () => {
   const context = createGasContext();
   loadDbtScripts(context, { includeStorage: false, includeAst: true });

--- a/tests/local/dbt-namespace.test.mjs
+++ b/tests/local/dbt-namespace.test.mjs
@@ -19,6 +19,7 @@ test('AST exposes DBT namespace and helper methods', () => {
   assert.equal(typeof context.AST.DBT.getColumn, 'function');
   assert.equal(typeof context.AST.DBT.lineage, 'function');
   assert.equal(typeof context.AST.DBT.diffEntities, 'function');
+  assert.equal(typeof context.AST.DBT.compareArtifacts, 'function');
   assert.equal(typeof context.AST.DBT.impact, 'function');
   assert.equal(typeof context.AST.DBT.qualityReport, 'function');
   assert.equal(typeof context.AST.DBT.testCoverage, 'function');


### PR DESCRIPTION
## Summary
Implements roadmap issue #198 by adding a first-class `AST.DBT.compareArtifacts(...)` API for deterministic artifact drift comparison across `manifest`, `catalog`, `run_results`, and `sources`.

Closes #198

## What changed
- Added new DBT operation: `compare_artifacts`
- Added public helper: `AST.DBT.compareArtifacts(request)`
- Added request validation for compare operations, including:
  - typed side descriptors (`left` / `right`)
  - supported side types (`manifest|catalog|run_results|sources`)
  - deterministic `changeTypes` (`added|removed|changed|unchanged`)
  - include/page normalization and side type mismatch errors
- Implemented comparison core with stable pagination-safe output:
  - summary counts (`leftCount`, `rightCount`, `added`, `removed`, `changed`, `unchanged`)
  - per-item change details and optional `diff.fieldChanges`
  - deterministic sorting by `uniqueId`
- Added catalog column signature comparison so column type/name drift is detected
- Updated DBT operation capabilities list

## Test updates
- Updated namespace coverage for new method:
  - `tests/local/dbt-namespace.test.mjs`
  - `apps_script_tools/testing/dbt/dbtNamespace.js`
- Added/extended compare coverage:
  - manifest bundle compare
  - catalog artifact compare
  - `AST.DBT.run({ operation: 'compare_artifacts', ... })` routing
  - mismatched side type validation

## Docs updates
- `docs/api/dbt-manifest-contracts.md`
- `docs/api/dbt-artifacts-impact.md`
- `docs/api/quick-reference.md`
- `docs/api/tools.md`
- `CHANGELOG.md`

## Verification
- `node --test tests/local/dbt-artifacts-diff-impact.test.mjs`
- `node --test tests/local/dbt-errors.test.mjs`
- `node --test tests/local/dbt-namespace.test.mjs`
- `npm run lint`
- `mkdocs build --strict`