### PR TITLE
Add script-properties payload size guards for Cache and Jobs (#238)

### DIFF
--- a/apps_script_tools/cache/backends/scriptProperties.js
+++ b/apps_script_tools/cache/backends/scriptProperties.js
@@ -1,4 +1,62 @@
 let AST_CACHE_SCRIPT_PROPERTIES_STATS = {};
+const AST_CACHE_SCRIPT_PROPERTIES_MAX_VALUE_BYTES = 9000;
+
+function astCacheScriptPropertiesUtf8ByteLength(value) {
+  const normalized = String(value == null ? '' : value);
+
+  try {
+    if (
+      typeof Utilities !== 'undefined' &&
+      Utilities &&
+      typeof Utilities.newBlob === 'function'
+    ) {
+      return Utilities.newBlob(normalized).getBytes().length;
+    }
+  } catch (_error) {
+    // Fall through to deterministic JavaScript fallback.
+  }
+
+  try {
+    if (typeof TextEncoder !== 'undefined') {
+      return new TextEncoder().encode(normalized).length;
+    }
+  } catch (_error) {
+    // Fall through to deterministic JavaScript fallback.
+  }
+
+  return unescape(encodeURIComponent(normalized)).length;
+}
+
+function astCacheScriptPropertiesMeasureDocument(document) {
+  const serialized = JSON.stringify(document);
+  return {
+    serialized,
+    bytes: astCacheScriptPropertiesUtf8ByteLength(serialized)
+  };
+}
+
+function astCacheScriptPropertiesAssertEntryFitsLimit(entry, config) {
+  const limitBytes = AST_CACHE_SCRIPT_PROPERTIES_MAX_VALUE_BYTES;
+  const probe = astCacheScriptPropertiesDefaultDocument(config.namespace);
+  probe.entries = {
+    [entry.keyHash]: entry
+  };
+  const measured = astCacheScriptPropertiesMeasureDocument(probe);
+  if (measured.bytes <= limitBytes) {
+    return;
+  }
+
+  throw new AstCacheValidationError(
+    'Cache script_properties entry exceeds per-property byte limit',
+    {
+      backend: 'script_properties',
+      namespace: config.namespace,
+      keyHash: entry.keyHash,
+      bytes: measured.bytes,
+      limitBytes
+    }
+  );
+}
 
 function astCacheScriptPropertiesStats(namespace) {
   if (!AST_CACHE_SCRIPT_PROPERTIES_STATS[namespace]) {
@@ -82,13 +140,60 @@ function astCacheScriptPropertiesReadDocument(handle, propertyKey, namespace) {
   return parsed;
 }
 
-function astCacheScriptPropertiesWriteDocument(handle, propertyKey, document) {
+function astCacheScriptPropertiesTrimToMaxBytes(document, maxBytes, stats) {
+  const keys = Object.keys(document.entries || {});
+  if (keys.length === 0) {
+    return astCacheScriptPropertiesMeasureDocument(document);
+  }
+
+  keys.sort((left, right) => {
+    const leftStamp = Number(document.entries[left] && document.entries[left].updatedAtMs || 0);
+    const rightStamp = Number(document.entries[right] && document.entries[right].updatedAtMs || 0);
+    return leftStamp - rightStamp;
+  });
+
+  let measured = astCacheScriptPropertiesMeasureDocument(document);
+  let removed = 0;
+
+  for (let idx = 0; idx < keys.length && measured.bytes > maxBytes; idx += 1) {
+    delete document.entries[keys[idx]];
+    removed += 1;
+    measured = astCacheScriptPropertiesMeasureDocument(document);
+  }
+
+  if (removed > 0) {
+    stats.evictions += removed;
+  }
+
+  return measured;
+}
+
+function astCacheScriptPropertiesWriteDocument(handle, propertyKey, document, config, stats) {
   if (typeof handle.setProperty !== 'function') {
     throw new AstCacheCapabilityError('Script properties handle does not support setProperty');
   }
 
-  const serialized = JSON.stringify(document);
-  handle.setProperty(propertyKey, serialized);
+  const limitBytes = AST_CACHE_SCRIPT_PROPERTIES_MAX_VALUE_BYTES;
+  let measured = astCacheScriptPropertiesMeasureDocument(document);
+
+  if (measured.bytes > limitBytes) {
+    measured = astCacheScriptPropertiesTrimToMaxBytes(document, limitBytes, stats);
+  }
+
+  if (measured.bytes > limitBytes) {
+    throw new AstCacheValidationError(
+      'Cache script_properties payload exceeds per-property byte limit',
+      {
+        backend: 'script_properties',
+        namespace: config.namespace,
+        propertyKey,
+        bytes: measured.bytes,
+        limitBytes
+      }
+    );
+  }
+
+  handle.setProperty(propertyKey, measured.serialized);
 }
 
 function astCacheScriptPropertiesPruneExpired(document, nowMs, stats) {
@@ -142,7 +247,7 @@ function astCacheScriptPropertiesWithDocument(config, mutator) {
     astCacheScriptPropertiesPruneExpired(document, nowMs, stats);
     const result = mutator(document, nowMs, stats);
     document.updatedAtMs = nowMs;
-    astCacheScriptPropertiesWriteDocument(handle, propertyKey, document);
+    astCacheScriptPropertiesWriteDocument(handle, propertyKey, document, config, stats);
 
     return result;
   }, config);
@@ -183,6 +288,7 @@ function astCacheScriptPropertiesGet(keyHash, config) {
 function astCacheScriptPropertiesSet(entry, config) {
   return astCacheScriptPropertiesWithDocument(config, (document, nowMs, stats) => {
     const nextEntry = astCacheTouchEntry(entry, nowMs);
+    astCacheScriptPropertiesAssertEntryFitsLimit(nextEntry, config);
     document.entries[nextEntry.keyHash] = nextEntry;
     stats.sets += 1;
     astCacheScriptPropertiesTrimToMaxEntries(document, config.maxMemoryEntries, stats);

--- a/apps_script_tools/jobs/general/jobStore.js
+++ b/apps_script_tools/jobs/general/jobStore.js
@@ -3,6 +3,50 @@ const AST_JOBS_INDEX_BUCKET_COUNT = 16;
 const AST_JOBS_PREFIX_REGISTRY_KEY = 'AST_JOBS_PREFIX_REGISTRY';
 const AST_JOBS_LEGACY_SCAN_REGISTRY_KEY = 'AST_JOBS_LEGACY_SCAN_REGISTRY';
 const AST_JOBS_LOCATOR_PREFIX = 'AST_JOBS_LOCATOR_';
+const AST_JOBS_SCRIPT_PROPERTIES_MAX_VALUE_BYTES = 9000;
+
+function astJobsUtf8ByteLength(value) {
+  const normalized = String(value == null ? '' : value);
+
+  try {
+    if (
+      typeof Utilities !== 'undefined' &&
+      Utilities &&
+      typeof Utilities.newBlob === 'function'
+    ) {
+      return Utilities.newBlob(normalized).getBytes().length;
+    }
+  } catch (_error) {
+    // Fall through to deterministic JavaScript fallback.
+  }
+
+  try {
+    if (typeof TextEncoder !== 'undefined') {
+      return new TextEncoder().encode(normalized).length;
+    }
+  } catch (_error) {
+    // Fall through to deterministic JavaScript fallback.
+  }
+
+  return unescape(encodeURIComponent(normalized)).length;
+}
+
+function astJobsAssertScriptPropertySize(propertyKey, value) {
+  const bytes = astJobsUtf8ByteLength(value);
+  if (bytes <= AST_JOBS_SCRIPT_PROPERTIES_MAX_VALUE_BYTES) {
+    return;
+  }
+
+  throw new AstJobsValidationError(
+    'Jobs script_properties payload exceeds per-property byte limit',
+    {
+      backend: 'script_properties',
+      propertyKey: astJobsNormalizeString(propertyKey, ''),
+      bytes,
+      limitBytes: AST_JOBS_SCRIPT_PROPERTIES_MAX_VALUE_BYTES
+    }
+  );
+}
 
 function astJobsGetScriptPropertiesHandle() {
   if (
@@ -142,6 +186,10 @@ function astJobsWritePropertiesEntries(scriptProperties, entries = {}) {
   if (keys.length === 0) {
     return;
   }
+
+  keys.forEach(key => {
+    astJobsAssertScriptPropertySize(key, source[key]);
+  });
 
   if (typeof scriptProperties.setProperties === 'function') {
     scriptProperties.setProperties(source, false);

--- a/docs/getting-started/cache-quickstart.md
+++ b/docs/getting-started/cache-quickstart.md
@@ -141,6 +141,7 @@ function cacheLockExample() {
 
 - Backends: `memory`, `drive_json`, `script_properties`, `storage_json`.
 - For multi-instance durability, prefer `storage_json` with `CACHE_STORAGE_URI`.
+- `script_properties` writes enforce an Apps Script-safe per-property payload cap (`~9 KB` UTF-8). The backend evicts oldest entries first when possible; oversized payloads still fail with `AstCacheValidationError`.
 - `stats()` returns backend hit/miss counters and eviction metadata.
 - `invalidateByPrefix`/`invalidateByPredicate` are bounded scans (`maxScan` default `10000`).
 - `lock` ensures single-writer execution with timeout/lease controls.

--- a/docs/getting-started/jobs-quickstart.md
+++ b/docs/getting-started/jobs-quickstart.md
@@ -172,4 +172,5 @@ function jobsReduce_(ctx) {
 - `chain`, `enqueueMany`, and `mapReduce` compile to normal job steps and use the same retry/cancel/checkpoint semantics.
 - `moveToDlq`, `replayDlq`, and `purgeDlq` provide deterministic failed-job triage/replay lifecycle.
 - `schedule` bridges Jobs definitions into Triggers lifecycle with `dispatch.mode='jobs'`.
+- Jobs persisted in `script_properties` enforce an Apps Script-safe per-property payload cap (`~9 KB` UTF-8); oversized writes throw `AstJobsValidationError` with size details.
 - Keep job payloads compact; store large artifacts in `AST.Storage` and pass references.

--- a/tests/local/cache-runtime.test.mjs
+++ b/tests/local/cache-runtime.test.mjs
@@ -1468,6 +1468,75 @@ test('script_properties backend supports set/get/delete/clear', () => {
   assert.equal(context.AST.Cache.get('props:c'), null);
 });
 
+test('script_properties backend throws typed error when payload exceeds property byte limit', () => {
+  const properties = createPropertiesService();
+  const context = createGasContext({
+    PropertiesService: properties.service,
+    LockService: {
+      getScriptLock: () => ({
+        tryLock: () => true,
+        releaseLock: () => {}
+      })
+    }
+  });
+
+  loadCacheScripts(context, { includeAst: true });
+
+  context.AST.Cache.clearConfig();
+  context.AST.Cache.configure({
+    backend: 'script_properties',
+    namespace: 'props_oversized'
+  });
+
+  assert.throws(
+    () => context.AST.Cache.set('props:huge', { value: 'x'.repeat(12000) }),
+    error => {
+      assert.equal(error && error.name, 'AstCacheValidationError');
+      assert.match(String(error && error.message), /byte limit/i);
+      assert.equal(error && error.details && error.details.backend, 'script_properties');
+      assert.equal(error && error.details && error.details.limitBytes, 9000);
+      assert.equal(typeof (error && error.details && error.details.bytes), 'number');
+      assert.equal(error.details.bytes > error.details.limitBytes, true);
+      return true;
+    }
+  );
+});
+
+test('script_properties backend trims oldest entries to satisfy property byte limit', () => {
+  const properties = createPropertiesService();
+  const context = createGasContext({
+    PropertiesService: properties.service,
+    LockService: {
+      getScriptLock: () => ({
+        tryLock: () => true,
+        releaseLock: () => {}
+      })
+    }
+  });
+
+  loadCacheScripts(context, { includeAst: true });
+
+  context.AST.Cache.clearConfig();
+  context.AST.Cache.configure({
+    backend: 'script_properties',
+    namespace: 'props_trimmed',
+    maxMemoryEntries: 100
+  });
+
+  context.AST.Cache.set('props:oldest', { value: 'a'.repeat(5000) });
+  context.AST.Cache.set('props:newest', { value: 'b'.repeat(5000) });
+
+  assert.equal(context.AST.Cache.get('props:oldest'), null);
+  assert.equal(
+    JSON.stringify(context.AST.Cache.get('props:newest')),
+    JSON.stringify({ value: 'b'.repeat(5000) })
+  );
+
+  const stats = context.AST.Cache.stats();
+  assert.equal(stats.backend, 'script_properties');
+  assert.equal(stats.stats.evictions >= 1, true);
+});
+
 test('script_properties backend isolates collision-prone namespace names', () => {
   const properties = createPropertiesService();
   const context = createGasContext({

--- a/tests/local/jobs-runtime.test.mjs
+++ b/tests/local/jobs-runtime.test.mjs
@@ -739,6 +739,40 @@ test('AST.Jobs.run fails deterministically when step output is non-serializable'
   assert.equal(persisted.status, 'failed');
 });
 
+test('AST.Jobs.enqueue throws typed error when serialized job exceeds script-properties byte limit', () => {
+  const { context } = createJobsContext();
+  const propertyPrefix = `AST_JOBS_LOCAL_OVERSIZED_${Date.now()}_`;
+
+  context.jobsOversizedNoop = () => true;
+
+  assert.throws(
+    () => context.AST.Jobs.enqueue({
+      name: 'oversized-job-payload',
+      options: {
+        propertyPrefix
+      },
+      steps: [
+        {
+          id: 'oversized_step',
+          handler: 'jobsOversizedNoop',
+          payload: {
+            value: 'x'.repeat(12000)
+          }
+        }
+      ]
+    }),
+    error => {
+      assert.equal(error && error.name, 'AstJobsValidationError');
+      assert.match(String(error && error.message), /byte limit/i);
+      assert.equal(error && error.details && error.details.backend, 'script_properties');
+      assert.equal(error && error.details && error.details.limitBytes, 9000);
+      assert.equal(typeof (error && error.details && error.details.bytes), 'number');
+      assert.equal(error.details.bytes > error.details.limitBytes, true);
+      return true;
+    }
+  );
+});
+
 test('AST.Jobs.cancel rejects jobs currently marked as running', () => {
   const { context } = createJobsContext();
   const propertyPrefix = `AST_JOBS_LOCAL_RUNNING_CANCEL_${Date.now()}_`;


### PR DESCRIPTION
## Summary
- closes #238
- add deterministic per-property UTF-8 byte guards for `script_properties` writes in Cache and Jobs
- add cache write-side trimming path to evict oldest entries when aggregate cache document exceeds property byte limit
- add explicit oversized payload failures with typed errors and structured details (`bytes`, `limitBytes`, `propertyKey`/`namespace`)
- document script-properties capacity constraints in cache/jobs quickstarts

## Implementation details
### Cache (`script_properties` backend)
- enforce `~9 KB` per-property cap before write
- for aggregate document overflow, evict oldest cache entries first and retry serialization
- fail with `AstCacheValidationError` if payload still exceeds limit
- prevent silent drop for oversized single entries by validating single-entry envelope fit before insertion

### Jobs (`script_properties` store)
- validate every key/value pair before `setProperties`/`setProperty`
- fail with `AstJobsValidationError` when any entry exceeds limit

## Tests added
- `script_properties backend throws typed error when payload exceeds property byte limit`
- `script_properties backend trims oldest entries to satisfy property byte limit`
- `AST.Jobs.enqueue throws typed error when serialized job exceeds script-properties byte limit`

## Validation
- `npm run lint`
- `node --test tests/local/cache-runtime.test.mjs tests/local/jobs-runtime.test.mjs`
- `npm run test:local`
- `mkdocs build --strict`