### PR TITLE
refactor(rag): decompose answer/search pipeline phase 1 (#247)

### DIFF
--- a/apps_script_tools/rag/general/answerWithRag.js
+++ b/apps_script_tools/rag/general/answerWithRag.js
@@ -1,5 +1,5 @@
 function astRagNowMs() {
-  return new Date().getTime();
+  return astRagPipelineNowMs();
 }
 
 function astRagBuildAnswerDiagnostics(cacheConfig = {}, timeoutMs = null) {
@@ -85,76 +85,19 @@ function astRagBuildAnswerDiagnostics(cacheConfig = {}, timeoutMs = null) {
 }
 
 function astRagApplyAnswerCacheOperationDiagnostics(diagnostics, operationMeta) {
-  if (!astRagIsPlainObject(diagnostics) || !astRagIsPlainObject(operationMeta)) {
-    return;
-  }
-
-  if (!astRagIsPlainObject(diagnostics.timings)) {
-    diagnostics.timings = {};
-  }
-  if (!astRagIsPlainObject(diagnostics.cache)) {
-    diagnostics.cache = {};
-  }
-
-  const durationMs = typeof operationMeta.durationMs === 'number' && isFinite(operationMeta.durationMs)
-    ? Math.max(0, operationMeta.durationMs)
-    : 0;
-  const lockWaitMs = typeof operationMeta.lockWaitMs === 'number' && isFinite(operationMeta.lockWaitMs)
-    ? Math.max(0, operationMeta.lockWaitMs)
-    : 0;
-  const lockContention = typeof operationMeta.lockContention === 'number' && isFinite(operationMeta.lockContention)
-    ? Math.max(0, operationMeta.lockContention)
-    : 0;
-
-  if (operationMeta.operation === 'set') {
-    diagnostics.timings.cacheSetMs = (diagnostics.timings.cacheSetMs || 0) + durationMs;
-  } else if (operationMeta.operation === 'delete') {
-    diagnostics.timings.cacheDeleteMs = (diagnostics.timings.cacheDeleteMs || 0) + durationMs;
-  } else {
-    diagnostics.timings.cacheGetMs = (diagnostics.timings.cacheGetMs || 0) + durationMs;
-  }
-
-  diagnostics.timings.lockWaitMs = (diagnostics.timings.lockWaitMs || 0) + lockWaitMs;
-  diagnostics.cache.lockContention = (diagnostics.cache.lockContention || 0) + lockContention;
-  diagnostics.cache.backend = astRagNormalizeString(operationMeta.backend, diagnostics.cache.backend);
-  diagnostics.cache.namespace = astRagNormalizeString(operationMeta.namespace, diagnostics.cache.namespace);
-  diagnostics.cache.lockScope = astRagNormalizeString(operationMeta.lockScope, diagnostics.cache.lockScope);
-  if (!diagnostics.cache.hitPath && operationMeta.hit && operationMeta.path) {
-    diagnostics.cache.hitPath = operationMeta.path;
-  }
+  astRagApplyCacheOperationDiagnosticsShared(diagnostics, operationMeta);
 }
 
 function astRagBuildAnswerTimeoutError(timeoutMs, stage, startedAtMs) {
-  return new AstRagRetrievalError('RAG retrieval exceeded maxRetrievalMs budget', {
-    timedOut: true,
-    timeoutMs,
-    timeoutStage: astRagNormalizeString(stage, 'retrieval'),
-    elapsedMs: Math.max(0, astRagNowMs() - startedAtMs)
-  });
+  return astRagBuildRetrievalTimeoutErrorShared(timeoutMs, stage, startedAtMs);
 }
 
 function astRagMarkAnswerTimeoutDiagnostics(diagnostics, timeoutMs, stage) {
-  if (!astRagIsPlainObject(diagnostics) || !astRagIsPlainObject(diagnostics.retrieval)) {
-    return;
-  }
-
-  diagnostics.retrieval.timedOut = true;
-  diagnostics.retrieval.timeoutMs = timeoutMs;
-  diagnostics.retrieval.timeoutStage = astRagNormalizeString(stage, 'retrieval');
+  astRagMarkRetrievalTimeoutDiagnosticsShared(diagnostics, timeoutMs, stage);
 }
 
 function astRagAssertAnswerRetrievalBudget(timeoutMs, startedAtMs, stage, diagnostics = null) {
-  if (!(typeof timeoutMs === 'number' && isFinite(timeoutMs) && timeoutMs > 0)) {
-    return;
-  }
-
-  const elapsedMs = Math.max(0, astRagNowMs() - startedAtMs);
-  if (elapsedMs <= timeoutMs) {
-    return;
-  }
-
-  astRagMarkAnswerTimeoutDiagnostics(diagnostics, timeoutMs, stage);
-  throw astRagBuildAnswerTimeoutError(timeoutMs, stage, startedAtMs);
+  astRagAssertRetrievalWithinBudgetShared(timeoutMs, startedAtMs, stage, diagnostics);
 }
 
 function astRagBuildRecoveryRetrievalConfig(retrieval, attempt, recoveryConfig) {

--- a/apps_script_tools/rag/general/pipelineShared.js
+++ b/apps_script_tools/rag/general/pipelineShared.js
@@ -1,0 +1,76 @@
+function astRagPipelineNowMs() {
+  return new Date().getTime();
+}
+
+function astRagApplyCacheOperationDiagnosticsShared(diagnostics, operationMeta) {
+  if (!astRagIsPlainObject(diagnostics) || !astRagIsPlainObject(operationMeta)) {
+    return;
+  }
+
+  if (!astRagIsPlainObject(diagnostics.timings)) {
+    diagnostics.timings = {};
+  }
+  if (!astRagIsPlainObject(diagnostics.cache)) {
+    diagnostics.cache = {};
+  }
+
+  const durationMs = typeof operationMeta.durationMs === 'number' && isFinite(operationMeta.durationMs)
+    ? Math.max(0, operationMeta.durationMs)
+    : 0;
+  const lockWaitMs = typeof operationMeta.lockWaitMs === 'number' && isFinite(operationMeta.lockWaitMs)
+    ? Math.max(0, operationMeta.lockWaitMs)
+    : 0;
+  const lockContention = typeof operationMeta.lockContention === 'number' && isFinite(operationMeta.lockContention)
+    ? Math.max(0, operationMeta.lockContention)
+    : 0;
+
+  if (operationMeta.operation === 'set') {
+    diagnostics.timings.cacheSetMs = (diagnostics.timings.cacheSetMs || 0) + durationMs;
+  } else if (operationMeta.operation === 'delete') {
+    diagnostics.timings.cacheDeleteMs = (diagnostics.timings.cacheDeleteMs || 0) + durationMs;
+  } else {
+    diagnostics.timings.cacheGetMs = (diagnostics.timings.cacheGetMs || 0) + durationMs;
+  }
+
+  diagnostics.timings.lockWaitMs = (diagnostics.timings.lockWaitMs || 0) + lockWaitMs;
+  diagnostics.cache.lockContention = (diagnostics.cache.lockContention || 0) + lockContention;
+  diagnostics.cache.backend = astRagNormalizeString(operationMeta.backend, diagnostics.cache.backend);
+  diagnostics.cache.namespace = astRagNormalizeString(operationMeta.namespace, diagnostics.cache.namespace);
+  diagnostics.cache.lockScope = astRagNormalizeString(operationMeta.lockScope, diagnostics.cache.lockScope);
+  if (!diagnostics.cache.hitPath && operationMeta.hit && operationMeta.path) {
+    diagnostics.cache.hitPath = operationMeta.path;
+  }
+}
+
+function astRagBuildRetrievalTimeoutErrorShared(timeoutMs, stage, startedAtMs) {
+  return new AstRagRetrievalError('RAG retrieval exceeded maxRetrievalMs budget', {
+    timedOut: true,
+    timeoutMs,
+    timeoutStage: astRagNormalizeString(stage, 'retrieval'),
+    elapsedMs: Math.max(0, astRagPipelineNowMs() - startedAtMs)
+  });
+}
+
+function astRagMarkRetrievalTimeoutDiagnosticsShared(diagnostics, timeoutMs, stage) {
+  if (!astRagIsPlainObject(diagnostics) || !astRagIsPlainObject(diagnostics.retrieval)) {
+    return;
+  }
+
+  diagnostics.retrieval.timedOut = true;
+  diagnostics.retrieval.timeoutMs = timeoutMs;
+  diagnostics.retrieval.timeoutStage = astRagNormalizeString(stage, 'retrieval');
+}
+
+function astRagAssertRetrievalWithinBudgetShared(timeoutMs, startedAtMs, stage, diagnostics = null) {
+  if (!(typeof timeoutMs === 'number' && isFinite(timeoutMs) && timeoutMs > 0)) {
+    return;
+  }
+
+  const elapsedMs = Math.max(0, astRagPipelineNowMs() - startedAtMs);
+  if (elapsedMs <= timeoutMs) {
+    return;
+  }
+
+  astRagMarkRetrievalTimeoutDiagnosticsShared(diagnostics, timeoutMs, stage);
+  throw astRagBuildRetrievalTimeoutErrorShared(timeoutMs, stage, startedAtMs);
+}

--- a/apps_script_tools/rag/general/searchRagIndex.js
+++ b/apps_script_tools/rag/general/searchRagIndex.js
@@ -130,71 +130,15 @@ function astRagSelectShardRefsForSearch(indexDocument, retrieval = {}, queryVect
 }
 
 function astRagApplyCacheOperationDiagnostics(diagnostics, operationMeta) {
-  if (!astRagIsPlainObject(diagnostics) || !astRagIsPlainObject(operationMeta)) {
-    return;
-  }
-
-  if (!astRagIsPlainObject(diagnostics.timings)) {
-    diagnostics.timings = {};
-  }
-  if (!astRagIsPlainObject(diagnostics.cache)) {
-    diagnostics.cache = {};
-  }
-
-  const durationMs = typeof operationMeta.durationMs === 'number' && isFinite(operationMeta.durationMs)
-    ? Math.max(0, operationMeta.durationMs)
-    : 0;
-  const lockWaitMs = typeof operationMeta.lockWaitMs === 'number' && isFinite(operationMeta.lockWaitMs)
-    ? Math.max(0, operationMeta.lockWaitMs)
-    : 0;
-  const lockContention = typeof operationMeta.lockContention === 'number' && isFinite(operationMeta.lockContention)
-    ? Math.max(0, operationMeta.lockContention)
-    : 0;
-
-  if (operationMeta.operation === 'set') {
-    diagnostics.timings.cacheSetMs = (diagnostics.timings.cacheSetMs || 0) + durationMs;
-  } else if (operationMeta.operation === 'delete') {
-    diagnostics.timings.cacheDeleteMs = (diagnostics.timings.cacheDeleteMs || 0) + durationMs;
-  } else {
-    diagnostics.timings.cacheGetMs = (diagnostics.timings.cacheGetMs || 0) + durationMs;
-  }
-
-  diagnostics.timings.lockWaitMs = (diagnostics.timings.lockWaitMs || 0) + lockWaitMs;
-  diagnostics.cache.lockContention = (diagnostics.cache.lockContention || 0) + lockContention;
-  diagnostics.cache.backend = astRagNormalizeString(operationMeta.backend, diagnostics.cache.backend);
-  diagnostics.cache.namespace = astRagNormalizeString(operationMeta.namespace, diagnostics.cache.namespace);
-  diagnostics.cache.lockScope = astRagNormalizeString(operationMeta.lockScope, diagnostics.cache.lockScope);
-  if (!diagnostics.cache.hitPath && operationMeta.hit && operationMeta.path) {
-    diagnostics.cache.hitPath = operationMeta.path;
-  }
+  astRagApplyCacheOperationDiagnosticsShared(diagnostics, operationMeta);
 }
 
 function astRagSearchBuildTimeoutError(timeoutMs, stage, startedAtMs) {
-  return new AstRagRetrievalError('RAG retrieval exceeded maxRetrievalMs budget', {
-    timedOut: true,
-    timeoutMs,
-    timeoutStage: astRagNormalizeString(stage, 'retrieval'),
-    elapsedMs: Math.max(0, new Date().getTime() - startedAtMs)
-  });
+  return astRagBuildRetrievalTimeoutErrorShared(timeoutMs, stage, startedAtMs);
 }
 
 function astRagSearchAssertWithinBudget(timeoutMs, startedAtMs, stage, diagnostics = null) {
-  if (!(typeof timeoutMs === 'number' && isFinite(timeoutMs) && timeoutMs > 0)) {
-    return;
-  }
-
-  const elapsedMs = Math.max(0, new Date().getTime() - startedAtMs);
-  if (elapsedMs <= timeoutMs) {
-    return;
-  }
-
-  if (astRagIsPlainObject(diagnostics) && astRagIsPlainObject(diagnostics.retrieval)) {
-    diagnostics.retrieval.timedOut = true;
-    diagnostics.retrieval.timeoutMs = timeoutMs;
-    diagnostics.retrieval.timeoutStage = astRagNormalizeString(stage, 'retrieval');
-  }
-
-  throw astRagSearchBuildTimeoutError(timeoutMs, stage, startedAtMs);
+  astRagAssertRetrievalWithinBudgetShared(timeoutMs, startedAtMs, stage, diagnostics);
 }
 
 function astRagSearchNormalizedCore(normalizedRequest, runtimeOptions = {}) {


### PR DESCRIPTION
## Summary
- start #247 by extracting shared retrieval-stage helpers from oversized RAG pipeline files
- add apps_script_tools/rag/general/pipelineShared.js for shared timeout and cache-operation diagnostics behavior
- wire both answerWithRag and searchRagIndex to shared helpers without changing public behavior

## Validation
- npm run lint
- node --test tests/local/rag-*.test.mjs

Part of #247
