### PR TITLE
refactor(messaging): shared normalizers phase 4 for chat/runtime/log (#246)

### DIFF
--- a/apps_script_tools/messaging/chat/chatApiAdapter.js
+++ b/apps_script_tools/messaging/chat/chatApiAdapter.js
@@ -1,19 +1,11 @@
-function astMessagingChatApiNormalizeString(value, fallback = '') {
-  if (typeof value !== 'string') {
-    return fallback;
-  }
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : fallback;
-}
-
 function astMessagingChatApiResolveToken(normalizedRequest = {}) {
-  const token = astMessagingChatApiNormalizeString(normalizedRequest.auth && normalizedRequest.auth.oauthToken, '');
+  const token = astMessagingNormalizeString(normalizedRequest.auth && normalizedRequest.auth.oauthToken, '');
   if (token) {
     return token;
   }
 
   if (typeof ScriptApp !== 'undefined' && ScriptApp && typeof ScriptApp.getOAuthToken === 'function') {
-    const oauthToken = astMessagingChatApiNormalizeString(ScriptApp.getOAuthToken(), '');
+    const oauthToken = astMessagingNormalizeString(ScriptApp.getOAuthToken(), '');
     if (oauthToken) {
       return oauthToken;
     }
@@ -25,7 +17,7 @@ function astMessagingChatApiResolveToken(normalizedRequest = {}) {
 }
 
 function astMessagingChatApiResolveBaseUrl(resolvedConfig = {}) {
-  const baseUrl = astMessagingChatApiNormalizeString(resolvedConfig.chat && resolvedConfig.chat.apiBaseUrl, 'https://chat.googleapis.com/v1');
+  const baseUrl = astMessagingNormalizeString(resolvedConfig.chat && resolvedConfig.chat.apiBaseUrl, 'https://chat.googleapis.com/v1');
   return baseUrl.replace(/\/$/, '');
 }
 
@@ -37,7 +29,7 @@ function astMessagingChatApiBuildHeaders(token) {
 }
 
 function astMessagingChatApiBuildSendUrl(baseUrl, body = {}, resolvedConfig = {}) {
-  const space = astMessagingChatApiNormalizeString(body.space, astMessagingChatApiNormalizeString(resolvedConfig.chat && resolvedConfig.chat.space, ''));
+  const space = astMessagingNormalizeString(body.space, astMessagingNormalizeString(resolvedConfig.chat && resolvedConfig.chat.space, ''));
   if (!space) {
     throw new AstMessagingValidationError('Chat API transport requires body.space', {
       field: 'body.space'
@@ -46,7 +38,7 @@ function astMessagingChatApiBuildSendUrl(baseUrl, body = {}, resolvedConfig = {}
 
   const params = [];
   const thread = body.thread && typeof body.thread === 'object' ? body.thread : {};
-  const threadKey = astMessagingChatApiNormalizeString(thread.threadKey, '');
+  const threadKey = astMessagingNormalizeString(thread.threadKey, '');
   const reply = thread.reply === true;
   if (threadKey) {
     params.push(`threadKey=${encodeURIComponent(threadKey)}`);
@@ -64,12 +56,12 @@ function astMessagingChatApiBuildPayload(body = {}) {
     return { text: body.message };
   }
 
-  if (body.message && typeof body.message === 'object' && !Array.isArray(body.message)) {
+  if (astMessagingIsPlainObject(body.message)) {
     return Object.assign({}, body.message);
   }
 
   return {
-    text: astMessagingChatApiNormalizeString(body.text, '')
+    text: astMessagingNormalizeString(body.text, '')
   };
 }
 
@@ -124,7 +116,7 @@ function astMessagingChatApiSendBatch(body = {}, normalizedRequest = {}, resolve
 function astMessagingChatApiGetMessage(body = {}, normalizedRequest = {}, resolvedConfig = {}) {
   const token = astMessagingChatApiResolveToken(normalizedRequest);
   const baseUrl = astMessagingChatApiResolveBaseUrl(resolvedConfig);
-  const messageName = astMessagingChatApiNormalizeString(body.messageName, '');
+  const messageName = astMessagingNormalizeString(body.messageName, '');
   if (!messageName) {
     throw new AstMessagingValidationError('chat_get_message requires body.messageName', {
       field: 'body.messageName'
@@ -151,7 +143,7 @@ function astMessagingChatApiGetMessage(body = {}, normalizedRequest = {}, resolv
 function astMessagingChatApiListMessages(body = {}, normalizedRequest = {}, resolvedConfig = {}) {
   const token = astMessagingChatApiResolveToken(normalizedRequest);
   const baseUrl = astMessagingChatApiResolveBaseUrl(resolvedConfig);
-  const space = astMessagingChatApiNormalizeString(body.space, astMessagingChatApiNormalizeString(resolvedConfig.chat && resolvedConfig.chat.space, ''));
+  const space = astMessagingNormalizeString(body.space, astMessagingNormalizeString(resolvedConfig.chat && resolvedConfig.chat.space, ''));
   if (!space) {
     throw new AstMessagingValidationError('chat_list_messages requires body.space', {
       field: 'body.space'
@@ -159,7 +151,7 @@ function astMessagingChatApiListMessages(body = {}, normalizedRequest = {}, reso
   }
 
   const pageSize = Math.max(1, Math.min(1000, Number(body.pageSize || 50)));
-  const pageToken = astMessagingChatApiNormalizeString(body.pageToken, '');
+  const pageToken = astMessagingNormalizeString(body.pageToken, '');
 
   const params = [`pageSize=${pageSize}`];
   if (pageToken) {

--- a/apps_script_tools/messaging/chat/webhookAdapter.js
+++ b/apps_script_tools/messaging/chat/webhookAdapter.js
@@ -1,37 +1,29 @@
-function astMessagingChatWebhookNormalizeString(value, fallback = '') {
-  if (typeof value !== 'string') {
-    return fallback;
-  }
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : fallback;
-}
-
 function astMessagingChatWebhookBuildPayload(body = {}) {
   if (typeof body.message === 'string') {
     return { text: body.message };
   }
 
-  if (body.message && typeof body.message === 'object' && !Array.isArray(body.message)) {
+  if (astMessagingIsPlainObject(body.message)) {
     return Object.assign({}, body.message);
   }
 
   return {
-    text: astMessagingChatWebhookNormalizeString(body.text, '')
+    text: astMessagingNormalizeString(body.text, '')
   };
 }
 
 function astMessagingChatResolveWebhookUrl(body = {}, normalizedRequest = {}, resolvedConfig = {}) {
-  const direct = astMessagingChatWebhookNormalizeString(body.webhookUrl, '');
+  const direct = astMessagingNormalizeString(body.webhookUrl, '');
   if (direct) {
     return direct;
   }
 
-  const authWebhook = astMessagingChatWebhookNormalizeString(normalizedRequest.auth && normalizedRequest.auth.chatWebhookUrl, '');
+  const authWebhook = astMessagingNormalizeString(normalizedRequest.auth && normalizedRequest.auth.chatWebhookUrl, '');
   if (authWebhook) {
     return authWebhook;
   }
 
-  return astMessagingChatWebhookNormalizeString(resolvedConfig.chat && resolvedConfig.chat.webhookUrl, '');
+  return astMessagingNormalizeString(resolvedConfig.chat && resolvedConfig.chat.webhookUrl, '');
 }
 
 function astMessagingChatSendWebhook(body = {}, normalizedRequest = {}, resolvedConfig = {}) {
@@ -71,7 +63,7 @@ function astMessagingChatSendWebhook(body = {}, normalizedRequest = {}, resolved
 
 function astMessagingChatSendWebhookBatch(body = {}, normalizedRequest = {}, resolvedConfig = {}) {
   const messages = Array.isArray(body.messages) ? body.messages : [];
-  const batchWebhookUrl = astMessagingChatWebhookNormalizeString(body.webhookUrl, '');
+  const batchWebhookUrl = astMessagingNormalizeString(body.webhookUrl, '');
   const items = messages.map(message => {
     const payload = message && typeof message === 'object' ? Object.assign({}, message) : { message };
     if (!payload.webhookUrl && batchWebhookUrl) {

--- a/apps_script_tools/messaging/general/asyncDispatch.js
+++ b/apps_script_tools/messaging/general/asyncDispatch.js
@@ -1,11 +1,3 @@
-function astMessagingAsyncNormalizeString(value, fallback = '') {
-  if (typeof value !== 'string') {
-    return fallback;
-  }
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : fallback;
-}
-
 function astMessagingAsyncJobsAvailable() {
   if (typeof AST_JOBS !== 'undefined' && AST_JOBS && typeof AST_JOBS.enqueue === 'function') {
     return true;
@@ -50,9 +42,9 @@ function astMessagingEnqueueAsync(normalizedRequest = {}, resolvedConfig = {}) {
   }
 
   const jobsApi = astMessagingAsyncGetJobsApi();
-  const queueName = astMessagingAsyncNormalizeString(
+  const queueName = astMessagingNormalizeString(
     normalizedRequest.options && normalizedRequest.options.async && normalizedRequest.options.async.queue,
-    astMessagingAsyncNormalizeString(resolvedConfig.async && resolvedConfig.async.queue, 'jobs')
+    astMessagingNormalizeString(resolvedConfig.async && resolvedConfig.async.queue, 'jobs')
   );
 
   if (queueName !== 'jobs') {

--- a/apps_script_tools/messaging/general/logStore.js
+++ b/apps_script_tools/messaging/general/logStore.js
@@ -3,14 +3,6 @@ const AST_MESSAGING_LOG_MEMORY = {
   events: {}
 };
 
-function astMessagingLogNormalizeString(value, fallback = '') {
-  if (typeof value !== 'string') {
-    return fallback;
-  }
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : fallback;
-}
-
 function astMessagingLogNowIso() {
   return new Date().toISOString();
 }
@@ -18,7 +10,7 @@ function astMessagingLogNowIso() {
 function astMessagingGenerateEventId() {
   try {
     if (typeof Utilities !== 'undefined' && Utilities && typeof Utilities.getUuid === 'function') {
-      const uuid = astMessagingLogNormalizeString(Utilities.getUuid(), '');
+      const uuid = astMessagingNormalizeString(Utilities.getUuid(), '');
       if (uuid) {
         return `evt_${uuid}`;
       }
@@ -100,8 +92,8 @@ function astMessagingCloneSerializableFallback(value, seen, depth) {
 }
 
 function astMessagingResolveLogCacheOptions(logsConfig = {}) {
-  const backend = astMessagingLogNormalizeString(logsConfig.backend, 'drive_json');
-  const namespace = astMessagingLogNormalizeString(logsConfig.namespace, 'ast_messaging_logs');
+  const backend = astMessagingNormalizeString(logsConfig.backend, 'drive_json');
+  const namespace = astMessagingNormalizeString(logsConfig.namespace, 'ast_messaging_logs');
   const ttlSec = Number(logsConfig.ttlSec || 31536000);
 
   const options = {
@@ -111,12 +103,12 @@ function astMessagingResolveLogCacheOptions(logsConfig = {}) {
   };
 
   if (backend === 'drive_json') {
-    options.driveFolderId = astMessagingLogNormalizeString(logsConfig.driveFolderId, '');
-    options.driveFileName = astMessagingLogNormalizeString(logsConfig.driveFileName, 'ast_messaging_logs.json');
+    options.driveFolderId = astMessagingNormalizeString(logsConfig.driveFolderId, '');
+    options.driveFileName = astMessagingNormalizeString(logsConfig.driveFileName, 'ast_messaging_logs.json');
   }
 
   if (backend === 'storage_json') {
-    options.storageUri = astMessagingLogNormalizeString(logsConfig.storageUri, '');
+    options.storageUri = astMessagingNormalizeString(logsConfig.storageUri, '');
   }
 
   return options;
@@ -206,15 +198,15 @@ function astMessagingLogDeleteEvent(cache, options, eventId) {
 }
 
 function astMessagingLogWrite(entry = {}, resolvedConfig = {}) {
-  const eventId = astMessagingLogNormalizeString(entry.eventId, '') || astMessagingGenerateEventId();
+  const eventId = astMessagingNormalizeString(entry.eventId, '') || astMessagingGenerateEventId();
   const nowIso = astMessagingLogNowIso();
 
   const normalizedEntry = {
     eventId,
-    timestamp: astMessagingLogNormalizeString(entry.timestamp, nowIso),
-    operation: astMessagingLogNormalizeString(entry.operation, ''),
-    channel: astMessagingLogNormalizeString(entry.channel, ''),
-    status: astMessagingLogNormalizeString(entry.status, 'ok'),
+    timestamp: astMessagingNormalizeString(entry.timestamp, nowIso),
+    operation: astMessagingNormalizeString(entry.operation, ''),
+    channel: astMessagingNormalizeString(entry.channel, ''),
+    status: astMessagingNormalizeString(entry.status, 'ok'),
     payload: entry.payload && typeof entry.payload === 'object' ? astMessagingCloneSerializable(entry.payload) : {},
     metadata: entry.metadata && typeof entry.metadata === 'object' ? astMessagingCloneSerializable(entry.metadata) : {}
   };
@@ -274,7 +266,7 @@ function astMessagingLogList(request = {}, resolvedConfig = {}) {
 
 function astMessagingLogGet(request = {}, resolvedConfig = {}) {
   const body = request.body && typeof request.body === 'object' ? request.body : {};
-  const eventId = astMessagingLogNormalizeString(body.eventId, null);
+  const eventId = astMessagingNormalizeString(body.eventId, null);
   if (!eventId) {
     throw new AstMessagingValidationError("Missing required messaging request field 'body.eventId'", {
       field: 'body.eventId'
@@ -295,7 +287,7 @@ function astMessagingLogGet(request = {}, resolvedConfig = {}) {
 
 function astMessagingLogDelete(request = {}, resolvedConfig = {}) {
   const body = request.body && typeof request.body === 'object' ? request.body : {};
-  const eventId = astMessagingLogNormalizeString(body.eventId, null);
+  const eventId = astMessagingNormalizeString(body.eventId, null);
   if (!eventId) {
     throw new AstMessagingValidationError("Missing required messaging request field 'body.eventId'", {
       field: 'body.eventId'

--- a/apps_script_tools/messaging/general/runMessagingRequest.js
+++ b/apps_script_tools/messaging/general/runMessagingRequest.js
@@ -1,11 +1,3 @@
-function astMessagingRuntimeNormalizeString(value, fallback = '') {
-  if (typeof value !== 'string') {
-    return fallback;
-  }
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : fallback;
-}
-
 function astMessagingRuntimeClone(value) {
   if (value == null) {
     return value;
@@ -39,7 +31,7 @@ function astMessagingTelemetryStart(normalizedRequest = {}) {
 
   if (typeof AST_TELEMETRY !== 'undefined' && AST_TELEMETRY && typeof AST_TELEMETRY.startSpan === 'function') {
     return AST_TELEMETRY.startSpan(
-      `${astMessagingRuntimeNormalizeString(normalizedRequest.options.telemetry.spanPrefix, 'messaging')}.${normalizedRequest.operation}`,
+      `${astMessagingNormalizeString(normalizedRequest.options.telemetry.spanPrefix, 'messaging')}.${normalizedRequest.operation}`,
       {
         operation: normalizedRequest.operation,
         channel: normalizedRequest.channel


### PR DESCRIPTION
## Summary
- continue #246 by replacing duplicate local string/object normalizers with shared messaging helpers
- migrate these files:
  - apps_script_tools/messaging/chat/chatApiAdapter.js
  - apps_script_tools/messaging/chat/webhookAdapter.js
  - apps_script_tools/messaging/general/asyncDispatch.js
  - apps_script_tools/messaging/general/runMessagingRequest.js
  - apps_script_tools/messaging/general/logStore.js
- preserve behavior and keep module contracts unchanged

## Validation
- npm run lint
- node --test tests/local/messaging-*.test.mjs

Part of #246