### PR TITLE
refactor(ai): dedupe openai/openrouter response parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@
 - Workspace helper functions now enforce typed validation and typed error mapping:
   - `openSpreadsheetById`, `openSpreadsheetByUrl`, `readFileFromDrive`, `createFileInDrive`
   - new workspace error hierarchy: `AstWorkspaceError`, `AstWorkspaceValidationError`, `AstWorkspaceNotFoundError`, `AstWorkspaceCapabilityError`, `AstWorkspaceProviderError`, `AstWorkspaceParseError`
+- OpenAI/OpenRouter response parsing is now centralized through a shared OpenAI-compatible parser helper, with regression coverage for equivalent text/tool and structured parsing envelopes.
 - `AST` namespace now exposes `AST.DBT`.
 - `AST` namespace now exposes `AST.Secrets`.
 - `AST` namespace now exposes `AST.Triggers`.

--- a/apps_script_tools/ai/general/providerPayloadHelpers.js
+++ b/apps_script_tools/ai/general/providerPayloadHelpers.js
@@ -235,6 +235,40 @@ function astAiExtractOpenAiToolCalls(message) {
   });
 }
 
+function astAiParseOpenAiCompatibleResponse(responseJson = {}, request = {}, config = {}, options = {}) {
+  const choice = responseJson.choices && responseJson.choices[0]
+    ? responseJson.choices[0]
+    : {};
+  const message = choice.message || {};
+
+  const text = astAiExtractOpenAiText(message.content);
+  const toolCalls = astAiExtractOpenAiToolCalls(message);
+
+  let structuredJson = null;
+  if (request.operation === 'structured') {
+    structuredJson = astAiSafeJsonParse(text);
+  }
+
+  const useUnixCreatedAt = options.useUnixCreatedAt === true;
+  const createdAt = useUnixCreatedAt
+    && Number.isFinite(responseJson.created)
+    ? new Date(responseJson.created * 1000).toISOString()
+    : new Date().toISOString();
+
+  return {
+    model: responseJson.model || config.model,
+    id: responseJson.id || '',
+    createdAt,
+    finishReason: choice.finish_reason || null,
+    output: {
+      text,
+      json: structuredJson,
+      toolCalls
+    },
+    usage: responseJson.usage || {}
+  };
+}
+
 function astAiPromptFromMessages(messages) {
   for (let idx = messages.length - 1; idx >= 0; idx--) {
     const message = messages[idx];

--- a/apps_script_tools/ai/openai/runOpenAi.js
+++ b/apps_script_tools/ai/openai/runOpenAi.js
@@ -118,34 +118,19 @@ function astRunOpenAi(request, config) {
   });
 
   const responseJson = response.json || {};
-  const choice = responseJson.choices && responseJson.choices[0]
-    ? responseJson.choices[0]
-    : {};
-  const message = choice.message || {};
-
-  const text = astAiExtractOpenAiText(message.content);
-  const toolCalls = astAiExtractOpenAiToolCalls(message);
-
-  let structuredJson = null;
-  if (request.operation === 'structured') {
-    structuredJson = astAiSafeJsonParse(text);
-  }
+  const parsed = astAiParseOpenAiCompatibleResponse(responseJson, request, config, {
+    useUnixCreatedAt: true
+  });
 
   return astNormalizeAiResponse({
     provider: 'openai',
     operation: request.operation,
-    model: responseJson.model || config.model,
-    id: responseJson.id || '',
-    createdAt: responseJson.created
-      ? new Date(responseJson.created * 1000).toISOString()
-      : new Date().toISOString(),
-    finishReason: choice.finish_reason || null,
-    output: {
-      text,
-      json: structuredJson,
-      toolCalls
-    },
-    usage: responseJson.usage || {},
+    model: parsed.model,
+    id: parsed.id,
+    createdAt: parsed.createdAt,
+    finishReason: parsed.finishReason,
+    output: parsed.output,
+    usage: parsed.usage,
     raw: responseJson,
     includeRaw
   });

--- a/apps_script_tools/ai/openrouter/runOpenRouter.js
+++ b/apps_script_tools/ai/openrouter/runOpenRouter.js
@@ -121,31 +121,19 @@ function astRunOpenRouter(request, config) {
   });
 
   const responseJson = response.json || {};
-  const choice = responseJson.choices && responseJson.choices[0]
-    ? responseJson.choices[0]
-    : {};
-  const message = choice.message || {};
-  const text = astAiExtractOpenAiText(message.content);
-  const toolCalls = astAiExtractOpenAiToolCalls(message);
-
-  let structuredJson = null;
-  if (request.operation === 'structured') {
-    structuredJson = astAiSafeJsonParse(text);
-  }
+  const parsed = astAiParseOpenAiCompatibleResponse(responseJson, request, config, {
+    useUnixCreatedAt: false
+  });
 
   return astNormalizeAiResponse({
     provider: 'openrouter',
     operation: request.operation,
-    model: responseJson.model || config.model,
-    id: responseJson.id || '',
-    createdAt: new Date().toISOString(),
-    finishReason: choice.finish_reason || null,
-    output: {
-      text,
-      json: structuredJson,
-      toolCalls
-    },
-    usage: responseJson.usage || {},
+    model: parsed.model,
+    id: parsed.id,
+    createdAt: parsed.createdAt,
+    finishReason: parsed.finishReason,
+    output: parsed.output,
+    usage: parsed.usage,
     raw: responseJson,
     includeRaw
   });

