### PR TITLE
docs: release-readiness sweep across README/MkDocs/changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@
 
 ### Changed
 
+- `AST.Cache.setMany(...)` stale/lease cleanup now preserves immediate per-key cleanup semantics while reducing cleanup overhead by using `deleteManyByKeyHashes([stale, lease])` when supported by the backend adapter.
 - Module error base classes now implement `toJSON()` for stable serialized error envelopes (`name`, `message`, `details`, and nested `cause`) across `AST.AI`, `AST.Cache`, `AST.Chat`, `AST.Config`, `AST.DBT`, `AST.GitHub`, `AST.Http`, `AST.Jobs`, `AST.Messaging`, `AST.RAG`, `AST.Runtime`, `AST.Secrets`, `AST.Storage`, `AST.Telemetry`, and `AST.Triggers`.
 - Workspace helper functions now enforce typed validation and typed error mapping:
   - `openSpreadsheetById`, `openSpreadsheetByUrl`, `readFileFromDrive`, `createFileInDrive`
@@ -212,6 +213,7 @@
   - `README.md` development gates include lint, local coverage, perf, security, docs, and Apps Script integration checks
   - `CONTRIBUTING.md` quality gates include `test:perf:check` and `test:security`
   - `docs/development/release.md` pre-release checks include `test:security`
+  - MkDocs nav now includes docs-site pages for contributing workflow and security policy
   - `docs/api/quick-reference.md` and `docs/api/tools.md` now include DataFrame/Series parity finishers (`stack`, `unstack`, `resample`, `rank`, `clip`, `rolling`, `expanding`, `ewm`)
 
 ### Docs / Changelog sync

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 ## Branching
 
-- Use `feature/` branch prefixes for implementation branches.
+- Use `codex/` branch prefixes for Codex-assisted implementation branches.
+- `feature/` prefixes are also acceptable for manual feature branches.
 - Keep PRs focused by scope (API/security, correctness, tests/CI, docs, release).
 
 ## Quality Gates
@@ -38,6 +39,16 @@ Override for local experimentation via:
 - Prefer explicit validation for public request objects.
 - Keep Apps Script service usage least-privilege and documented.
 
+## Documentation Sync Requirements
+
+When a PR changes public behavior, contracts, defaults, or configuration:
+
+1. Update the relevant API/getting-started docs under `docs/`.
+2. Update `docs/api/quick-reference.md` and/or `docs/api/tools.md` when surface area changes.
+3. Update `README.md` when top-level module coverage or setup guidance changes.
+4. Update `CHANGELOG.md` `v0.0.5 (unreleased)` with user-facing additions/changes/fixes.
+5. Update `mkdocs.yml` nav when adding new documentation pages.
+
 ## Naming Convention (Top-Level Functions)
 
 - Public top-level functions must be explicitly exposed:
@@ -59,3 +70,11 @@ Override for local experimentation via:
 
 - Use clear, descriptive commit messages.
 - Do not bundle unrelated refactors with behavior changes.
+
+## Pull Request Checklist
+
+Before requesting review:
+
+- all quality gates pass locally
+- docs are updated for any public-surface change
+- changelog entry is added/updated under `v0.0.5 (unreleased)`

--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ Module quickstarts:
 - Chat: <https://joe-broadhead.github.io/apps-script-tools/getting-started/chat-quickstart/>
 - Messaging: <https://joe-broadhead.github.io/apps-script-tools/getting-started/messaging-quickstart/>
 - Telemetry: <https://joe-broadhead.github.io/apps-script-tools/getting-started/telemetry-quickstart/>
+- Contributing guide: `CONTRIBUTING.md`
+- Release process: `RELEASE.md`
+- Security policy: `SECURITY.md`
+
+## Documentation standards
+
+- `README.md` stays overview-focused (what the library provides, how to install/use it quickly).
+- Detailed API contracts and operation behavior live in `docs/` (published via MkDocs).
+- Every user-facing change should be recorded under `CHANGELOG.md` in `v0.0.5 (unreleased)` until release.
+- When adding docs pages, include them in `mkdocs.yml` navigation.
 
 ## Cookbooks
 
@@ -114,6 +124,11 @@ Notes:
 - Keep project app code in `cookbooks/<project>/src/`.
 - Keep reusable logic in the library (`apps_script_tools/`).
 - `.clasp.json` and credentials stay local-only and untracked.
