### PR TITLE
feat(workspace): harden workspace helpers with typed errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,9 @@
 ### Changed
 
 - Module error base classes now implement `toJSON()` for stable serialized error envelopes (`name`, `message`, `details`, and nested `cause`) across `AST.AI`, `AST.Cache`, `AST.Chat`, `AST.Config`, `AST.DBT`, `AST.GitHub`, `AST.Http`, `AST.Jobs`, `AST.Messaging`, `AST.RAG`, `AST.Runtime`, `AST.Secrets`, `AST.Storage`, `AST.Telemetry`, and `AST.Triggers`.
+- Workspace helper functions now enforce typed validation and typed error mapping:
+  - `openSpreadsheetById`, `openSpreadsheetByUrl`, `readFileFromDrive`, `createFileInDrive`
+  - new workspace error hierarchy: `AstWorkspaceError`, `AstWorkspaceValidationError`, `AstWorkspaceNotFoundError`, `AstWorkspaceCapabilityError`, `AstWorkspaceProviderError`, `AstWorkspaceParseError`
 - `AST` namespace now exposes `AST.DBT`.
 - `AST` namespace now exposes `AST.Secrets`.
 - `AST` namespace now exposes `AST.Triggers`.

--- a/apps_script_tools/workspace/drive/createFileInDrive.js
+++ b/apps_script_tools/workspace/drive/createFileInDrive.js
@@ -1,43 +1,200 @@
-function createFileInDrive(fileType, fileName, { content = null, destinationFolder = null } = {}) {
+function createFileInDrive(fileType, fileName, options = {}) {
+  const normalizedFileType = astWorkspaceNormalizeCreateFileType_(fileType);
+  const normalizedFileName = astWorkspaceNormalizeCreateFileName_(fileName);
+  const normalizedOptions = astWorkspaceNormalizeCreateFileOptions_(options);
   let newFile;
 
-  switch (fileType) {
+  switch (normalizedFileType) {
     case `spreadsheet`:
-      newFile = SpreadsheetApp.create(fileName);
+      newFile = astWorkspaceRunCreateOperation_(
+        () => SpreadsheetApp.create(normalizedFileName),
+        normalizedFileType,
+        normalizedFileName
+      );
       break;
 
     case `document`:
-      newFile = DocumentApp.create(fileName);
+      newFile = astWorkspaceRunCreateOperation_(
+        () => DocumentApp.create(normalizedFileName),
+        normalizedFileType,
+        normalizedFileName
+      );
       break;
 
     case `presentation`:
-      newFile = SlidesApp.create(fileName);
+      newFile = astWorkspaceRunCreateOperation_(
+        () => SlidesApp.create(normalizedFileName),
+        normalizedFileType,
+        normalizedFileName
+      );
       break;
 
     case `form`:
-      newFile = FormApp.create(fileName);
+      newFile = astWorkspaceRunCreateOperation_(
+        () => FormApp.create(normalizedFileName),
+        normalizedFileType,
+        normalizedFileName
+      );
       break;
 
     case `json`:
-      if (!content || !Array.isArray(content)) throw new Error("Valid records are required to create a JSON file.");
-      const jsonContent = JSON.stringify(content, null, 2);
-      newFile = DriveApp.createFile(`${fileName}.json`, jsonContent);
+      astWorkspaceValidateCreateRecords_(normalizedOptions.content, normalizedFileType);
+      newFile = astWorkspaceRunCreateOperation_(
+        () => {
+          const jsonContent = JSON.stringify(normalizedOptions.content, null, 2);
+          return DriveApp.createFile(`${normalizedFileName}.json`, jsonContent);
+        },
+        normalizedFileType,
+        normalizedFileName
+      );
       break;
 
     case `csv`:
-        if (!content || !Array.isArray(content)) throw new Error("Valid records are required to create a CSV file.");
-        const csvContent = convertRecordsToCsvFormat(content);
-        newFile = DriveApp.createFile(`${fileName}.csv`, csvContent);
-        break;
+      astWorkspaceValidateCreateRecords_(normalizedOptions.content, normalizedFileType);
+      newFile = astWorkspaceRunCreateOperation_(
+        () => {
+          const csvContent = convertRecordsToCsvFormat(normalizedOptions.content);
+          return DriveApp.createFile(`${normalizedFileName}.csv`, csvContent);
+        },
+        normalizedFileType,
+        normalizedFileName
+      );
+      break;
 
     default:
-        throw new Error('Unsupported file type');
+      throw new AstWorkspaceCapabilityError('Unsupported file type', { fileType: normalizedFileType });
   }
 
-  if (destinationFolder) {
+  if (normalizedOptions.destinationFolder) {
+    astWorkspaceValidateDestinationFolder_(normalizedOptions.destinationFolder);
+
+    const normalizedFileId = astWorkspaceNormalizeCreateFileId_(newFile && newFile.getId && newFile.getId());
+    if (!normalizedFileId) {
+      throw new AstWorkspaceProviderError('Unable to resolve created file id', {
+        operation: 'drive.create',
+        fileType: normalizedFileType,
+        fileName: normalizedFileName
+      });
+    }
+
+    try {
       const file = DriveApp.getFileById(newFile.getId());
-      file.moveTo(destinationFolder);
+      if (!file) {
+        throw new AstWorkspaceNotFoundError('Created Drive file not found', {
+          operation: 'drive.create',
+          fileId: normalizedFileId,
+          fileType: normalizedFileType,
+          fileName: normalizedFileName
+        });
+      }
+      file.moveTo(normalizedOptions.destinationFolder);
+    } catch (error) {
+      throw astWorkspaceMapCreateDriveProviderError_(
+        'Unable to move created file to destination folder',
+        {
+          operation: 'drive.create',
+          fileId: normalizedFileId,
+          fileType: normalizedFileType,
+          fileName: normalizedFileName
+        },
+        error
+      );
+    }
   }
 
   return newFile;
-};
+}
+
+function astWorkspaceNormalizeCreateFileType_(fileType) {
+  const value = astWorkspaceNormalizeCreateString_(fileType, '').toLowerCase();
+  if (!value) {
+    throw new AstWorkspaceValidationError('fileType is required');
+  }
+  const supported = {
+    spreadsheet: true,
+    document: true,
+    presentation: true,
+    form: true,
+    json: true,
+    csv: true
+  };
+  if (!supported[value]) {
+    throw new AstWorkspaceValidationError('Unsupported file type', { fileType: value });
+  }
+  return value;
+}
+
+function astWorkspaceNormalizeCreateFileName_(fileName) {
+  const value = astWorkspaceNormalizeCreateString_(fileName, '');
+  if (!value) {
+    throw new AstWorkspaceValidationError('fileName is required');
+  }
+  return value;
+}
+
+function astWorkspaceNormalizeCreateFileOptions_(options) {
+  if (!options || typeof options !== 'object' || Array.isArray(options)) {
+    throw new AstWorkspaceValidationError('options must be an object');
+  }
+  return {
+    content: options.content == null ? null : options.content,
+    destinationFolder: options.destinationFolder == null ? null : options.destinationFolder
+  };
+}
+
+function astWorkspaceValidateCreateRecords_(records, fileType) {
+  if (!Array.isArray(records) || records.length === 0) {
+    throw new AstWorkspaceValidationError(
+      'Valid records are required to create this file type.',
+      { fileType: fileType }
+    );
+  }
+}
+
+function astWorkspaceValidateDestinationFolder_(destinationFolder) {
+  if (!destinationFolder || typeof destinationFolder !== 'object') {
+    throw new AstWorkspaceValidationError('destinationFolder must be a folder object');
+  }
+}
+
+function astWorkspaceNormalizeCreateFileId_(fileId) {
+  return astWorkspaceNormalizeCreateString_(fileId, '');
+}
+
+function astWorkspaceRunCreateOperation_(createFn, fileType, fileName) {
+  try {
+    return createFn();
+  } catch (error) {
+    throw astWorkspaceMapCreateDriveProviderError_(
+      'Unable to create file in Drive',
+      {
+        operation: 'drive.create',
+        fileType: fileType,
+        fileName: fileName
+      },
+      error
+    );
+  }
+}
+
+function astWorkspaceMapCreateDriveProviderError_(message, details, error) {
+  if (error && error.name && String(error.name).indexOf('AstWorkspace') === 0) {
+    return error;
+  }
+
+  const text = astWorkspaceNormalizeCreateString_(error && error.message, '').toLowerCase();
+  if (text.indexOf('not found') >= 0 || text.indexOf('no item with the given id') >= 0) {
+    return new AstWorkspaceNotFoundError(message, details, error);
+  }
+  return new AstWorkspaceProviderError(message, details, error);
+}
+
+function astWorkspaceNormalizeCreateString_(value, fallback = '') {
+  if (value == null) {
+    return fallback;
+  }
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  return value.trim();
+}

--- a/apps_script_tools/workspace/drive/readFileFromDrive.js
+++ b/apps_script_tools/workspace/drive/readFileFromDrive.js
@@ -1,20 +1,149 @@
 function readFileFromDrive(fileId, fileType, options = {}) {
-  const file = DriveApp.getFileById(fileId);
-  const content = file.getBlob().getDataAsString();
-  
-  switch (fileType.toLowerCase()) {
+  const normalizedFileId = astWorkspaceValidateDriveFileId_(fileId);
+  const normalizedFileType = astWorkspaceValidateDriveFileType_(fileType);
+  const normalizedOptions = astWorkspaceNormalizeReadFileOptions_(options);
+
+  const file = astWorkspaceOpenDriveFileById_(normalizedFileId);
+  let content = '';
+  try {
+    content = file.getBlob().getDataAsString();
+  } catch (error) {
+    throw new AstWorkspaceProviderError(
+      'Unable to read file content from Drive',
+      { operation: 'drive.read', fileId: normalizedFileId, fileType: normalizedFileType },
+      error
+    );
+  }
+
+  switch (normalizedFileType) {
     case 'txt':
       return content;
 
     case 'json':
-      return JSON.parse(content);
+      try {
+        return JSON.parse(content);
+      } catch (error) {
+        throw new AstWorkspaceParseError(
+          'Unable to parse JSON file content',
+          { operation: 'drive.read', fileId: normalizedFileId, fileType: normalizedFileType },
+          error
+        );
+      }
       
     case 'csv':
-      const { headerRow = 0, delimiter = ',' } = options;
-      const csvArrays = Utilities.parseCsv(content, delimiter);
-      return zipArraysIntoRecords(csvArrays, headerRow);
+      try {
+        const csvArrays = Utilities.parseCsv(content, normalizedOptions.delimiter);
+        return zipArraysIntoRecords(csvArrays, normalizedOptions.headerRow);
+      } catch (error) {
+        throw new AstWorkspaceParseError(
+          'Unable to parse CSV file content',
+          {
+            operation: 'drive.read',
+            fileId: normalizedFileId,
+            fileType: normalizedFileType,
+            delimiter: normalizedOptions.delimiter,
+            headerRow: normalizedOptions.headerRow
+          },
+          error
+        );
+      }
       
     default:
-      throw new Error('Unsupported file type. Use "txt", "json" or "csv".');
+      throw new AstWorkspaceCapabilityError('Unsupported file type. Use "txt", "json" or "csv".', {
+        operation: 'drive.read',
+        fileType: normalizedFileType
+      });
   }
-};
+}
+
+function astWorkspaceValidateDriveFileId_(fileId) {
+  const value = astWorkspaceNormalizeDriveString_(fileId, '');
+  if (!value) {
+    throw new AstWorkspaceValidationError('fileId is required');
+  }
+  return value;
+}
+
+function astWorkspaceValidateDriveFileType_(fileType) {
+  const value = astWorkspaceNormalizeDriveString_(fileType, '').toLowerCase();
+  if (!value) {
+    throw new AstWorkspaceValidationError('fileType is required');
+  }
+  const supported = { txt: true, json: true, csv: true };
+  if (!supported[value]) {
+    throw new AstWorkspaceValidationError('Unsupported file type. Use "txt", "json" or "csv".', {
+      fileType: value
+    });
+  }
+  return value;
+}
+
+function astWorkspaceNormalizeReadFileOptions_(options) {
+  if (options == null) {
+    return { headerRow: 0, delimiter: ',' };
+  }
+  if (!options || typeof options !== 'object' || Array.isArray(options)) {
+    throw new AstWorkspaceValidationError('options must be an object');
+  }
+
+  const out = {
+    headerRow: options.headerRow == null ? 0 : options.headerRow,
+    delimiter: options.delimiter == null ? ',' : options.delimiter
+  };
+
+  if (!Number.isFinite(out.headerRow) || Math.floor(out.headerRow) !== out.headerRow || out.headerRow < 0) {
+    throw new AstWorkspaceValidationError('options.headerRow must be a non-negative integer', {
+      headerRow: out.headerRow
+    });
+  }
+
+  out.delimiter = astWorkspaceNormalizeDriveString_(out.delimiter, '');
+  if (!out.delimiter) {
+    throw new AstWorkspaceValidationError('options.delimiter must be a non-empty string');
+  }
+
+  return out;
+}
+
+function astWorkspaceOpenDriveFileById_(fileId) {
+  let file = null;
+  try {
+    file = DriveApp.getFileById(fileId);
+  } catch (error) {
+    throw astWorkspaceMapDriveProviderError_(
+      'Unable to load file from Drive',
+      { operation: 'drive.read', fileId: fileId },
+      error
+    );
+  }
+
+  if (!file) {
+    throw new AstWorkspaceNotFoundError('Drive file not found', {
+      operation: 'drive.read',
+      fileId: fileId
+    });
+  }
+  return file;
+}
+
+function astWorkspaceMapDriveProviderError_(message, details, error) {
+  if (error && error.name && String(error.name).indexOf('AstWorkspace') === 0) {
+    return error;
+  }
+
+  const text = astWorkspaceNormalizeDriveString_(error && error.message, '').toLowerCase();
+  if (text.indexOf('not found') >= 0 || text.indexOf('no item with the given id') >= 0) {
+    return new AstWorkspaceNotFoundError(message, details, error);
+  }
+  return new AstWorkspaceProviderError(message, details, error);
+}
+
+function astWorkspaceNormalizeDriveString_(value, fallback = '') {
+  if (value == null) {
+    return fallback;
+  }
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  return value.trim();
+}

--- a/apps_script_tools/workspace/general/errors.js
+++ b/apps_script_tools/workspace/general/errors.js
@@ -1,0 +1,156 @@
+class AstWorkspaceError extends Error {
+  constructor(message, details = {}, cause = null) {
+    super(message);
+    this.name = 'AstWorkspaceError';
+    this.details = (
+      details != null
+      && typeof details === 'object'
+      && !Array.isArray(details)
+    ) ? details : {};
+
+    if (cause) {
+      this.cause = cause;
+    }
+  }
+
+  toJSON() {
+    const out = {
+      name: this.name,
+      message: this.message,
+      details: this.details
+    };
+    if (Object.prototype.hasOwnProperty.call(this, 'cause')) {
+      out.cause = astWorkspaceSerializeErrorCause_(this.cause);
+    }
+    return out;
+  }
+}
+
+class AstWorkspaceValidationError extends AstWorkspaceError {
+  constructor(message, details = {}, cause = null) {
+    super(message, details, cause);
+    this.name = 'AstWorkspaceValidationError';
+  }
+}
+
+class AstWorkspaceNotFoundError extends AstWorkspaceError {
+  constructor(message, details = {}, cause = null) {
+    super(message, details, cause);
+    this.name = 'AstWorkspaceNotFoundError';
+  }
+}
+
+class AstWorkspaceCapabilityError extends AstWorkspaceError {
+  constructor(message, details = {}, cause = null) {
+    super(message, details, cause);
+    this.name = 'AstWorkspaceCapabilityError';
+  }
+}
+
+class AstWorkspaceProviderError extends AstWorkspaceError {
+  constructor(message, details = {}, cause = null) {
+    super(message, details, cause);
+    this.name = 'AstWorkspaceProviderError';
+  }
+}
+
+class AstWorkspaceParseError extends AstWorkspaceError {
+  constructor(message, details = {}, cause = null) {
+    super(message, details, cause);
+    this.name = 'AstWorkspaceParseError';
+  }
+}
+
+function astWorkspaceSerializeErrorCause_(cause) {
+  if (cause == null) {
+    return cause;
+  }
+
+  let causeToJson = null;
+  if (cause && (typeof cause === 'object' || typeof cause === 'function')) {
+    try {
+      causeToJson = cause.toJSON;
+    } catch (_error) {
+      causeToJson = null;
+    }
+  }
+
+  if (typeof causeToJson === 'function') {
+    try {
+      return causeToJson.call(cause);
+    } catch (_error) {
+      // ignore serialization failures and fall back below
+    }
+  }
+
+  if (cause instanceof Error) {
+    return {
+      name: cause.name,
+      message: cause.message
+    };
+  }
+
+  if (typeof cause === 'object') {
+    return astWorkspaceCloneSerializableValue_(cause, []);
+  }
+
+  return { message: String(cause) };
+}
+
+function astWorkspaceCloneSerializableValue_(value, seen) {
+  if (value == null) {
+    return value;
+  }
+
+  if (typeof value !== 'object') {
+    return value;
+  }
+
+  for (let i = 0; i < seen.length; i += 1) {
+    if (seen[i] === value) {
+      return '[Circular]';
+    }
+  }
+
+  seen.push(value);
+  if (Array.isArray(value)) {
+    const outputArray = [];
+    for (let i = 0; i < value.length; i += 1) {
+      let entry;
+      try {
+        entry = value[i];
+      } catch (_error) {
+        outputArray.push('[Unserializable]');
+        continue;
+      }
+      outputArray.push(astWorkspaceCloneSerializableValue_(entry, seen));
+    }
+    seen.pop();
+    return outputArray;
+  }
+
+  const output = {};
+  const keys = Object.keys(value);
+  for (let i = 0; i < keys.length; i += 1) {
+    const key = keys[i];
+    if (key === 'toJSON') {
+      continue;
+    }
+
+    let entry;
+    try {
+      entry = value[key];
+    } catch (_error) {
+      output[key] = '[Unserializable]';
+      continue;
+    }
+
+    if (typeof entry === 'function') {
+      continue;
+    }
+
+    output[key] = astWorkspaceCloneSerializableValue_(entry, seen);
+  }
+  seen.pop();
+  return output;
+}

--- a/apps_script_tools/workspace/sheets/openSpreadsheetById.js
+++ b/apps_script_tools/workspace/sheets/openSpreadsheetById.js
@@ -1,3 +1,53 @@
 function openSpreadsheetById(spreadsheetId) {
-  return new EnhancedSpreadsheet(SpreadsheetApp.openById(spreadsheetId));
-};
+  const normalizedSpreadsheetId = astWorkspaceValidateSpreadsheetId_(spreadsheetId);
+
+  try {
+    const spreadsheet = SpreadsheetApp.openById(normalizedSpreadsheetId);
+    if (!spreadsheet) {
+      throw new AstWorkspaceNotFoundError(
+        'Spreadsheet not found',
+        { operation: 'sheets.open_by_id', spreadsheetId: normalizedSpreadsheetId }
+      );
+    }
+    return new EnhancedSpreadsheet(spreadsheet);
+  } catch (error) {
+    throw astWorkspaceMapSheetsProviderError_(
+      'Unable to open spreadsheet by id',
+      { operation: 'sheets.open_by_id', spreadsheetId: normalizedSpreadsheetId },
+      error
+    );
+  }
+}
+
+function astWorkspaceValidateSpreadsheetId_(spreadsheetId) {
+  const value = astWorkspaceNormalizeWorkspaceString_(spreadsheetId, '');
+  if (!value) {
+    throw new AstWorkspaceValidationError('spreadsheetId is required');
+  }
+  if (/^https?:\/\//i.test(value)) {
+    throw new AstWorkspaceValidationError('spreadsheetId must be an ID, not a URL', { spreadsheetId: value });
+  }
+  return value;
+}
+
+function astWorkspaceNormalizeWorkspaceString_(value, fallback = '') {
+  if (value == null) {
+    return fallback;
+  }
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  return value.trim();
+}
+
+function astWorkspaceMapSheetsProviderError_(message, details, error) {
+  if (error && error.name && String(error.name).indexOf('AstWorkspace') === 0) {
+    return error;
+  }
+
+  const text = astWorkspaceNormalizeWorkspaceString_(error && error.message, '').toLowerCase();
+  if (text.indexOf('not found') >= 0 || text.indexOf('cannot find') >= 0) {
+    return new AstWorkspaceNotFoundError(message, details, error);
+  }
+  return new AstWorkspaceProviderError(message, details, error);
+}

--- a/apps_script_tools/workspace/sheets/openSpreadsheetByUrl.js
+++ b/apps_script_tools/workspace/sheets/openSpreadsheetByUrl.js
@@ -1,3 +1,56 @@
 function openSpreadsheetByUrl(spreadsheetUrl) {
-  return new EnhancedSpreadsheet(SpreadsheetApp.openByUrl(spreadsheetUrl));
-};
+  const normalizedSpreadsheetUrl = astWorkspaceValidateSpreadsheetUrl_(spreadsheetUrl);
+
+  try {
+    const spreadsheet = SpreadsheetApp.openByUrl(normalizedSpreadsheetUrl);
+    if (!spreadsheet) {
+      throw new AstWorkspaceNotFoundError(
+        'Spreadsheet not found',
+        { operation: 'sheets.open_by_url', spreadsheetUrl: normalizedSpreadsheetUrl }
+      );
+    }
+    return new EnhancedSpreadsheet(spreadsheet);
+  } catch (error) {
+    throw astWorkspaceMapSheetsProviderErrorByUrl_(
+      'Unable to open spreadsheet by url',
+      { operation: 'sheets.open_by_url', spreadsheetUrl: normalizedSpreadsheetUrl },
+      error
+    );
+  }
+}
+
+function astWorkspaceValidateSpreadsheetUrl_(spreadsheetUrl) {
+  const value = astWorkspaceNormalizeWorkspaceUrlString_(spreadsheetUrl, '');
+  if (!value) {
+    throw new AstWorkspaceValidationError('spreadsheetUrl is required');
+  }
+  if (!/^https:\/\/docs\.google\.com\/spreadsheets\//i.test(value)) {
+    throw new AstWorkspaceValidationError(
+      'spreadsheetUrl must be a Google Sheets URL',
+      { spreadsheetUrl: value }
+    );
+  }
+  return value;
+}
+
+function astWorkspaceNormalizeWorkspaceUrlString_(value, fallback = '') {
+  if (value == null) {
+    return fallback;
+  }
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  return value.trim();
+}
+
+function astWorkspaceMapSheetsProviderErrorByUrl_(message, details, error) {
+  if (error && error.name && String(error.name).indexOf('AstWorkspace') === 0) {
+    return error;
+  }
+
+  const text = astWorkspaceNormalizeWorkspaceUrlString_(error && error.message, '').toLowerCase();
+  if (text.indexOf('not found') >= 0 || text.indexOf('cannot find') >= 0) {
+    return new AstWorkspaceNotFoundError(message, details, error);
+  }
+  return new AstWorkspaceProviderError(message, details, error);
+}