--- a/tests/local/ai-providers-structured.test.mjs
+++ b/tests/local/ai-providers-structured.test.mjs
@@ -135,6 +135,56 @@ test('astRunOpenRouter parses structured output', () => {
   assert.equal(JSON.stringify(output.output.json), JSON.stringify({ ok: true, source: 'openrouter' }));
 });
 
+test('astRunOpenAi and astRunOpenRouter produce equivalent structured parsing for same envelope', () => {
+  const completionEnvelope = {
+    id: 'shared_1',
+    created: 1700000000,
+    model: 'shared/model',
+    choices: [{
+      finish_reason: 'stop',
+      message: { content: '{"ok":true,"shared":true}' }
+    }],
+    usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 }
+  };
+
+  const openAiContext = createGasContext({
+    UrlFetchApp: {
+      fetch: () => asResponse(completionEnvelope)
+    }
+  });
+  loadAiScripts(openAiContext);
+
+  const openRouterContext = createGasContext({
+    UrlFetchApp: {
+      fetch: () => asResponse(completionEnvelope)
+    }
+  });
+  loadAiScripts(openRouterContext);
+
+  const openAiOut = openAiContext.astRunOpenAi(structuredRequest('openai'), {
+    provider: 'openai',
+    apiKey: 'key',
+    model: 'shared/model'
+  });
+
+  const openRouterOut = openRouterContext.astRunOpenRouter(
+    structuredRequest('openrouter'),
+    {
+      provider: 'openrouter',
+      apiKey: 'key',
+      model: 'shared/model'
+    }
+  );
+
+  assert.equal(
+    JSON.stringify(openAiOut.output.json),
+    JSON.stringify(openRouterOut.output.json)
+  );
+  assert.equal(openAiOut.output.text, openRouterOut.output.text);
+  assert.equal(openAiOut.finishReason, openRouterOut.finishReason);
+  assert.equal(openAiOut.usage.totalTokens, openRouterOut.usage.totalTokens);
+});
+
 test('astRunPerplexity parses structured output', () => {
   const context = createGasContext({
     UrlFetchApp: {

--- a/tests/local/ai-providers-text.test.mjs
+++ b/tests/local/ai-providers-text.test.mjs
@@ -253,6 +253,70 @@ test('astRunOpenRouter normalizes text output', () => {
   assert.equal(output.provider, 'openrouter');
 });
 
+test('astRunOpenAi and astRunOpenRouter produce equivalent text/tool parsing for same envelope', () => {
+  const completionEnvelope = {
+    id: 'cmp_1',
+    created: 1700000000,
+    model: 'shared/model',
+    choices: [{
+      finish_reason: 'stop',
+      message: {
+        content: [
+          { type: 'text', text: 'hello ' },
+          { type: 'text', value: 'world' }
+        ],
+        tool_calls: [{
+          id: 'tool_call_1',
+          type: 'function',
+          function: {
+            name: 'lookup',
+            arguments: '{"id":42}'
+          }
+        }]
+      }
+    }],
+    usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 }
+  };
+
+  const openAiContext = createGasContext({
+    UrlFetchApp: {
+      fetch: () => asResponse(completionEnvelope)
+    }
+  });
+  loadAiScripts(openAiContext);
+
+  const openRouterContext = createGasContext({
+    UrlFetchApp: {
+      fetch: () => asResponse(completionEnvelope)
+    }
+  });
+  loadAiScripts(openRouterContext);
+
+  const openAiOut = openAiContext.astRunOpenAi(baseRequest('text'), {
+    provider: 'openai',
+    apiKey: 'key',
+    model: 'shared/model'
+  });
+
+  const openRouterOut = openRouterContext.astRunOpenRouter(
+    Object.assign(baseRequest('text'), { provider: 'openrouter' }),
+    {
+      provider: 'openrouter',
+      apiKey: 'key',
+      model: 'shared/model'
+    }
+  );
+
+  assert.equal(openAiOut.output.text, 'hello world');
+  assert.equal(openRouterOut.output.text, 'hello world');
+  assert.equal(openAiOut.finishReason, openRouterOut.finishReason);
+  assert.equal(openAiOut.usage.totalTokens, openRouterOut.usage.totalTokens);
+  assert.equal(
+    JSON.stringify(openAiOut.output.toolCalls),
+    JSON.stringify(openRouterOut.output.toolCalls)
+  );
+});
+
 test('astRunPerplexity normalizes text output', () => {
   const context = createGasContext({
     UrlFetchApp: {


### PR DESCRIPTION
## Summary
- extract shared OpenAI-compatible completion parser in AI general payload helpers
- refactor astRunOpenAi and astRunOpenRouter to use the shared parser while preserving provider-specific transport configuration and timestamp behavior
- add regression tests proving equivalent parse output for OpenAI/OpenRouter on identical text+tool and structured envelopes
- update unreleased changelog entry for parser deduplication

## Validation
- npm run lint
- node --test tests/local/ai-providers-text.test.mjs tests/local/ai-providers-structured.test.mjs
- node --test tests/local/ai-routing.test.mjs

Closes #250