### PR TITLE
Use muteHttpExceptions and structured error mapping in Databricks SQL submit path (#244)

### DIFF
--- a/apps_script_tools/database/databricks/runDatabricksSql.js
+++ b/apps_script_tools/database/databricks/runDatabricksSql.js
@@ -106,6 +106,20 @@ function astDatabricksParseResponseBody(response) {
   }
 }
 
+function astDatabricksAssertSuccessfulResponse(response, errorMessage, details = {}) {
+  const statusCode = astDatabricksGetHttpStatus(response);
+  if (statusCode >= 200 && statusCode < 300) {
+    return;
+  }
+
+  const payload = astDatabricksParseResponseBody(response);
+  throw astBuildDatabricksSqlError(errorMessage, {
+    statusCode,
+    response: payload,
+    ...details
+  });
+}
+
 function astDatabricksSubmitStatement(apiBaseUrl, token, payload) {
   const response = UrlFetchApp.fetch(apiBaseUrl, {
     method: 'post',
@@ -113,10 +127,24 @@ function astDatabricksSubmitStatement(apiBaseUrl, token, payload) {
     headers: {
       Authorization: `Bearer ${token}`
     },
-    payload: JSON.stringify(payload)
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true
   });
 
-  return JSON.parse(response.getContentText());
+  astDatabricksAssertSuccessfulResponse(response, 'Databricks SQL submit request failed');
+
+  const parsed = astDatabricksParseResponseBody(response);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw astBuildDatabricksSqlError(
+      'Databricks SQL submit response was not valid JSON',
+      {
+        statusCode: astDatabricksGetHttpStatus(response),
+        response: parsed
+      }
+    );
+  }
+
+  return parsed;
 }
 
 function astExecuteDatabricksSqlDetailed(query, parameters, placeholders = {}, options = {}) {

--- a/tests/local/databricks-errors.test.mjs
+++ b/tests/local/databricks-errors.test.mjs
@@ -65,6 +65,75 @@ test('astRunDatabricksSql validates required Databricks parameters', () => {
   );
 });
 
+test('astRunDatabricksSql maps submit 401/403/500 responses to DatabricksSqlError with structured details', () => {
+  [401, 403, 500].forEach(statusCode => {
+    const context = createGasContext({
+      UrlFetchApp: {
+        fetch: () => ({
+          getResponseCode: () => statusCode,
+          getContentText: () => JSON.stringify({
+            error_code: 'REQUEST_FAILED',
+            message: `status-${statusCode}`
+          })
+        })
+      }
+    });
+
+    loadScripts(context, [
+      'apps_script_tools/database/general/replacePlaceHoldersInQuery.js',
+      'apps_script_tools/database/databricks/runDatabricksSql.js'
+    ]);
+
+    assert.throws(
+      () => context.astRunDatabricksSql('select 1', {
+        host: 'dbc.example.com',
+        sqlWarehouseId: 'warehouse-1',
+        schema: 'default',
+        token: 'token'
+      }),
+      error => {
+        assert.equal(error.name, 'DatabricksSqlError');
+        assert.equal(error.details.statusCode, statusCode);
+        assert.equal(error.details.response.error_code, 'REQUEST_FAILED');
+        assert.equal(error.details.response.message, `status-${statusCode}`);
+        return true;
+      }
+    );
+  });
+});
+
+test('astRunDatabricksSql throws parse-safe submit error when successful response is not JSON', () => {
+  const context = createGasContext({
+    UrlFetchApp: {
+      fetch: () => ({
+        getResponseCode: () => 200,
+        getContentText: () => 'not-json'
+      })
+    }
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/database/general/replacePlaceHoldersInQuery.js',
+    'apps_script_tools/database/databricks/runDatabricksSql.js'
+  ]);
+
+  assert.throws(
+    () => context.astRunDatabricksSql('select 1', {
+      host: 'dbc.example.com',
+      sqlWarehouseId: 'warehouse-1',
+      schema: 'default',
+      token: 'token'
+    }),
+    error => {
+      assert.equal(error.name, 'DatabricksSqlError');
+      assert.match(error.message, /submit response was not valid json/i);
+      assert.equal(error.details.statusCode, 200);
+      assert.equal(error.details.response, 'not-json');
+      return true;
+    }
+  );
+});
+
 test('astRunDatabricksSql rejects pollIntervalMs greater than maxWaitMs', () => {
   const context = createGasContext();
 


### PR DESCRIPTION
## Summary
- closes #244
- add `muteHttpExceptions: true` on Databricks SQL statement submit
- map submit 4xx/5xx responses to deterministic `DatabricksSqlError` with `statusCode` and parsed response body
- guard successful submit path with explicit JSON-shape validation

## Details
- new helper `astDatabricksAssertSuccessfulResponse(...)` centralizes HTTP status handling
- `astDatabricksSubmitStatement(...)` now:
  - sends submit with `muteHttpExceptions: true`
  - throws typed submit error on non-2xx with structured details
  - throws parse-safe typed error if 2xx body is not valid JSON object

## Tests
- submit error mapping for `401`, `403`, `500`
- submit success body parse-safety when body is non-JSON
- existing Databricks status/cancel tests remain green

## Validation
- `npm run lint`
- `node --test tests/local/databricks-errors.test.mjs tests/local/sql-execution-control.test.mjs`