### PR TITLE
perf(cache): reduce batch set cleanup overhead

### DIFF
--- a/apps_script_tools/cache/general/runtime.js
+++ b/apps_script_tools/cache/general/runtime.js
@@ -942,7 +942,7 @@ function astCacheGetValueWithContext(context, normalizedKey, keyHash, includeMet
   return value;
 }
 
-function astCacheSetValueWithContext(context, normalizedKey, keyHash, value, operationOptions = {}, cleanupMode = 'immediate') {
+function astCacheSetValueWithContext(context, normalizedKey, keyHash, value, operationOptions = {}) {
   const resolvedKeyHash = typeof keyHash === 'string' && keyHash.length > 0
     ? keyHash
     : astCacheHashKey(normalizedKey);
@@ -965,8 +965,12 @@ function astCacheSetValueWithContext(context, normalizedKey, keyHash, value, ope
   });
 
   const saved = context.adapter.set(entry);
-  const shouldDeferCleanup = cleanupMode === 'defer';
-  if (!shouldDeferCleanup) {
+  if (typeof context.adapter.deleteManyByKeyHashes === 'function') {
+    astCacheTryOrFallback(
+      () => context.adapter.deleteManyByKeyHashes([staleKeyHash, leaseKeyHash]),
+      0
+    );
+  } else {
     astCacheTryOrFallback(() => context.adapter.delete(staleKeyHash), false);
     astCacheTryOrFallback(() => context.adapter.delete(leaseKeyHash), false);
   }
@@ -979,10 +983,6 @@ function astCacheSetValueWithContext(context, normalizedKey, keyHash, value, ope
     tags: saved.tags.slice(),
     expiresAt: typeof saved.expiresAtMs === 'number' ? new Date(saved.expiresAtMs).toISOString() : null
   };
-
-  if (shouldDeferCleanup) {
-    output.cleanupKeyHashes = [staleKeyHash, leaseKeyHash];
-  }
 
   return output;
 }
@@ -1231,46 +1231,26 @@ function astCacheSetManyValues(entries, options = {}) {
   const context = astCacheBuildResolvedContext(options);
   const normalizedEntries = astCacheNormalizeBatchEntries(entries);
   const items = [];
-  const deferredCleanupKeyHashes = [];
 
-  try {
-    for (let idx = 0; idx < normalizedEntries.length; idx += 1) {
-      const entry = normalizedEntries[idx];
-      const entryOptions = Object.assign({}, context.options, entry.options);
-      const saved = astCacheSetValueWithContext(
-        context,
-        entry.normalizedKey,
-        entry.keyHash,
-        entry.value,
-        entryOptions,
-        'defer'
-      );
+  for (let idx = 0; idx < normalizedEntries.length; idx += 1) {
+    const entry = normalizedEntries[idx];
+    const entryOptions = Object.assign({}, context.options, entry.options);
+    const saved = astCacheSetValueWithContext(
+      context,
+      entry.normalizedKey,
+      entry.keyHash,
+      entry.value,
+      entryOptions
+    );
 
-      if (Array.isArray(saved.cleanupKeyHashes)) {
-        deferredCleanupKeyHashes.push(...saved.cleanupKeyHashes);
-      }
-
-      items.push({
-        key: entry.key,
-        keyHash: saved.keyHash,
-        status: 'set',
-        ttlSec: saved.ttlSec,
-        tags: saved.tags.slice(),
-        expiresAt: saved.expiresAt
-      });
-    }
-  } finally {
-    if (deferredCleanupKeyHashes.length > 0) {
-      const uniqueCleanupKeyHashes = Array.from(new Set(deferredCleanupKeyHashes));
-      if (typeof context.adapter.deleteManyByKeyHashes === 'function') {
-        astCacheTryOrFallback(() => context.adapter.deleteManyByKeyHashes(uniqueCleanupKeyHashes), 0);
-      } else {
-        for (let idx = 0; idx < uniqueCleanupKeyHashes.length; idx += 1) {
-          const cleanupKeyHash = uniqueCleanupKeyHashes[idx];
-          astCacheTryOrFallback(() => context.adapter.delete(cleanupKeyHash), false);
-        }
-      }
-    }
+    items.push({
+      key: entry.key,
+      keyHash: saved.keyHash,
+      status: 'set',
+      ttlSec: saved.ttlSec,
+      tags: saved.tags.slice(),
+      expiresAt: saved.expiresAt
+    });
   }
 
   return {


### PR DESCRIPTION
## Summary
- preserve immediate stale/lease cleanup semantics for each `setMany` entry write
- reduce cleanup overhead by using `deleteManyByKeyHashes([stale, lease])` when available
- keep fallback to individual deletes for adapters without bulk delete support

## Why
`npm run test:perf:check` was failing on `cache.batch_profile` because `setMany` cleanup overhead was too high.

A first pass deferred cleanup across the whole batch, but that changed in-flight `forceRefresh` behavior for concurrent readers. This PR keeps the semantic contract and still improves performance.

## Validation
- npm run test:local
- npm run test:perf:check

## Perf result
- `cache.batch_profile.setManyRelativePct`: **99.135** (failing baseline) -> **89.266** (passing, threshold <= 92)