--- a/tests/local/workspace-drive.test.mjs
+++ b/tests/local/workspace-drive.test.mjs
@@ -55,6 +55,7 @@ test('createFileInDrive writes JSON and CSV files and supports destination folde
   });
 
   loadScripts(context, [
+    'apps_script_tools/workspace/general/errors.js',
     'apps_script_tools/utilities/records/convertRecordsToCsvFormat.js',
     'apps_script_tools/workspace/drive/createFileInDrive.js'
   ]);
@@ -85,6 +86,7 @@ test('readFileFromDrive reads CSV into record objects', () => {
   });
 
   loadScripts(context, [
+    'apps_script_tools/workspace/general/errors.js',
     'apps_script_tools/utilities/object/zipArraysIntoObject.js',
     'apps_script_tools/utilities/records/zipArraysIntoRecords.js',
     'apps_script_tools/workspace/drive/readFileFromDrive.js'
@@ -97,5 +99,89 @@ test('readFileFromDrive reads CSV into record objects', () => {
       { id: '1', name: 'Alice' },
       { id: '2', name: 'Bob' }
     ])
+  );
+});
+
+test('workspace drive helpers throw typed validation/not-found/parse errors', () => {
+  const mocks = buildDriveMocks();
+  const context = createGasContext({
+    DriveApp: mocks.DriveApp
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/workspace/general/errors.js',
+    'apps_script_tools/utilities/object/zipArraysIntoObject.js',
+    'apps_script_tools/utilities/records/zipArraysIntoRecords.js',
+    'apps_script_tools/workspace/drive/readFileFromDrive.js'
+  ]);
+
+  assert.throws(
+    () => context.readFileFromDrive('', 'csv'),
+    error => error && error.name === 'AstWorkspaceValidationError'
+  );
+
+  assert.throws(
+    () => context.readFileFromDrive('missing-file', 'csv'),
+    error => error && error.name === 'AstWorkspaceNotFoundError'
+  );
+
+  const brokenJsonFile = mocks.createDriveFile('broken.json', '{bad json');
+  assert.throws(
+    () => context.readFileFromDrive(brokenJsonFile.getId(), 'json'),
+    error => error && error.name === 'AstWorkspaceParseError'
+  );
+});
+
+test('createFileInDrive maps validation failures to typed workspace errors', () => {
+  const mocks = buildDriveMocks();
+  const context = createGasContext({
+    DriveApp: mocks.DriveApp,
+    SpreadsheetApp: mocks.SpreadsheetApp,
+    DocumentApp: mocks.DocumentApp,
+    SlidesApp: mocks.SlidesApp,
+    FormApp: mocks.FormApp
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/workspace/general/errors.js',
+    'apps_script_tools/utilities/records/convertRecordsToCsvFormat.js',
+    'apps_script_tools/workspace/drive/createFileInDrive.js'
+  ]);
+
+  assert.throws(
+    () => context.createFileInDrive('csv', 'dataset', { content: 'not-array' }),
+    error => error && error.name === 'AstWorkspaceValidationError'
+  );
+
+  assert.throws(
+    () => context.createFileInDrive('csv', 'dataset', { content: [{ id: 1 }], destinationFolder: 'folder-id' }),
+    error => error && error.name === 'AstWorkspaceValidationError'
+  );
+});
+
+test('createFileInDrive maps provider failures to typed workspace errors', () => {
+  const mocks = buildDriveMocks();
+  const context = createGasContext({
+    DriveApp: {
+      ...mocks.DriveApp,
+      createFile: () => {
+        throw new Error('permission denied');
+      }
+    },
+    SpreadsheetApp: mocks.SpreadsheetApp,
+    DocumentApp: mocks.DocumentApp,
+    SlidesApp: mocks.SlidesApp,
+    FormApp: mocks.FormApp
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/workspace/general/errors.js',
+    'apps_script_tools/utilities/records/convertRecordsToCsvFormat.js',
+    'apps_script_tools/workspace/drive/createFileInDrive.js'
+  ]);
+
+  assert.throws(
+    () => context.createFileInDrive('json', 'dataset', { content: [{ id: 1 }] }),
+    error => error && error.name === 'AstWorkspaceProviderError'
   );
 });

