### PR TITLE
refactor(messaging): shared normalize/object helpers (phase 1 of #246)

### DIFF
--- a/apps_script_tools/messaging/chat/runChatOperation.js
+++ b/apps_script_tools/messaging/chat/runChatOperation.js
@@ -1,17 +1,5 @@
-function astMessagingRunChatNormalizeString(value, fallback = '') {
-  if (typeof value !== 'string') {
-    return fallback;
-  }
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : fallback;
-}
-
-function astMessagingRunChatIsPlainObject(value) {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
-}
-
 function astMessagingRunChatParseHttpsHostname(url) {
-  const normalized = astMessagingRunChatNormalizeString(url, '');
+  const normalized = astMessagingNormalizeString(url, '');
   if (!normalized) {
     return '';
   }
@@ -22,7 +10,7 @@ function astMessagingRunChatParseHttpsHostname(url) {
       if (String(parsed.protocol || '').toLowerCase() !== 'https:') {
         return '';
       }
-      return astMessagingRunChatNormalizeString(parsed.hostname, '').toLowerCase();
+      return astMessagingNormalizeString(parsed.hostname, '').toLowerCase();
     }
   } catch (_error) {
     // Fall through to deterministic regex parsing for runtimes without URL support.
@@ -33,7 +21,7 @@ function astMessagingRunChatParseHttpsHostname(url) {
     return '';
   }
 
-  let authority = astMessagingRunChatNormalizeString(match[1], '').toLowerCase();
+  let authority = astMessagingNormalizeString(match[1], '').toLowerCase();
   if (!authority) {
     return '';
   }
@@ -61,14 +49,14 @@ function astMessagingRunChatHostnameMatches(hostname, exactHosts = [], suffixHos
   }
 
   for (let i = 0; i < exactHosts.length; i += 1) {
-    const exact = astMessagingRunChatNormalizeString(exactHosts[i], '').toLowerCase();
+    const exact = astMessagingNormalizeString(exactHosts[i], '').toLowerCase();
     if (exact && hostname === exact) {
       return true;
     }
   }
 
   for (let i = 0; i < suffixHosts.length; i += 1) {
-    const suffix = astMessagingRunChatNormalizeString(suffixHosts[i], '').toLowerCase();
+    const suffix = astMessagingNormalizeString(suffixHosts[i], '').toLowerCase();
     if (!suffix) {
       continue;
     }
@@ -100,7 +88,7 @@ function astMessagingRunChatResolveWebhookProvider(url) {
 }
 
 function astMessagingRunChatCollectSendHints(normalizedRequest = {}) {
-  const body = astMessagingRunChatIsPlainObject(normalizedRequest.body)
+  const body = astMessagingIsPlainObject(normalizedRequest.body)
     ? normalizedRequest.body
     : {};
 
@@ -110,21 +98,21 @@ function astMessagingRunChatCollectSendHints(normalizedRequest = {}) {
   let unknownWebhookHost = false;
 
   const inspectPayload = payload => {
-    if (!astMessagingRunChatIsPlainObject(payload)) {
+    if (!astMessagingIsPlainObject(payload)) {
       return;
     }
 
-    if (astMessagingRunChatNormalizeString(payload.space, '')) {
+    if (astMessagingNormalizeString(payload.space, '')) {
       hasSpace = true;
       providers.chat_api = true;
     }
 
-    if (astMessagingRunChatNormalizeString(payload.channel, '')) {
+    if (astMessagingNormalizeString(payload.channel, '')) {
       hasChannel = true;
       providers.slack_hint = true;
     }
 
-    const webhookUrl = astMessagingRunChatNormalizeString(payload.webhookUrl, '');
+    const webhookUrl = astMessagingNormalizeString(payload.webhookUrl, '');
     const webhookProvider = astMessagingRunChatResolveWebhookProvider(webhookUrl);
     if (webhookProvider) {
       providers[webhookProvider] = true;
@@ -138,7 +126,7 @@ function astMessagingRunChatCollectSendHints(normalizedRequest = {}) {
   if (normalizedRequest.operation === 'chat_send_batch') {
     const messages = Array.isArray(body.messages) ? body.messages : [];
     messages.forEach(message => {
-      inspectPayload(astMessagingRunChatIsPlainObject(message) ? message : {});
+      inspectPayload(astMessagingIsPlainObject(message) ? message : {});
     });
   }
 

--- a/apps_script_tools/messaging/chat/slackAdapter.js
+++ b/apps_script_tools/messaging/chat/slackAdapter.js
@@ -1,33 +1,15 @@
-function astMessagingSlackIsPlainObject(value) {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function astMessagingSlackNormalizeString(value, fallback = '') {
-  if (typeof value !== 'string') {
-    return fallback;
-  }
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : fallback;
-}
-
-function astMessagingSlackCloneObject(value) {
-  return astMessagingSlackIsPlainObject(value)
-    ? Object.assign({}, value)
-    : {};
-}
-
 function astMessagingSlackResolveWebhookUrl(body = {}, normalizedRequest = {}, resolvedConfig = {}) {
-  return astMessagingSlackNormalizeString(body.webhookUrl, '')
-    || astMessagingSlackNormalizeString(normalizedRequest.auth && normalizedRequest.auth.slackWebhookUrl, '')
-    || astMessagingSlackNormalizeString(normalizedRequest.auth && normalizedRequest.auth.slack_webhook_url, '')
-    || astMessagingSlackNormalizeString(resolvedConfig.chat && resolvedConfig.chat.slackWebhookUrl, '');
+  return astMessagingNormalizeString(body.webhookUrl, '')
+    || astMessagingNormalizeString(normalizedRequest.auth && normalizedRequest.auth.slackWebhookUrl, '')
+    || astMessagingNormalizeString(normalizedRequest.auth && normalizedRequest.auth.slack_webhook_url, '')
+    || astMessagingNormalizeString(resolvedConfig.chat && resolvedConfig.chat.slackWebhookUrl, '');
 }
 
 function astMessagingSlackResolveBotToken(normalizedRequest = {}, resolvedConfig = {}) {
-  const token = astMessagingSlackNormalizeString(normalizedRequest.auth && normalizedRequest.auth.slackBotToken, '')
-    || astMessagingSlackNormalizeString(normalizedRequest.auth && normalizedRequest.auth.slack_bot_token, '')
-    || astMessagingSlackNormalizeString(normalizedRequest.auth && normalizedRequest.auth.token, '')
-    || astMessagingSlackNormalizeString(resolvedConfig.chat && resolvedConfig.chat.slackBotToken, '');
+  const token = astMessagingNormalizeString(normalizedRequest.auth && normalizedRequest.auth.slackBotToken, '')
+    || astMessagingNormalizeString(normalizedRequest.auth && normalizedRequest.auth.slack_bot_token, '')
+    || astMessagingNormalizeString(normalizedRequest.auth && normalizedRequest.auth.token, '')
+    || astMessagingNormalizeString(resolvedConfig.chat && resolvedConfig.chat.slackBotToken, '');
 
   if (!token) {
     throw new AstMessagingAuthError('Missing Slack bot token for slack_api transport', {
@@ -40,7 +22,7 @@ function astMessagingSlackResolveBotToken(normalizedRequest = {}, resolvedConfig
 }
 
 function astMessagingSlackResolveApiBaseUrl(resolvedConfig = {}) {
-  const baseUrl = astMessagingSlackNormalizeString(
+  const baseUrl = astMessagingNormalizeString(
     resolvedConfig.chat && resolvedConfig.chat.slackApiBaseUrl,
     'https://slack.com/api'
   );
@@ -49,27 +31,27 @@ function astMessagingSlackResolveApiBaseUrl(resolvedConfig = {}) {
 }
 
 function astMessagingSlackResolveChannel(body = {}, resolvedConfig = {}) {
-  return astMessagingSlackNormalizeString(body.channel, '')
-    || astMessagingSlackNormalizeString(resolvedConfig.chat && resolvedConfig.chat.slackChannel, '');
+  return astMessagingNormalizeString(body.channel, '')
+    || astMessagingNormalizeString(resolvedConfig.chat && resolvedConfig.chat.slackChannel, '');
 }
 
 function astMessagingSlackBuildPayload(body = {}, resolvedConfig = {}) {
   let payload = {};
   if (typeof body.message === 'string') {
     payload = { text: body.message };
-  } else if (astMessagingSlackIsPlainObject(body.message)) {
-    payload = astMessagingSlackCloneObject(body.message);
+  } else if (astMessagingIsPlainObject(body.message)) {
+    payload = astMessagingClonePlainObject(body.message);
   } else {
-    payload = { text: astMessagingSlackNormalizeString(body.text, '') };
+    payload = { text: astMessagingNormalizeString(body.text, '') };
   }
 
   const channel = astMessagingSlackResolveChannel(body, resolvedConfig);
-  if (channel && !astMessagingSlackNormalizeString(payload.channel, '')) {
+  if (channel && !astMessagingNormalizeString(payload.channel, '')) {
     payload.channel = channel;
   }
 
-  const threadTs = astMessagingSlackNormalizeString(body.threadTs || body.thread_ts, '');
-  if (threadTs && !astMessagingSlackNormalizeString(payload.thread_ts, '')) {
+  const threadTs = astMessagingNormalizeString(body.threadTs || body.thread_ts, '');
+  if (threadTs && !astMessagingNormalizeString(payload.thread_ts, '')) {
     payload.thread_ts = threadTs;
   }
 
@@ -123,7 +105,7 @@ function astMessagingSlackSendApi(body = {}, normalizedRequest = {}, resolvedCon
   const baseUrl = astMessagingSlackResolveApiBaseUrl(resolvedConfig);
   const payload = astMessagingSlackBuildPayload(body, resolvedConfig);
 
-  if (!astMessagingSlackNormalizeString(payload.channel, '')) {
+  if (!astMessagingNormalizeString(payload.channel, '')) {
     throw new AstMessagingValidationError('Slack API transport requires channel (body.channel or MESSAGING_SLACK_CHANNEL)', {
       field: 'body.channel'
     });
@@ -142,7 +124,7 @@ function astMessagingSlackSendApi(body = {}, normalizedRequest = {}, resolvedCon
     retries: resolvedConfig.retries
   });
 
-  const json = astMessagingSlackIsPlainObject(response.json)
+  const json = astMessagingIsPlainObject(response.json)
     ? response.json
     : null;
   if (json && json.ok === false) {
@@ -171,10 +153,10 @@ function astMessagingSlackSendApi(body = {}, normalizedRequest = {}, resolvedCon
 
 function astMessagingSlackSendWebhookBatch(body = {}, normalizedRequest = {}, resolvedConfig = {}) {
   const messages = Array.isArray(body.messages) ? body.messages : [];
-  const batchWebhookUrl = astMessagingSlackNormalizeString(body.webhookUrl, '');
+  const batchWebhookUrl = astMessagingNormalizeString(body.webhookUrl, '');
   const items = messages.map(message => {
-    const payload = astMessagingSlackIsPlainObject(message)
-      ? astMessagingSlackCloneObject(message)
+    const payload = astMessagingIsPlainObject(message)
+      ? astMessagingClonePlainObject(message)
       : { message };
 
     if (!payload.webhookUrl && batchWebhookUrl) {
@@ -197,10 +179,10 @@ function astMessagingSlackSendWebhookBatch(body = {}, normalizedRequest = {}, re
 
 function astMessagingSlackSendApiBatch(body = {}, normalizedRequest = {}, resolvedConfig = {}) {
   const messages = Array.isArray(body.messages) ? body.messages : [];
-  const batchChannel = astMessagingSlackNormalizeString(body.channel, '');
+  const batchChannel = astMessagingNormalizeString(body.channel, '');
   const items = messages.map(message => {
-    const payload = astMessagingSlackIsPlainObject(message)
-      ? astMessagingSlackCloneObject(message)
+    const payload = astMessagingIsPlainObject(message)
+      ? astMessagingClonePlainObject(message)
       : { message };
 
     if (!payload.channel && batchChannel) {

--- a/apps_script_tools/messaging/chat/teamsAdapter.js
+++ b/apps_script_tools/messaging/chat/teamsAdapter.js
@@ -1,26 +1,8 @@
-function astMessagingTeamsIsPlainObject(value) {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function astMessagingTeamsNormalizeString(value, fallback = '') {
-  if (typeof value !== 'string') {
-    return fallback;
-  }
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : fallback;
-}
-
-function astMessagingTeamsCloneObject(value) {
-  return astMessagingTeamsIsPlainObject(value)
-    ? Object.assign({}, value)
-    : {};
-}
-
 function astMessagingTeamsResolveWebhookUrl(body = {}, normalizedRequest = {}, resolvedConfig = {}) {
-  return astMessagingTeamsNormalizeString(body.webhookUrl, '')
-    || astMessagingTeamsNormalizeString(normalizedRequest.auth && normalizedRequest.auth.teamsWebhookUrl, '')
-    || astMessagingTeamsNormalizeString(normalizedRequest.auth && normalizedRequest.auth.teams_webhook_url, '')
-    || astMessagingTeamsNormalizeString(resolvedConfig.chat && resolvedConfig.chat.teamsWebhookUrl, '');
+  return astMessagingNormalizeString(body.webhookUrl, '')
+    || astMessagingNormalizeString(normalizedRequest.auth && normalizedRequest.auth.teamsWebhookUrl, '')
+    || astMessagingNormalizeString(normalizedRequest.auth && normalizedRequest.auth.teams_webhook_url, '')
+    || astMessagingNormalizeString(resolvedConfig.chat && resolvedConfig.chat.teamsWebhookUrl, '');
 }
 
 function astMessagingTeamsBuildPayload(body = {}) {
@@ -28,11 +10,11 @@ function astMessagingTeamsBuildPayload(body = {}) {
     return { text: body.message };
   }
 
-  if (astMessagingTeamsIsPlainObject(body.message)) {
-    return astMessagingTeamsCloneObject(body.message);
+  if (astMessagingIsPlainObject(body.message)) {
+    return astMessagingClonePlainObject(body.message);
   }
 
-  const text = astMessagingTeamsNormalizeString(body.text, '');
+  const text = astMessagingNormalizeString(body.text, '');
   if (text) {
     return { text };
   }
@@ -77,10 +59,10 @@ function astMessagingTeamsSendWebhook(body = {}, normalizedRequest = {}, resolve
 
 function astMessagingTeamsSendWebhookBatch(body = {}, normalizedRequest = {}, resolvedConfig = {}) {
   const messages = Array.isArray(body.messages) ? body.messages : [];
-  const batchWebhookUrl = astMessagingTeamsNormalizeString(body.webhookUrl, '');
+  const batchWebhookUrl = astMessagingNormalizeString(body.webhookUrl, '');
   const items = messages.map(message => {
-    const payload = astMessagingTeamsIsPlainObject(message)
-      ? astMessagingTeamsCloneObject(message)
+    const payload = astMessagingIsPlainObject(message)
+      ? astMessagingClonePlainObject(message)
       : { message };
 
     if (!payload.webhookUrl && batchWebhookUrl) {

--- a/apps_script_tools/messaging/general/normalize.js
+++ b/apps_script_tools/messaging/general/normalize.js
@@ -1,0 +1,22 @@
+function astMessagingIsPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function astMessagingNormalizeString(value, fallback = '') {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : fallback;
+}
+
+function astMessagingClonePlainObject(value, fallback = {}) {
+  if (!astMessagingIsPlainObject(value)) {
+    return Object.assign({}, fallback);
+  }
+  return Object.assign({}, value);
+}
+
+function astMessagingNormalizeArray(value) {
+  return Array.isArray(value) ? value.slice() : [];
+}


### PR DESCRIPTION
## Summary
- add canonical messaging helper file: apps_script_tools/messaging/general/normalize.js
- migrate chat transport internals to shared helpers:
  - runChatOperation
  - slackAdapter
  - teamsAdapter
- remove duplicated module-local normalize/isPlainObject implementations in migrated files

## Validation
- npm run lint
- node --test tests/local/messaging-chat-api.test.mjs tests/local/messaging-chat-slack.test.mjs tests/local/messaging-chat-teams.test.mjs tests/local/messaging-chat-webhook.test.mjs tests/local/messaging-validation.test.mjs

## Issue
- Part of #246