### PR TITLE
Enforce local coverage thresholds in CI (#243)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
           npm run lint
 
       - name: Local tests with coverage report
+        env:
+          COVERAGE_ENFORCE: 'true'
+          COVERAGE_MIN_LINES: '88'
+          COVERAGE_MIN_BRANCHES: '86'
+          COVERAGE_MIN_FUNCTIONS: '72'
+          COVERAGE_MIN_FILES: '88'
         run: npm run test:local:coverage
 
       - name: Publish coverage summary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,21 @@ Before opening a PR:
 5. `mkdocs build --strict` (for docs changes)
 6. `clasp push && clasp run runAllTests` (when Apps Script credentials are configured)
 
+Coverage threshold defaults enforced by the local coverage runner and CI:
+
+- lines: `88%`
+- branches: `86%`
+- functions: `72%`
+- files: `88%`
+
+Override for local experimentation via:
+
+- `COVERAGE_MIN_LINES`
+- `COVERAGE_MIN_BRANCHES`
+- `COVERAGE_MIN_FUNCTIONS`
+- `COVERAGE_MIN_FILES`
+- `COVERAGE_ENFORCE` (`true`/`false`)
+
 ## Code Standards
 
 - Keep public APIs under the `AST` namespace.

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -21,6 +21,24 @@ Local coverage report (uses Node test coverage, writes artifacts to `coverage/`)
 npm run test:local:coverage
 ```
 
+Coverage thresholds (default runner/CI values):
+
+- lines: `88%`
+- branches: `86%`
+- functions: `72%`
+- files: `88%`
+
+Optional local overrides:
+
+```bash
+COVERAGE_MIN_LINES=90 \
+COVERAGE_MIN_BRANCHES=88 \
+COVERAGE_MIN_FUNCTIONS=74 \
+COVERAGE_MIN_FILES=90 \
+COVERAGE_ENFORCE=true \
+npm run test:local:coverage
+```
+
 ## Local performance checks
 
 Report run:

--- a/scripts/run-local-coverage.mjs
+++ b/scripts/run-local-coverage.mjs
@@ -7,6 +7,12 @@ const COVERAGE_DIR = path.join(ROOT, 'coverage');
 const COVERAGE_LOG_PATH = path.join(COVERAGE_DIR, 'local-coverage.txt');
 const COVERAGE_SUMMARY_JSON_PATH = path.join(COVERAGE_DIR, 'local-coverage-summary.json');
 const COVERAGE_SUMMARY_MD_PATH = path.join(COVERAGE_DIR, 'local-coverage-summary.md');
+const COVERAGE_DEFAULT_THRESHOLDS = Object.freeze({
+  linesPct: 88,
+  branchesPct: 86,
+  functionsPct: 72,
+  filesPct: 88
+});
 
 function toNumber(value, fallback) {
   const numeric = Number(value);
@@ -137,10 +143,10 @@ function writeCoverageArtifacts(payload, combinedOutput) {
 
 function main() {
   const thresholds = {
-    linesPct: toNumber(process.env.COVERAGE_MIN_LINES, 0),
-    branchesPct: toNumber(process.env.COVERAGE_MIN_BRANCHES, 0),
-    functionsPct: toNumber(process.env.COVERAGE_MIN_FUNCTIONS, 0),
-    filesPct: toNumber(process.env.COVERAGE_MIN_FILES, 0)
+    linesPct: toNumber(process.env.COVERAGE_MIN_LINES, COVERAGE_DEFAULT_THRESHOLDS.linesPct),
+    branchesPct: toNumber(process.env.COVERAGE_MIN_BRANCHES, COVERAGE_DEFAULT_THRESHOLDS.branchesPct),
+    functionsPct: toNumber(process.env.COVERAGE_MIN_FUNCTIONS, COVERAGE_DEFAULT_THRESHOLDS.functionsPct),
+    filesPct: toNumber(process.env.COVERAGE_MIN_FILES, COVERAGE_DEFAULT_THRESHOLDS.filesPct)
   };
   const enforceThresholds = parseBoolean(process.env.COVERAGE_ENFORCE, false);
   const testFiles = listLocalTestFiles();


### PR DESCRIPTION
## Summary
- closes #243
- set non-zero default coverage thresholds in `scripts/run-local-coverage.mjs`
- enable CI enforcement by setting `COVERAGE_ENFORCE=true` with explicit threshold env vars in `.github/workflows/ci.yml`
- document threshold defaults and override env vars in contributor/testing docs

## Thresholds
- lines: 88%
- branches: 86%
- functions: 72%
- files: 88%

## Why these values
- chosen from current baseline with safety margin to avoid flaky failures while still blocking meaningful regressions

## Validation
- `npm run lint`
- `npm run test:local:coverage`
- `COVERAGE_ENFORCE=true npm run test:local:coverage`