### PR TITLE
Ensure DBFS chunked writes perform best-effort handle cleanup on failures (#239)

### DIFF
--- a/apps_script_tools/storage/dbfs/runDbfsStorage.js
+++ b/apps_script_tools/storage/dbfs/runDbfsStorage.js
@@ -253,36 +253,94 @@ function astDbfsWriteChunked({ request, config, bytes }) {
 
   let requestCount = 1;
 
-  for (let start = 0; start < bytes.length; start += AST_DBFS_WRITE_BLOCK_BYTES) {
-    const end = Math.min(bytes.length, start + AST_DBFS_WRITE_BLOCK_BYTES);
-    const slice = bytes.slice(start, end);
-    const chunkBase64 = astStorageBytesToBase64(slice);
+  try {
+    for (let start = 0; start < bytes.length; start += AST_DBFS_WRITE_BLOCK_BYTES) {
+      const end = Math.min(bytes.length, start + AST_DBFS_WRITE_BLOCK_BYTES);
+      const slice = bytes.slice(start, end);
+      const chunkBase64 = astStorageBytesToBase64(slice);
+
+      astDbfsRequest({
+        request,
+        config,
+        endpoint: 'add-block',
+        method: 'post',
+        payload: {
+          handle,
+          data: chunkBase64
+        }
+      });
+
+      requestCount += 1;
+    }
 
     astDbfsRequest({
       request,
       config,
-      endpoint: 'add-block',
+      endpoint: 'close',
       method: 'post',
       payload: {
-        handle,
-        data: chunkBase64
+        handle
       }
     });
 
     requestCount += 1;
+  } catch (error) {
+    let cleanupError = null;
+
+    try {
+      astDbfsRequest({
+        request,
+        config,
+        endpoint: 'close',
+        method: 'post',
+        payload: {
+          handle
+        }
+      });
+      requestCount += 1;
+    } catch (closeError) {
+      cleanupError = closeError;
+    }
+
+    if (error && typeof error === 'object') {
+      const details = astStorageIsPlainObject(error.details)
+        ? Object.assign({}, error.details)
+        : {};
+      details.cleanupClose = {
+        attempted: true,
+        succeeded: cleanupError == null,
+        error: cleanupError
+          ? {
+              name: astStorageNormalizeString(cleanupError.name, 'Error'),
+              message: astStorageNormalizeString(cleanupError.message, 'DBFS close cleanup failed')
+            }
+          : null
+      };
+      error.details = details;
+      throw error;
+    }
+
+    throw new AstStorageProviderError(
+      'DBFS chunked write failed',
+      {
+        provider: 'dbfs',
+        operation: request.operation,
+        uri: request.uri,
+        cleanupClose: {
+          attempted: true,
+          succeeded: cleanupError == null,
+          error: cleanupError
+            ? {
+                name: astStorageNormalizeString(cleanupError.name, 'Error'),
+                message: astStorageNormalizeString(cleanupError.message, 'DBFS close cleanup failed')
+              }
+            : null
+        }
+      },
+      error
+    );
   }
 
-  astDbfsRequest({
-    request,
-    config,
-    endpoint: 'close',
-    method: 'post',
-    payload: {
-      handle
-    }
-  });
-
-  requestCount += 1;
   return requestCount;
 }
 

--- a/tests/local/storage-dbfs.test.mjs
+++ b/tests/local/storage-dbfs.test.mjs
@@ -174,6 +174,142 @@ test('DBFS chunked write uses create/add-block/close for large payloads', () => 
   assert.equal(calls.some(call => call.url.includes('/dbfs/close')), true);
 });
 
+test('DBFS chunked write attempts best-effort close when add-block fails', () => {
+  const calls = [];
+
+  const context = createGasContext({
+    UrlFetchApp: {
+      fetch: (url, options = {}) => {
+        calls.push({ url, options });
+
+        if (url.includes('/dbfs/create')) {
+          return createResponse({ body: JSON.stringify({ handle: 22 }) });
+        }
+
+        if (url.includes('/dbfs/add-block')) {
+          return createResponse({
+            status: 500,
+            body: JSON.stringify({
+              error_code: 'INTERNAL_ERROR',
+              message: 'add-block failed'
+            })
+          });
+        }
+
+        if (url.includes('/dbfs/close')) {
+          return createResponse({ body: '{}' });
+        }
+
+        return createResponse({ body: '{}' });
+      }
+    },
+    PropertiesService: {
+      getScriptProperties: () => ({
+        getProperties: () => ({
+          DATABRICKS_HOST: 'dbc.example.com',
+          DATABRICKS_TOKEN: 'test-token'
+        })
+      })
+    }
+  });
+
+  loadStorageScripts(context);
+
+  const largeText = 'x'.repeat(2 * 1024 * 1024);
+  assert.throws(
+    () => context.astRunStorageRequest({
+      uri: 'dbfs:/mnt/data/large-fail.txt',
+      operation: 'write',
+      payload: {
+        text: largeText
+      }
+    }),
+    error => {
+      assert.equal(error.name, 'AstStorageProviderError');
+      assert.equal(error.details.cleanupClose.attempted, true);
+      assert.equal(error.details.cleanupClose.succeeded, true);
+      assert.equal(error.details.cleanupClose.error, null);
+      return true;
+    }
+  );
+
+  assert.equal(calls.some(call => call.url.includes('/dbfs/add-block')), true);
+  assert.equal(calls.some(call => call.url.includes('/dbfs/close')), true);
+});
+
+test('DBFS chunked write preserves original error and includes cleanup error details on close cleanup failure', () => {
+  const calls = [];
+  let closeAttempts = 0;
+
+  const context = createGasContext({
+    UrlFetchApp: {
+      fetch: (url, options = {}) => {
+        calls.push({ url, options });
+
+        if (url.includes('/dbfs/create')) {
+          return createResponse({ body: JSON.stringify({ handle: 33 }) });
+        }
+
+        if (url.includes('/dbfs/add-block')) {
+          return createResponse({
+            status: 500,
+            body: JSON.stringify({
+              error_code: 'INTERNAL_ERROR',
+              message: 'add-block exploded'
+            })
+          });
+        }
+
+        if (url.includes('/dbfs/close')) {
+          closeAttempts += 1;
+          return createResponse({
+            status: 500,
+            body: JSON.stringify({
+              error_code: 'INTERNAL_ERROR',
+              message: `close failed ${closeAttempts}`
+            })
+          });
+        }
+
+        return createResponse({ body: '{}' });
+      }
+    },
+    PropertiesService: {
+      getScriptProperties: () => ({
+        getProperties: () => ({
+          DATABRICKS_HOST: 'dbc.example.com',
+          DATABRICKS_TOKEN: 'test-token'
+        })
+      })
+    }
+  });
+
+  loadStorageScripts(context);
+
+  const largeText = 'x'.repeat(2 * 1024 * 1024);
+  assert.throws(
+    () => context.astRunStorageRequest({
+      uri: 'dbfs:/mnt/data/large-close-fail.txt',
+      operation: 'write',
+      payload: {
+        text: largeText
+      }
+    }),
+    error => {
+      assert.equal(error.name, 'AstStorageProviderError');
+      assert.equal(error.details.cleanupClose.attempted, true);
+      assert.equal(error.details.cleanupClose.succeeded, false);
+      assert.equal(error.details.cleanupClose.error.name, 'AstStorageProviderError');
+      assert.equal(typeof error.details.cleanupClose.error.message, 'string');
+      assert.equal(error.details.cleanupClose.error.message.length > 0, true);
+      return true;
+    }
+  );
+
+  assert.equal(calls.some(call => call.url.includes('/dbfs/add-block')), true);
+  assert.equal(calls.filter(call => call.url.includes('/dbfs/close')).length >= 1, true);
+});
+
 test('DBFS maps missing resources to AstStorageNotFoundError', () => {
   const context = createGasContext({
     UrlFetchApp: {


### PR DESCRIPTION
## Summary
- closes #239
- harden DBFS chunked write flow to always attempt best-effort `close` after chunk write failures
- preserve original failure as primary thrown error
- include cleanup attempt result (`cleanupClose`) on thrown error details

## Changes
- wrapped chunk add/close sequence in guarded `try/catch`
- on failure, attempt DBFS `close` with same handle in cleanup path
- attach deterministic cleanup metadata:
  - `attempted`
  - `succeeded`
  - optional cleanup error name/message
- maintain success-path behavior and request counting

## Tests
- existing success test retained
- added: cleanup close attempt after add-block failure
- added: cleanup close failure details are attached while primary error is preserved

## Validation
- `npm run lint`
- `node --test tests/local/storage-dbfs.test.mjs`