### PR TITLE
docs(jsdoc): expand facade request/response contracts (#251)

### DIFF
--- a/apps_script_tools/ai/AI.js
+++ b/apps_script_tools/ai/AI.js
@@ -1,57 +1,151 @@
+/**
+ * @typedef {Object} AstAiFacadeRequest
+ * @property {string} [provider]
+ * @property {string} [operation]
+ * @property {string} [model]
+ * @property {Array<Object>} [messages]
+ * @property {Object} [options]
+ * @property {Object} [auth]
+ * @property {Object} [providerOptions]
+ */
+
+/**
+ * Runs an AI request using the normalized AST.AI operation contract.
+ *
+ * @param {AstAiFacadeRequest} [request={}] AI request payload.
+ * @returns {Object} Provider-normalized AI response.
+ * @throws {AstAiValidationError|AstAiAuthError|AstAiProviderError}
+ */
 function astAiRun(request = {}) {
   return astRunAiRequest(request);
 }
 
+/**
+ * Runs a text completion/chat operation.
+ *
+ * @param {AstAiFacadeRequest} [request={}] AI request payload.
+ * @returns {Object} Provider-normalized text response.
+ */
 function astAiText(request = {}) {
   return astRunAiRequest(Object.assign({}, request, { operation: 'text' }));
 }
 
+/**
+ * Runs a structured output operation.
+ *
+ * @param {AstAiFacadeRequest} [request={}] AI request payload.
+ * @returns {Object} Provider-normalized structured response.
+ */
 function astAiStructured(request = {}) {
   return astRunAiRequest(Object.assign({}, request, { operation: 'structured' }));
 }
 
+/**
+ * Runs a tool-calling operation.
+ *
+ * @param {AstAiFacadeRequest} [request={}] AI request payload.
+ * @returns {Object} Provider-normalized tools response.
+ */
 function astAiTools(request = {}) {
   return astRunAiRequest(Object.assign({}, request, { operation: 'tools' }));
 }
 
+/**
+ * Runs an image operation for providers that support it.
+ *
+ * @param {AstAiFacadeRequest} [request={}] AI request payload.
+ * @returns {Object} Provider-normalized image response.
+ */
 function astAiImage(request = {}) {
   return astRunAiRequest(Object.assign({}, request, { operation: 'image' }));
 }
 
+/**
+ * Runs a synthetic stream-mode AI operation.
+ *
+ * @param {AstAiFacadeRequest} [request={}] AI request payload.
+ * @returns {Object} Provider-normalized stream response.
+ */
 function astAiStream(request = {}) {
   return astRunAiRequest(Object.assign({}, request, {
     options: Object.assign({}, request.options || {}, { stream: true })
   }));
 }
 
+/**
+ * Estimates token usage for model input.
+ *
+ * @param {Object} [request={}] Token estimation request.
+ * @returns {Object} Token estimation output.
+ */
 function astAiEstimateTokensApi(request = {}) {
   return astAiEstimateTokens(request);
 }
 
+/**
+ * Truncates message arrays to fit model limits.
+ *
+ * @param {Object} [request={}] Truncation request.
+ * @returns {Object} Truncation output.
+ */
 function astAiTruncateMessagesApi(request = {}) {
   return astAiTruncateMessages(request);
 }
 
+/**
+ * Renders an AI prompt template with variables.
+ *
+ * @param {Object} [request={}] Prompt template request.
+ * @returns {Object} Rendered template output.
+ */
 function astAiRenderPromptTemplateApi(request = {}) {
   return astAiRenderPromptTemplate(request);
 }
 
+/**
+ * Lists registered AI providers.
+ *
+ * @returns {string[]} Provider names.
+ */
 function astAiProviders() {
   return AST_AI_PROVIDERS.slice();
 }
 
+/**
+ * Returns operation capabilities for a provider.
+ *
+ * @param {string} provider Provider key.
+ * @returns {Object} Capability matrix.
+ */
 function astAiCapabilities(provider) {
   return astGetAiCapabilities(provider);
 }
 
+/**
+ * Sets runtime AI configuration overrides.
+ *
+ * @param {Object} [config={}] Runtime config patch.
+ * @param {Object} [options={}] Configure behavior options.
+ * @returns {Object} Updated runtime config snapshot.
+ */
 function astAiConfigure(config = {}, options = {}) {
   return astSetAiRuntimeConfig(config, options);
 }
 
+/**
+ * Gets current resolved AI runtime config.
+ *
+ * @returns {Object} Runtime config snapshot.
+ */
 function astAiGetConfig() {
   return astGetAiRuntimeConfig();
 }
 
+/**
+ * Clears runtime AI configuration overrides.
+ *
+ * @returns {Object} Cleared runtime config snapshot.
+ */
 function astAiClearConfig() {
   return astClearAiRuntimeConfig();
 }

--- a/apps_script_tools/cache/Cache.js
+++ b/apps_script_tools/cache/Cache.js
@@ -1,47 +1,143 @@
+/**
+ * @typedef {Object} AstCacheOptions
+ * @property {string} [backend]
+ * @property {string} [namespace]
+ * @property {number} [ttlSec]
+ * @property {boolean} [includeExpired]
+ */
+
+/**
+ * Gets a cached value by key.
+ *
+ * @param {string} key Cache key.
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Normalized cache read response.
+ */
 function astCacheApiGet(key, options = {}) {
   return astCacheGetValue(key, options);
 }
 
+/**
+ * Sets a cached value.
+ *
+ * @param {string} key Cache key.
+ * @param {*} value Value to cache.
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Normalized cache write response.
+ */
 function astCacheApiSet(key, value, options = {}) {
   return astCacheSetValue(key, value, options);
 }
 
+/**
+ * Gets multiple cached values by key list.
+ *
+ * @param {string[]} keys Cache keys.
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Normalized cache read-many response.
+ */
 function astCacheApiGetMany(keys, options = {}) {
   return astCacheGetManyValues(keys, options);
 }
 
+/**
+ * Sets multiple cache entries in a single operation.
+ *
+ * @param {Array<Object>} entries Cache entry records.
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Normalized cache write-many response.
+ */
 function astCacheApiSetMany(entries, options = {}) {
   return astCacheSetManyValues(entries, options);
 }
 
+/**
+ * Returns cached value or resolves and stores on miss.
+ *
+ * @param {string} key Cache key.
+ * @param {Function} resolver Miss resolver callback.
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Normalized fetch response.
+ */
 function astCacheApiFetch(key, resolver, options = {}) {
   return astCacheFetchValue(key, resolver, options);
 }
 
+/**
+ * Returns cached values or resolves missing keys and stores them.
+ *
+ * @param {string[]} keys Cache keys.
+ * @param {Function} resolver Miss resolver callback.
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Normalized fetch-many response.
+ */
 function astCacheApiFetchMany(keys, resolver, options = {}) {
   return astCacheFetchManyValues(keys, resolver, options);
 }
 
+/**
+ * Deletes a cached key.
+ *
+ * @param {string} key Cache key.
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Normalized delete response.
+ */
 function astCacheApiDelete(key, options = {}) {
   return astCacheDeleteValue(key, options);
 }
 
+/**
+ * Deletes multiple cached keys.
+ *
+ * @param {string[]} keys Cache keys.
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Normalized delete-many response.
+ */
 function astCacheApiDeleteMany(keys, options = {}) {
   return astCacheDeleteManyValues(keys, options);
 }
 
+/**
+ * Invalidates cache entries matching a tag.
+ *
+ * @param {string} tag Invalidation tag.
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Invalidation response.
+ */
 function astCacheApiInvalidateByTag(tag, options = {}) {
   return astCacheInvalidateTag(tag, options);
 }
 
+/**
+ * Invalidates cache entries matching a key prefix.
+ *
+ * @param {string} prefix Key prefix.
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Invalidation response.
+ */
 function astCacheApiInvalidateByPrefix(prefix, options = {}) {
   return astCacheInvalidatePrefix(prefix, options);
 }
 
+/**
+ * Invalidates entries using a predicate callback.
+ *
+ * @param {Function} predicate Predicate callback.
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Invalidation response.
+ */
 function astCacheApiInvalidateByPredicate(predicate, options = {}) {
   return astCacheInvalidatePredicate(predicate, options);
 }
 
+/**
+ * Acquires a cache lock and optionally runs task work.
+ *
+ * @param {string} key Lock key.
+ * @param {Function|Object} [taskOrOptions={}] Task function or lock options.
+ * @param {Object} [options={}] Lock options when second arg is a task.
+ * @returns {*} Task return value or lock acquisition result.
+ */
 function astCacheApiLock(key, taskOrOptions = {}, options = {}) {
   if (typeof taskOrOptions === 'function') {
     return astCacheLock(key, taskOrOptions, options);
@@ -55,22 +151,51 @@ function astCacheApiLock(key, taskOrOptions = {}, options = {}) {
   return astCacheLock(key, task, lockOptions);
 }
 
+/**
+ * Returns backend/cache statistics for the selected namespace.
+ *
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Stats response.
+ */
 function astCacheApiStats(options = {}) {
   return astCacheStats(options);
 }
 
+/**
+ * Sets runtime cache configuration overrides.
+ *
+ * @param {Object} [config={}] Runtime config patch.
+ * @param {Object} [options={}] Configure behavior options.
+ * @returns {Object} Updated runtime config snapshot.
+ */
 function astCacheApiConfigure(config = {}, options = {}) {
   return astCacheSetRuntimeConfig(config, options);
 }
 
+/**
+ * Gets current resolved cache runtime config.
+ *
+ * @returns {Object} Runtime config snapshot.
+ */
 function astCacheApiGetConfig() {
   return astCacheGetRuntimeConfig();
 }
 
+/**
+ * Clears runtime cache config overrides.
+ *
+ * @returns {Object} Cleared runtime config snapshot.
+ */
 function astCacheApiClearConfig() {
   return astCacheClearRuntimeConfig();
 }
 
+/**
+ * Clears cache entries for the target backend/namespace.
+ *
+ * @param {AstCacheOptions} [options={}] Cache options.
+ * @returns {Object} Clear response.
+ */
 function astCacheApiClear(options = {}) {
   return astCacheClear(options);
 }

--- a/apps_script_tools/dbt/DBT.js
+++ b/apps_script_tools/dbt/DBT.js
@@ -1,3 +1,20 @@
+/**
+ * @typedef {Object} AstDbtRequest
+ * @property {string} [operation]
+ * @property {Object} [bundle]
+ * @property {Object} [manifest]
+ * @property {Object} [source]
+ * @property {Object} [filters]
+ * @property {Object} [options]
+ */
+
+/**
+ * Runs a DBT operation via the unified AST.DBT router.
+ *
+ * @param {AstDbtRequest} [request={}] DBT operation request.
+ * @returns {Object} Normalized DBT response.
+ * @throws {AstDbtValidationError|AstDbtLoadError|AstDbtSchemaError}
+ */
 function astDbtRun(request = {}) {
   const normalized = astDbtValidateRunRequest(request);
 
@@ -45,74 +62,182 @@ function astDbtRun(request = {}) {
   }
 }
 
+/**
+ * Loads and validates a manifest bundle.
+ *
+ * @param {AstDbtRequest} [request={}] Load manifest request.
+ * @returns {Object} Manifest load response.
+ */
 function astDbtLoadManifest(request = {}) {
   return astDbtLoadManifestCore(request);
 }
 
+/**
+ * Inspects a loaded manifest bundle.
+ *
+ * @param {AstDbtRequest} [request={}] Inspect manifest request.
+ * @returns {Object} Manifest inspection response.
+ */
 function astDbtInspectManifest(request = {}) {
   return astDbtInspectManifestCore(request);
 }
 
+/**
+ * Loads a generic dbt artifact payload.
+ *
+ * @param {AstDbtRequest} [request={}] Load artifact request.
+ * @returns {Object} Artifact load response.
+ */
 function astDbtLoadArtifact(request = {}) {
   return astDbtLoadArtifactCore(request);
 }
 
+/**
+ * Inspects a loaded dbt artifact bundle.
+ *
+ * @param {AstDbtRequest} [request={}] Inspect artifact request.
+ * @returns {Object} Artifact inspection response.
+ */
 function astDbtInspectArtifact(request = {}) {
   return astDbtInspectArtifactCore(request);
 }
 
+/**
+ * Lists entities from a manifest bundle.
+ *
+ * @param {AstDbtRequest} [request={}] List entities request.
+ * @returns {Object} Entity list response.
+ */
 function astDbtListEntities(request = {}) {
   return astDbtListEntitiesCore(request);
 }
 
+/**
+ * Runs structured search across entities/columns.
+ *
+ * @param {AstDbtRequest} [request={}] Search request.
+ * @returns {Object} Search response.
+ */
 function astDbtSearch(request = {}) {
   return astDbtSearchCore(request);
 }
 
+/**
+ * Retrieves a single entity by unique id.
+ *
+ * @param {AstDbtRequest} [request={}] Get entity request.
+ * @returns {Object} Entity response.
+ */
 function astDbtGetEntity(request = {}) {
   return astDbtGetEntityCore(request);
 }
 
+/**
+ * Retrieves a single column by entity + column name.
+ *
+ * @param {AstDbtRequest} [request={}] Get column request.
+ * @returns {Object} Column response.
+ */
 function astDbtGetColumn(request = {}) {
   return astDbtGetColumnCore(request);
 }
 
+/**
+ * Traverses entity lineage graph.
+ *
+ * @param {AstDbtRequest} [request={}] Lineage request.
+ * @returns {Object} Lineage response.
+ */
 function astDbtLineage(request = {}) {
   return astDbtLineageCore(request);
 }
 
+/**
+ * Traverses column-level lineage graph.
+ *
+ * @param {AstDbtRequest} [request={}] Column lineage request.
+ * @returns {Object} Column lineage response.
+ */
 function astDbtColumnLineage(request = {}) {
   return astDbtColumnLineageCore(request);
 }
 
+/**
+ * Compares two entities side-by-side.
+ *
+ * @param {AstDbtRequest} [request={}] Diff request.
+ * @returns {Object} Diff response.
+ */
 function astDbtDiffEntities(request = {}) {
   return astDbtDiffEntitiesCore(request);
 }
 
+/**
+ * Computes downstream impact for an entity.
+ *
+ * @param {AstDbtRequest} [request={}] Impact request.
+ * @returns {Object} Impact response.
+ */
 function astDbtImpact(request = {}) {
   return astDbtImpactCore(request);
 }
 
+/**
+ * Compares two dbt artifacts.
+ *
+ * @param {AstDbtRequest} [request={}] Compare artifacts request.
+ * @returns {Object} Compare artifacts response.
+ */
 function astDbtCompareArtifacts(request = {}) {
   return astDbtCompareArtifactsCore(request);
 }
 
+/**
+ * Produces entity metadata quality report.
+ *
+ * @param {AstDbtRequest} [request={}] Quality report request.
+ * @returns {Object} Quality report response.
+ */
 function astDbtQualityReport(request = {}) {
   return astDbtQualityReportCore(request);
 }
 
+/**
+ * Reports test coverage for entity/manifest scope.
+ *
+ * @param {AstDbtRequest} [request={}] Test coverage request.
+ * @returns {Object} Test coverage response.
+ */
 function astDbtTestCoverage(request = {}) {
   return astDbtTestCoverageCore(request);
 }
 
+/**
+ * Lists owners and owner metadata.
+ *
+ * @param {AstDbtRequest} [request={}] Owners request.
+ * @returns {Object} Owners response.
+ */
 function astDbtOwners(request = {}) {
   return astDbtOwnersCore(request);
 }
 
+/**
+ * Searches owners by identifier/metadata.
+ *
+ * @param {AstDbtRequest} [request={}] Search owners request.
+ * @returns {Object} Search owners response.
+ */
 function astDbtSearchOwners(request = {}) {
   return astDbtSearchOwnersCore(request);
 }
 
+/**
+ * Computes ownership coverage metrics.
+ *
+ * @param {AstDbtRequest} [request={}] Owner coverage request.
+ * @returns {Object} Owner coverage response.
+ */
 function astDbtOwnerCoverage(request = {}) {
   return astDbtOwnerCoverageCore(request);
 }
@@ -168,18 +293,41 @@ function astDbtValidateManifestCore(request = {}) {
   };
 }
 
+/**
+ * Validates a manifest against the configured schema mode.
+ *
+ * @param {AstDbtRequest} [request={}] Validate manifest request.
+ * @returns {Object} Validation response.
+ */
 function astDbtValidateManifest(request = {}) {
   return astDbtValidateManifestCore(request);
 }
 
+/**
+ * Sets runtime DBT configuration overrides.
+ *
+ * @param {Object} [config={}] Runtime config patch.
+ * @param {Object} [options={}] Configure behavior options.
+ * @returns {Object} Updated runtime config snapshot.
+ */
 function astDbtConfigure(config = {}, options = {}) {
   return astDbtSetRuntimeConfig(config, options);
 }
 
+/**
+ * Gets current resolved DBT runtime config.
+ *
+ * @returns {Object} Runtime config snapshot.
+ */
 function astDbtGetConfig() {
   return astDbtGetRuntimeConfig();
 }
 
+/**
+ * Clears runtime DBT config overrides.
+ *
+ * @returns {Object} Cleared runtime config snapshot.
+ */
 function astDbtClearConfig() {
   return astDbtClearRuntimeConfig();
 }

--- a/apps_script_tools/github/GitHub.js
+++ b/apps_script_tools/github/GitHub.js
@@ -1,27 +1,90 @@
+/**
+ * @typedef {Object} AstGitHubRequest
+ * @property {string} [operation]
+ * @property {string} [owner]
+ * @property {string} [repo]
+ * @property {number} [issueNumber]
+ * @property {number} [pullNumber]
+ * @property {string} [path]
+ * @property {string} [branch]
+ * @property {string} [ref]
+ * @property {Object} [body]
+ * @property {Object} [auth]
+ * @property {Object} [options]
+ * @property {Object} [providerOptions]
+ */
+
+/**
+ * Runs a GitHub operation using the unified AST.GitHub request contract.
+ *
+ * @param {AstGitHubRequest} [request={}] GitHub operation request.
+ * @returns {Object} Normalized GitHub response.
+ * @throws {AstGitHubValidationError|AstGitHubAuthError|AstGitHubProviderError}
+ */
 function astGitHubRun(request = {}) {
   return astRunGitHubRequest(request);
 }
 
+/**
+ * Runs a specific GitHub operation by operation id.
+ *
+ * @param {string} operation Operation id from `AST.GitHub.operations()`.
+ * @param {AstGitHubRequest} [request={}] GitHub operation request.
+ * @returns {Object} Normalized GitHub response.
+ */
 function astGitHubRunOperation(operation, request = {}) {
   return astRunGitHubRequest(Object.assign({}, request, { operation }));
 }
 
+/**
+ * Executes a GraphQL operation against the configured GitHub GraphQL endpoint.
+ *
+ * @param {AstGitHubRequest} [request={}] GraphQL request payload.
+ * @returns {Object} Normalized GraphQL response.
+ */
 function astGitHubGraphql(request = {}) {
   return astGitHubRunOperation('graphql', request);
 }
 
+/**
+ * Exchanges GitHub App credentials for an installation token.
+ *
+ * @param {AstGitHubRequest} [request={}] App-auth request payload.
+ * @returns {Object} Normalized auth response.
+ */
 function astGitHubAuthAsApp(request = {}) {
   return astGitHubRunOperation('auth_as_app', request);
 }
 
+/**
+ * Verifies webhook signature and envelope integrity.
+ *
+ * @param {AstGitHubRequest} [request={}] Verify webhook request.
+ * @returns {Object} Verification result.
+ */
 function astGitHubVerifyWebhook(request = {}) {
   return astGitHubRunOperation('verify_webhook', request);
 }
 
+/**
+ * Parses and normalizes webhook payloads after verification.
+ *
+ * @param {AstGitHubRequest} [request={}] Parse webhook request.
+ * @returns {Object} Parsed webhook payload.
+ */
 function astGitHubParseWebhook(request = {}) {
   return astGitHubRunOperation('parse_webhook', request);
 }
 
+/**
+ * Operation-specific convenience wrappers.
+ *
+ * Each wrapper below is a thin adapter to `astGitHubRunOperation(...)`.
+ * Contract:
+ * - input: `AstGitHubRequest`
+ * - output: normalized operation response object
+ * - errors: typed GitHub module errors from `astRunGitHubRequest`
+ */
 function astGitHubGetMe(request = {}) {
   return astGitHubRunOperation('get_me', request);
 }
@@ -270,26 +333,59 @@ function astGitHubRateLimit(request = {}) {
   return astGitHubRunOperation('rate_limit', request);
 }
 
+/**
+ * Lists supported GitHub operation ids.
+ *
+ * @returns {string[]} Sorted list of operation ids.
+ */
 function astGitHubOperations() {
   return Array.from(new Set(astGitHubListOperations().concat(['graphql']))).sort();
 }
 
+/**
+ * Lists providers exposed by this namespace.
+ *
+ * @returns {string[]} Provider keys.
+ */
 function astGitHubProviders() {
   return ['github'];
 }
 
+/**
+ * Returns capabilities for a specific operation or operation group.
+ *
+ * @param {string} operationOrGroup Operation id or capability group.
+ * @returns {Object} Capability matrix.
+ */
 function astGitHubCapabilities(operationOrGroup) {
   return astGitHubGetCapabilities(operationOrGroup);
 }
 
+/**
+ * Sets runtime GitHub configuration overrides.
+ *
+ * @param {Object} [config={}] Runtime config patch.
+ * @param {Object} [options={}] Configure behavior options.
+ * @returns {Object} Updated runtime config snapshot.
+ */
 function astGitHubConfigure(config = {}, options = {}) {
   return astGitHubSetRuntimeConfig(config, options);
 }
 
+/**
+ * Gets current resolved GitHub runtime config.
+ *
+ * @returns {Object} Runtime config snapshot.
+ */
 function astGitHubGetConfig() {
   return astGitHubGetRuntimeConfig();
 }
 
+/**
+ * Clears runtime GitHub config overrides.
+ *
+ * @returns {Object} Cleared runtime config snapshot.
+ */
 function astGitHubClearConfig() {
   return astGitHubClearRuntimeConfig();
 }

--- a/apps_script_tools/storage/Storage.js
+++ b/apps_script_tools/storage/Storage.js
@@ -1,3 +1,20 @@
+/**
+ * @typedef {Object} AstStorageRequest
+ * @property {string} [provider]
+ * @property {string} [operation]
+ * @property {string} [uri]
+ * @property {Object} [location]
+ * @property {Object} [payload]
+ * @property {Object} [options]
+ * @property {Object} [auth]
+ */
+
+/**
+ * Runs a storage operation using the unified AST.Storage contract.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Normalized storage response.
+ */
 function astStorageRun(request = {}) {
   const operation = astStorageBulkNormalizeOperation(request && request.operation);
   if (operation === 'walk') {
@@ -19,66 +36,162 @@ function astStorageRun(request = {}) {
   return astRunStorageRequest(request);
 }
 
+/**
+ * Lists objects for a provider/location.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Normalized list response.
+ */
 function astStorageList(request = {}) {
   return astRunStorageRequest(Object.assign({}, request, { operation: 'list' }));
 }
 
+/**
+ * Fetches object metadata without reading payload bytes.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Normalized head response.
+ */
 function astStorageHead(request = {}) {
   return astRunStorageRequest(Object.assign({}, request, { operation: 'head' }));
 }
 
+/**
+ * Reads an object payload.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Normalized read response.
+ */
 function astStorageRead(request = {}) {
   return astRunStorageRequest(Object.assign({}, request, { operation: 'read' }));
 }
 
+/**
+ * Writes an object payload.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Normalized write response.
+ */
 function astStorageWrite(request = {}) {
   return astRunStorageRequest(Object.assign({}, request, { operation: 'write' }));
 }
 
+/**
+ * Deletes an object.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Normalized delete response.
+ */
 function astStorageDelete(request = {}) {
   return astRunStorageRequest(Object.assign({}, request, { operation: 'delete' }));
 }
 
+/**
+ * Checks whether an object exists.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Normalized exists response.
+ */
 function astStorageExists(request = {}) {
   return astRunStorageRequest(Object.assign({}, request, { operation: 'exists' }));
 }
 
+/**
+ * Copies an object.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Normalized copy response.
+ */
 function astStorageCopy(request = {}) {
   return astRunStorageRequest(Object.assign({}, request, { operation: 'copy' }));
 }
 
+/**
+ * Moves/renames an object.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Normalized move response.
+ */
 function astStorageMove(request = {}) {
   return astRunStorageRequest(Object.assign({}, request, { operation: 'move' }));
 }
 
+/**
+ * Generates a signed URL for supported providers.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Normalized signed URL response.
+ */
 function astStorageSignedUrl(request = {}) {
   return astRunStorageRequest(Object.assign({}, request, { operation: 'signed_url' }));
 }
 
+/**
+ * Writes large objects through multipart/chunked flows where supported.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Normalized multipart write response.
+ */
 function astStorageMultipartWrite(request = {}) {
   return astRunStorageRequest(Object.assign({}, request, { operation: 'multipart_write' }));
 }
 
+/**
+ * Walks a prefix recursively with optional filtering.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Walk response.
+ */
 function astStorageWalk(request = {}) {
   return astStorageWalkPrefix(request);
 }
 
+/**
+ * Copies all objects under one prefix to another.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Copy-prefix response.
+ */
 function astStorageCopyPrefixApi(request = {}) {
   return astStorageCopyPrefix(request);
 }
 
+/**
+ * Deletes all objects under a prefix.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Delete-prefix response.
+ */
 function astStorageDeletePrefixApi(request = {}) {
   return astStorageDeletePrefix(request);
 }
 
+/**
+ * Synchronizes source and destination prefixes.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Sync response.
+ */
 function astStorageSync(request = {}) {
   return astStorageSyncPrefixes(request);
 }
 
+/**
+ * Transfers objects across providers/locations.
+ *
+ * @param {AstStorageRequest} [request={}] Storage request payload.
+ * @returns {Object} Transfer response.
+ */
 function astStorageTransferApi(request = {}) {
   return astStorageTransfer(request);
 }
 
+/**
+ * Returns provider operation capabilities.
+ *
+ * @param {string} provider Provider key.
+ * @returns {Object} Capability matrix.
+ */
 function astStorageCapabilities(provider) {
   const base = astStorageGetCapabilities(provider);
   return Object.assign({}, base, {
@@ -90,14 +203,31 @@ function astStorageCapabilities(provider) {
   });
 }
 
+/**
+ * Sets runtime storage configuration overrides.
+ *
+ * @param {Object} [config={}] Runtime config patch.
+ * @param {Object} [options={}] Configure behavior options.
+ * @returns {Object} Updated runtime config snapshot.
+ */
 function astStorageConfigure(config = {}, options = {}) {
   return astStorageSetRuntimeConfig(config, options);
 }
 
+/**
+ * Gets current resolved storage runtime config.
+ *
+ * @returns {Object} Runtime config snapshot.
+ */
 function astStorageGetConfig() {
   return astStorageGetRuntimeConfig();
 }
 
+/**
+ * Clears runtime storage config overrides.
+ *
+ * @returns {Object} Cleared runtime config snapshot.
+ */
 function astStorageClearConfig() {
   return astStorageClearRuntimeConfig();
 }


### PR DESCRIPTION
## Summary
- expands facade-level JSDoc and typedef coverage for core API namespaces
- documents method contracts without changing runtime behavior
- aligns with roadmap item #251 under epic #234

## Scope
- `apps_script_tools/ai/AI.js`
  - adds `AstAiFacadeRequest` typedef
  - adds method-level JSDoc for public facade methods
- `apps_script_tools/cache/Cache.js`
  - adds `AstCacheOptions` typedef
  - adds method-level JSDoc for get/set/fetch/invalidate/lock/config APIs
- `apps_script_tools/storage/Storage.js`
  - adds `AstStorageRequest` typedef
  - adds method-level JSDoc for CRUD + bulk helpers + config APIs
- `apps_script_tools/dbt/DBT.js`
  - adds `AstDbtRequest` typedef
  - adds method-level JSDoc for run/load/search/entity/lineage/governance/config APIs
- `apps_script_tools/github/GitHub.js`
  - adds `AstGitHubRequest` typedef
  - documents core execution/config/capability methods and wrapper contract

## Validation
- `npm run lint`
- `npm run test:local`

## Notes
- no runtime behavior changes
- this PR is documentation-only to improve IDE discoverability and API contract clarity

Closes #251
