### PR TITLE
perf(dbt): incremental index perf hardening (part 2 of #254)

### DIFF
--- a/apps_script_tools/dbt/general/buildManifestIndexes.js
+++ b/apps_script_tools/dbt/general/buildManifestIndexes.js
@@ -135,6 +135,65 @@ function astDbtExtractColumnSearchText(columnName, columnValue = {}) {
   return parts.filter(Boolean).join(' ');
 }
 
+function astDbtBuildEntityColumnArtifacts(entityRecord) {
+  const columns = astDbtIsPlainObject(entityRecord && entityRecord.columns)
+    ? entityRecord.columns
+    : {};
+  const columnEntries = Object.keys(columns);
+
+  const columnIndex = {
+    order: [],
+    byName: {}
+  };
+  const columnTokenRefs = [];
+
+  columnEntries.forEach(columnName => {
+    const columnValue = columns[columnName];
+    const normalizedColumnName = astDbtNormalizeString(columnName, '');
+    if (!normalizedColumnName) {
+      return;
+    }
+
+    const columnLower = normalizedColumnName.toLowerCase();
+    const columnRecord = {
+      uniqueId: entityRecord.uniqueId,
+      uniqueIdLower: entityRecord.uniqueIdLower,
+      columnName: normalizedColumnName,
+      columnNameLower: columnLower,
+      section: entityRecord.section,
+      resourceType: entityRecord.resourceType,
+      packageName: entityRecord.packageName,
+      dataType: astDbtNormalizeString(
+        astDbtIsPlainObject(columnValue) ? columnValue.data_type : '',
+        ''
+      ),
+      tags: astDbtNormalizeTags(astDbtIsPlainObject(columnValue) ? columnValue.tags : []),
+      meta: astDbtIsPlainObject(columnValue) && astDbtIsPlainObject(columnValue.meta)
+        ? columnValue.meta
+        : {},
+      description: astDbtNormalizeString(
+        astDbtIsPlainObject(columnValue) ? columnValue.description : '',
+        ''
+      ),
+      raw: astDbtIsPlainObject(columnValue) ? columnValue : {}
+    };
+
+    columnIndex.order.push(normalizedColumnName);
+    columnIndex.byName[columnLower] = columnRecord;
+
+    const columnTokenId = `${entityRecord.uniqueIdLower}::${columnLower}`;
+    columnTokenRefs.push({
+      tokenId: columnTokenId,
+      tokens: astDbtTokenizeText(astDbtExtractColumnSearchText(normalizedColumnName, columnValue))
+    });
+  });
+
+  return {
+    columnIndex,
+    columnTokenRefs
+  };
+}
+
 function astDbtBuildEntityRecord(section, mapKey, entity, options = {}) {
   if (!astDbtIsPlainObject(entity)) {
     return null;
@@ -163,6 +222,11 @@ function astDbtBuildEntityRecord(section, mapKey, entity, options = {}) {
   };
 
   normalized.searchText = astDbtExtractEntitySearchText(entity, normalized);
+  normalized.searchTokens = astDbtTokenizeText(normalized.searchText);
+
+  const columnArtifacts = astDbtBuildEntityColumnArtifacts(normalized);
+  normalized.columnIndex = columnArtifacts.columnIndex;
+  normalized.columnTokenRefs = columnArtifacts.columnTokenRefs;
   return normalized;
 }
 
@@ -407,58 +471,33 @@ function astDbtBuildManifestIndexFromEntityRecords(manifest, entities, entitySig
       astDbtAppendIndexValue(byTag, tag, entity);
     });
 
-    const entityTokens = astDbtTokenizeText(entity.searchText);
+    const entityTokens = Array.isArray(entity.searchTokens)
+      ? entity.searchTokens
+      : astDbtTokenizeText(entity.searchText);
     entityTokens.forEach(token => {
       astDbtAppendToken(entityTokenMap, token, entity.uniqueIdLower);
     });
 
-    const columnEntries = astDbtIsPlainObject(entity.columns)
-      ? Object.keys(entity.columns)
-      : [];
+    const hasPrecomputedColumnArtifacts = astDbtIsPlainObject(entity.columnIndex)
+      && Array.isArray(entity.columnIndex.order)
+      && astDbtIsPlainObject(entity.columnIndex.byName)
+      && Array.isArray(entity.columnTokenRefs);
+    const columnArtifacts = hasPrecomputedColumnArtifacts
+      ? {
+          columnIndex: entity.columnIndex,
+          columnTokenRefs: entity.columnTokenRefs
+        }
+      : astDbtBuildEntityColumnArtifacts(entity);
+    const columnIndex = columnArtifacts.columnIndex;
 
-    const columnIndex = {
-      order: [],
-      byName: {}
-    };
-
-    columnEntries.forEach(columnName => {
-      const columnValue = entity.columns[columnName];
-      const normalizedColumnName = astDbtNormalizeString(columnName, '');
-      if (!normalizedColumnName) {
+    columnArtifacts.columnTokenRefs.forEach(tokenRef => {
+      if (!astDbtIsPlainObject(tokenRef)) {
         return;
       }
-
-      const columnLower = normalizedColumnName.toLowerCase();
-      const columnRecord = {
-        uniqueId: entity.uniqueId,
-        uniqueIdLower: entity.uniqueIdLower,
-        columnName: normalizedColumnName,
-        columnNameLower: columnLower,
-        section: entity.section,
-        resourceType: entity.resourceType,
-        packageName: entity.packageName,
-        dataType: astDbtNormalizeString(
-          astDbtIsPlainObject(columnValue) ? columnValue.data_type : '',
-          ''
-        ),
-        tags: astDbtNormalizeTags(astDbtIsPlainObject(columnValue) ? columnValue.tags : []),
-        meta: astDbtIsPlainObject(columnValue) && astDbtIsPlainObject(columnValue.meta)
-          ? columnValue.meta
-          : {},
-        description: astDbtNormalizeString(
-          astDbtIsPlainObject(columnValue) ? columnValue.description : '',
-          ''
-        ),
-        raw: astDbtIsPlainObject(columnValue) ? columnValue : {}
-      };
-
-      columnIndex.order.push(normalizedColumnName);
-      columnIndex.byName[columnLower] = columnRecord;
-
-      const columnTokenId = `${entity.uniqueIdLower}::${columnLower}`;
-      const columnTokens = astDbtTokenizeText(astDbtExtractColumnSearchText(normalizedColumnName, columnValue));
-      columnTokens.forEach(token => {
-        astDbtAppendToken(columnTokenMap, token, columnTokenId);
+      const tokenId = astDbtNormalizeString(tokenRef.tokenId, '');
+      const tokens = Array.isArray(tokenRef.tokens) ? tokenRef.tokens : [];
+      tokens.forEach(token => {
+        astDbtAppendToken(columnTokenMap, token, tokenId);
       });
     });
 

--- a/tests/local/dbt-persistent-cache.test.mjs
+++ b/tests/local/dbt-persistent-cache.test.mjs
@@ -114,6 +114,7 @@ test('loadManifest persistent cache reuses cached bundle for drive source', () =
   assert.equal(second.cache.hit, true);
   assert.equal(blobReadCount, 1);
   assert.equal(second.counts.entityCount, first.counts.entityCount);
+  assert.equal(second.indexBuild, null);
 });
 
 test('persistent cache supports includeManifest=false with gzip compression', () => {
@@ -161,6 +162,7 @@ test('persistent cache supports includeManifest=false with gzip compression', ()
   assert.equal(second.cache.hit, true);
   assert.equal(blobReadCount, 1);
   assert.equal(second.bundle.manifest, null);
+  assert.equal(second.indexBuild, null);
 
   const search = context.AST.DBT.search({
     bundle: second.bundle,

--- a/tests/perf/dbt-manifest.perf.test.mjs
+++ b/tests/perf/dbt-manifest.perf.test.mjs
@@ -1,4 +1,5 @@
 import { measureBenchmark } from './measure.mjs';
+import { performance } from 'node:perf_hooks';
 
 function astPerfCreateManifestFixture(entityCount = 600, columnsPerEntity = 5) {
   const nodes = {};
@@ -123,6 +124,31 @@ function astPerfCreateManifestVariantFixture(entityCount = 600, columnsPerEntity
   return clone;
 }
 
+function astPerfCreateManifestSmallDeltaFixture(entityCount = 600, columnsPerEntity = 5) {
+  const fixture = astPerfCreateManifestFixture(entityCount, columnsPerEntity);
+  const clone = JSON.parse(JSON.stringify(fixture));
+  clone.nodes['model.perf.model_250'].description = 'Updated performance model 250 small delta';
+  clone.nodes['model.perf.model_250'].columns.col_1.description = 'Updated small delta column description';
+  return clone;
+}
+
+function measureAverageMs(fn, iterations = 1) {
+  const safeIterations = Math.max(1, Math.floor(Number(iterations) || 1));
+  let totalMs = 0;
+  let lastResult = null;
+
+  for (let idx = 0; idx < safeIterations; idx += 1) {
+    const startedAt = performance.now();
+    lastResult = fn();
+    totalMs += (performance.now() - startedAt);
+  }
+
+  return {
+    ms: totalMs / safeIterations,
+    result: lastResult
+  };
+}
+
 export function runDbtManifestPerf(context, options = {}) {
   const {
     samples = 1,
@@ -212,11 +238,60 @@ export function runDbtManifestPerf(context, options = {}) {
     { samples }
   );
 
+  const incrementalProfileSamples = [];
+  for (let sampleIdx = 0; sampleIdx < samples; sampleIdx += 1) {
+    const baseManifest = astPerfCreateManifestFixture(entities, columnsPerEntity);
+    const smallDeltaManifest = astPerfCreateManifestSmallDeltaFixture(entities, columnsPerEntity);
+    const previousIndex = context.astDbtBuildManifestIndexes(baseManifest);
+
+    context.astDbtBuildManifestIndexes(smallDeltaManifest);
+    context.astDbtBuildManifestIndexesIncremental(smallDeltaManifest, previousIndex);
+
+    const fullRebuild = measureAverageMs(
+      () => context.astDbtBuildManifestIndexes(smallDeltaManifest),
+      3
+    );
+    const incremental = measureAverageMs(
+      () => context.astDbtBuildManifestIndexesIncremental(smallDeltaManifest, previousIndex),
+      3
+    );
+
+    incrementalProfileSamples.push({
+      fullRebuildMs: fullRebuild.ms,
+      incrementalMs: incremental.ms,
+      incrementalRelativePct: fullRebuild.ms > 0 ? (incremental.ms / fullRebuild.ms) * 100 : 0,
+      applied: Boolean(incremental.result && incremental.result.incremental && incremental.result.incremental.applied)
+    });
+  }
+
+  const bestIncrementalProfile = incrementalProfileSamples
+    .slice()
+    .sort((left, right) => left.incrementalRelativePct - right.incrementalRelativePct)[0];
+  const medianIncrementalProfile = incrementalProfileSamples
+    .slice()
+    .sort((left, right) => left.fullRebuildMs - right.fullRebuildMs)[Math.floor(incrementalProfileSamples.length / 2)];
+
+  const incrementalProfile = {
+    name: 'dbt.incremental_small_delta_profile',
+    bestMs: Number(bestIncrementalProfile.incrementalMs.toFixed(3)),
+    medianMs: Number(medianIncrementalProfile.fullRebuildMs.toFixed(3)),
+    maxHeapDeltaBytes: 0,
+    samples,
+    counters: {
+      incrementalRelativePct: Number(bestIncrementalProfile.incrementalRelativePct.toFixed(3)),
+      fullRebuildMs: Number(bestIncrementalProfile.fullRebuildMs.toFixed(3)),
+      incrementalMs: Number(bestIncrementalProfile.incrementalMs.toFixed(3)),
+      fallbackCount: bestIncrementalProfile.applied ? 0 : 1
+    },
+    outputType: 'Object'
+  };
+
   return [
     loadIndex,
     searchTop20,
     getEntityAvg,
     getColumnAvg,
-    diffEntities
+    diffEntities,
+    incrementalProfile
   ];
 }

--- a/tests/perf/perf-thresholds.json
+++ b/tests/perf/perf-thresholds.json
@@ -75,6 +75,10 @@
       },
       "cache.invalidation_profile": {
         "predicateRelativePct": 180
+      },
+      "dbt.incremental_small_delta_profile": {
+        "incrementalRelativePct": 85,
+        "fallbackCount": 0
       }
     }
   }


### PR DESCRIPTION
Summary:\n- continues #254 after #277 with incremental DBT indexing perf hardening\n- reuses precomputed entity/column token artifacts for unchanged records during incremental rebuilds\n- adds cache-hit response contract regression checks for top-level indexBuild\n- adds dbt.incremental_small_delta_profile perf benchmark and thresholds\n\nValidation:\n- npm run lint\n- npm run test:local\n- npm run test:perf:check\n\nIssue:\n- #254