### PR TITLE
fix(ci): pin clasp version and add secret-scan permissions

### DIFF
--- a/.github/actions/setup-clasp/action.yml
+++ b/.github/actions/setup-clasp/action.yml
@@ -18,13 +18,21 @@ inputs:
   clasp-refresh-token:
     description: OAuth refresh token used by clasp.
     required: true
+  clasp-version:
+    description: Pinned @google/clasp version. Bump intentionally during dependency maintenance.
+    required: false
+    default: 2.4.2
 
 runs:
   using: composite
   steps:
     - name: Install clasp
       shell: bash
-      run: npm install -g @google/clasp
+      env:
+        CLASP_VERSION: ${{ inputs.clasp-version }}
+      run: |
+        set -euo pipefail
+        npm install -g "@google/clasp@${CLASP_VERSION}"
 
     - name: Configure clasp auth
       shell: bash

--- a/.github/workflows/security-secret-scan.yml
+++ b/.github/workflows/security-secret-scan.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   secret-scan:
     runs-on: ubuntu-latest

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -44,6 +44,7 @@ CI workflow config:
 
 - Set repository variable `GAS_SCRIPT_ID` for GitHub Actions integration workflows.
 - Set repository secrets: `CLASP_CLIENT_ID`, `CLASP_CLIENT_SECRET`, `CLASP_REFRESH_TOKEN`.
+- Keep the pinned clasp version in `.github/actions/setup-clasp/action.yml` (`clasp-version`) current; bump it intentionally and validate CI before release.
 
 Consumer validation (recommended):
 


### PR DESCRIPTION
## Summary
- fixes #241
- fixes #240
- add explicit least-privilege `permissions` block to secret-scan workflow
- pin `@google/clasp` version in `setup-clasp` composite action
- document clasp pin maintenance in release docs

## Changes
- `.github/workflows/security-secret-scan.yml`
- `.github/actions/setup-clasp/action.yml`
- `docs/development/release.md`

## Validation
- `npm run lint`