### PR TITLE
security(scan): expand provider/context secret rules (#262)

### DIFF
--- a/scripts/security-scan.mjs
+++ b/scripts/security-scan.mjs
@@ -54,7 +54,7 @@ export const SECRET_RULES = Object.freeze([
   {
     id: 'azure_storage_account_key',
     description: 'Azure storage account key in assignment-like context',
-    regex: /\b(?:AZURE_STORAGE_KEY|AZURE_STORAGE_ACCOUNT_KEY)\b\s*[:=]\s*['\"]?[A-Za-z0-9+/]{86,90}={0,2}/g
+    regex: /\b(?:AZURE_STORAGE_KEY|AZURE_STORAGE_ACCOUNT_KEY)\b\s*[:=]\s*['\"]?[A-Za-z0-9+/]{86,90}={0,2}/gi
   },
   {
     id: 'heroku_api_key',

--- a/tests/local/security-scan.test.mjs
+++ b/tests/local/security-scan.test.mjs
@@ -35,7 +35,7 @@ test('security scan detects azure, heroku, digitalocean, stripe, twilio, sendgri
     'c2lnbmF0dXJlMTIzNDU2Nzg5MA'
   ].join('.');
   const content = [
-    `AZURE_STORAGE_KEY=${azureStorageKey}`,
+    `azure_storage_key=${azureStorageKey}`,
     `HEROKU_API_KEY = ${herokuKey}`,
     `DO_TOKEN=${doToken}`,
     `STRIPE=${stripeKey}`,


### PR DESCRIPTION
## Summary\n- add high-confidence secret scanner rules for Azure storage account keys, Heroku API keys, and DigitalOcean PATs\n- keep existing placeholder/allowlist behavior unchanged\n- extend local scanner tests to cover new rule IDs and detections\n\n## Testing\n- npm run lint\n- node --test tests/local/security-scan.test.mjs\n\nCloses #262