### PR TITLE
fix(ci): harden workflow_dispatch input handling

### DIFF
--- a/.github/workflows/integration-ai-live.yml
+++ b/.github/workflows/integration-ai-live.yml
@@ -63,7 +63,12 @@ jobs:
           clasp-refresh-token: ${{ env.CLASP_REFRESH_TOKEN }}
 
       - name: Push and execute live AI smoke
+        env:
+          INPUT_PROVIDER: ${{ inputs.provider }}
+          INPUT_PROMPT: ${{ inputs.prompt }}
+          INPUT_MODEL: ${{ inputs.model }}
         run: |
           clasp status
           clasp push
-          clasp run runAiLiveSmoke --params "[\"${{ inputs.provider }}\",\"${{ inputs.prompt }}\",\"${{ inputs.model }}\"]"
+          AI_PARAMS="$(node -e "process.stdout.write(JSON.stringify([process.env.INPUT_PROVIDER || '', process.env.INPUT_PROMPT || '', process.env.INPUT_MODEL || '']))")"
+          clasp run runAiLiveSmoke --params "$AI_PARAMS"

--- a/.github/workflows/integration-gas.yml
+++ b/.github/workflows/integration-gas.yml
@@ -64,10 +64,12 @@ jobs:
           clasp-refresh-token: ${{ env.CLASP_REFRESH_TOKEN }}
 
       - name: Push and execute integration tests
+        env:
+          INPUT_SUITE: ${{ inputs.suite }}
         run: |
           clasp status
           clasp push
-          if [ "${{ inputs.suite }}" = "perf" ]; then
+          if [ "${INPUT_SUITE}" = "perf" ]; then
             clasp run runPerformanceBenchmarks
           else
             clasp run runAllTests

--- a/.github/workflows/integration-github-live.yml
+++ b/.github/workflows/integration-github-live.yml
@@ -53,8 +53,12 @@ jobs:
           clasp-refresh-token: ${{ env.CLASP_REFRESH_TOKEN }}
 
       - name: Push and execute GitHub live smoke
+        env:
+          INPUT_OWNER: ${{ inputs.owner }}
+          INPUT_REPO: ${{ inputs.repo }}
         run: |
           clasp status
           clasp push
           clasp run seedGitHubLiveSmokeToken --params "[\"${LIVE_GITHUB_TOKEN}\"]"
-          clasp run runGitHubLiveSmokeForRepo --params "[\"${{ inputs.owner }}\",\"${{ inputs.repo }}\"]"
+          GITHUB_PARAMS="$(node -e "process.stdout.write(JSON.stringify([process.env.INPUT_OWNER || '', process.env.INPUT_REPO || '']))")"
+          clasp run runGitHubLiveSmokeForRepo --params "$GITHUB_PARAMS"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,11 +65,24 @@ jobs:
 
       - name: Resolve tag
         id: resolve_tag
+        env:
+          WORKFLOW_EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          if [ "${WORKFLOW_EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ -z "${INPUT_TAG}" ]; then
+              echo "Dispatch input 'tag' must be non-empty" >&2
+              exit 1
+            fi
+            case "${INPUT_TAG}" in
+              *$'\n'*|*$'\r'*)
+                echo "Dispatch input 'tag' must not contain newlines" >&2
+                exit 1
+                ;;
+            esac
+            printf 'tag=%s\n' "${INPUT_TAG}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            printf 'tag=%s\n' "${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Verify tag exists


### PR DESCRIPTION
## Summary
- fixes #236
- remove direct `inputs.*` shell interpolation from workflow `run:` command strings
- pass dispatch inputs via step `env:` vars and consume as shell variables
- harden release tag resolution to reject empty/newline dispatch tag input

## Changes
- update `.github/workflows/integration-ai-live.yml`
- update `.github/workflows/integration-github-live.yml`
- update `.github/workflows/integration-gas.yml`
- update `.github/workflows/release.yml`

## Validation
- `npm run lint`