--- a/tests/local/workspace-sheets.test.mjs
+++ b/tests/local/workspace-sheets.test.mjs
@@ -44,6 +44,7 @@ test('workspace sheet helpers expose EnhancedSpreadsheet behavior', () => {
   });
 
   loadScripts(context, [
+    'apps_script_tools/workspace/general/errors.js',
     'apps_script_tools/workspace/sheets/EnhancedSheet.js',
     'apps_script_tools/workspace/sheets/EnhancedSpreadsheet.js',
     'apps_script_tools/workspace/sheets/openSpreadsheetById.js',
@@ -62,4 +63,60 @@ test('workspace sheet helpers expose EnhancedSpreadsheet behavior', () => {
 
   assert.equal(context.numberToSheetRangeNotation(1), 'A');
   assert.equal(context.numberToSheetRangeNotation(27), 'AA');
+});
+
+test('openSpreadsheetById and openSpreadsheetByUrl validate request inputs', () => {
+  const mocks = buildSpreadsheetMocks();
+  const context = createGasContext({
+    SpreadsheetApp: mocks.SpreadsheetApp
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/workspace/general/errors.js',
+    'apps_script_tools/workspace/sheets/EnhancedSheet.js',
+    'apps_script_tools/workspace/sheets/EnhancedSpreadsheet.js',
+    'apps_script_tools/workspace/sheets/openSpreadsheetById.js',
+    'apps_script_tools/workspace/sheets/openSpreadsheetByUrl.js'
+  ]);
+
+  assert.throws(
+    () => context.openSpreadsheetById('https://docs.google.com/spreadsheets/d/abc123'),
+    error => error && error.name === 'AstWorkspaceValidationError'
+  );
+
+  assert.throws(
+    () => context.openSpreadsheetByUrl('https://example.com/not-a-sheet'),
+    error => error && error.name === 'AstWorkspaceValidationError'
+  );
+});
+
+test('sheet open helpers map provider errors to typed workspace errors', () => {
+  const context = createGasContext({
+    SpreadsheetApp: {
+      openById: () => {
+        throw new Error('backend unavailable');
+      },
+      openByUrl: () => {
+        throw new Error('Spreadsheet not found');
+      }
+    }
+  });
+
+  loadScripts(context, [
+    'apps_script_tools/workspace/general/errors.js',
+    'apps_script_tools/workspace/sheets/EnhancedSheet.js',
+    'apps_script_tools/workspace/sheets/EnhancedSpreadsheet.js',
+    'apps_script_tools/workspace/sheets/openSpreadsheetById.js',
+    'apps_script_tools/workspace/sheets/openSpreadsheetByUrl.js'
+  ]);
+
+  assert.throws(
+    () => context.openSpreadsheetById('spreadsheet-id'),
+    error => error && error.name === 'AstWorkspaceProviderError'
+  );
+
+  assert.throws(
+    () => context.openSpreadsheetByUrl('https://docs.google.com/spreadsheets/d/sheet-id'),
+    error => error && error.name === 'AstWorkspaceNotFoundError'
+  );
 });


### PR DESCRIPTION
## Summary
- add workspace error hierarchy in workspace/general/errors.js
- harden openSpreadsheetById, openSpreadsheetByUrl, readFileFromDrive, and createFileInDrive with deterministic validation and typed error mapping
- map provider/not-found/parse failures to workspace typed errors instead of plain Error
- add local tests for validation, not-found, parse, and provider failure paths for workspace sheets/drive helpers
- update unreleased changelog with workspace hardening changes

## Validation
- npm run lint
- node --test tests/local/workspace-sheets.test.mjs tests/local/workspace-drive.test.mjs tests/local/ast-facade-integration.test.mjs

Closes #249