+
+Global structures note:
+
+- Structure classes are global constructors, not namespaced properties.
+- Use `new Queue()` (or `new Trie()`, etc.), not `new ASTX.Queue()`.
 
 ## Development
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,0 +1,46 @@
+# Contributing
+
+This page mirrors the repository contribution contract so contributors can work from the docs site.
+
+Source of truth: [`CONTRIBUTING.md`](https://github.com/joe-broadhead/apps-script-tools/blob/master/CONTRIBUTING.md).
+
+## Branching
+
+- Prefer `codex/` for Codex-assisted feature branches.
+- `feature/` is also valid for manual implementation branches.
+- Keep each PR scoped to one concern (behavior fix, API expansion, docs sync, CI, release prep).
+
+## Quality gates
+
+Run before opening a PR:
+
+```bash
+npm run lint
+npm run test:local:coverage
+npm run test:perf:check
+npm run test:security
+mkdocs build --strict
+```
+
+Apps Script integration checks when credentials are configured:
+
+```bash
+clasp push
+clasp run runAllTests
+```
+
+## Documentation requirements
+
+If public API behavior changes, update all applicable docs:
+
+- module API docs in `docs/api/`
+- quick indexes: `docs/api/quick-reference.md`, `docs/api/tools.md`
+- top-level overview in `README.md` when needed
+- `CHANGELOG.md` under `v0.0.5 (unreleased)`
+- `mkdocs.yml` nav for new pages
+
+## Naming and API conventions
+
+- Public surfaces belong on `AST` namespace bindings.
+- Internal top-level helpers must be clearly internal (`ast*`, `__ast*`, or `*_` suffix).
+- Public request contracts should validate strictly and emit typed errors.

--- a/docs/operations/security-policy.md
+++ b/docs/operations/security-policy.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+This page mirrors the repository security policy for docs-site discoverability.
+
+Source of truth: [`SECURITY.md`](https://github.com/joe-broadhead/apps-script-tools/blob/master/SECURITY.md).
+
+## Supported line
+
+- Current published release line: `v0.0.4`
+- Current development line on `master`: `v0.0.5` (unreleased)
+
+## How to report vulnerabilities
+
+Preferred:
+
+- GitHub private vulnerability report:
+  - <https://github.com/joe-broadhead/apps-script-tools/security/advisories/new>
+
+Fallback:
+
+- Open a maintainer contact issue without exploit details:
+  - <https://github.com/joe-broadhead/apps-script-tools/issues/new/choose>
+  - include `[SECURITY]` in the title
+
+## SLA targets
+
+- acknowledgement: within 3 business days
+- triage (severity + repro): within 7 business days
+- remediation plan:
+  - critical/high: within 14 days
+  - medium/low: within 30 days
+
+## Security defaults
+
+- unsafe SQL placeholder interpolation is disabled by default
+- dynamic string-evaluated predicates are not part of public API contracts
+- secret scanning and dependency/code scanning are enforced in CI

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,7 @@ nav:
     - Benchmarks: performance/benchmarks.md
     - Optimization Playbook: performance/optimization-playbook.md
   - Operations:
+    - Security Policy: operations/security-policy.md
     - Telemetry: operations/telemetry.md
     - AI Security: operations/ai-security.md
     - RAG Indexing: operations/rag-indexing.md
@@ -156,6 +157,7 @@ nav:
     - Testing: operations/testing.md
     - Troubleshooting: operations/troubleshooting.md
   - Development:
+    - Contributing: development/contributing.md
     - Architecture Decisions:
       - Overview: decisions/index.md
       - ADR Template: decisions/adr-template.md


### PR DESCRIPTION
## Summary
- align contributor docs and docs-site navigation for release readiness
- add docs-site pages for contributing workflow and security policy
- tighten README documentation standards and global structure usage note
- update unreleased changelog with the recent cache setMany cleanup/perf semantics fix

## Changes
- updated `README.md`
- updated `CONTRIBUTING.md`
- updated `mkdocs.yml`
- added `docs/development/contributing.md`
- added `docs/operations/security-policy.md`
- updated `CHANGELOG.md` (`v0.0.5` unreleased)

## Validation
- `npm run lint`
- `uv run mkdocs build --strict`
