### PR TITLE
feat(cookbooks): add jobs and triggers orchestration cookbook

### DIFF
--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -91,6 +91,7 @@ The template README documents:
 - `storage_ops`: practical `AST.Storage` example covering object CRUD, `walk`, `transfer`, `copyPrefix`, `deletePrefix`, and `sync`.
 - `github_issue_digest`: template-v2 GitHub automation cookbook for issues, PRs, checks, Actions, GraphQL, Projects v2, and dry-run mutation planning via `AST.GitHub`.
 - `http_ingestion_pipeline`: template-v2 `AST.Http` cookbook for resilient request flows, batch error handling, safe redaction, and optional cache/telemetry composition.
+- `jobs_triggers_orchestration`: template-v2 orchestration cookbook for `AST.Jobs` and `AST.Triggers`, including retry/resume flows, schedule bridge, and DLQ lifecycle.
 - `rag_chat_starter`: template-v2 webapp starter for grounded `AST.RAG` chat with `AST.Chat` thread persistence, linked citations, and configurable branding.
 - `dbt_manifest_summary`: template-v2 DBT artifact explorer for manifest search, lineage, governance, and artifact comparison via `AST.DBT`.
 - `storage_cache_warmer`: focused `AST.Cache` example for warming persisted `storage_json` cache entries.

--- a/cookbooks/jobs_triggers_orchestration/.clasp.json.example
+++ b/cookbooks/jobs_triggers_orchestration/.clasp.json.example
@@ -1,0 +1,4 @@
+{
+  "scriptId": "<COOKBOOK_SCRIPT_ID>",
+  "rootDir": "src"
+}

--- a/cookbooks/jobs_triggers_orchestration/.claspignore
+++ b/cookbooks/jobs_triggers_orchestration/.claspignore
@@ -1,0 +1,3 @@
+# `rootDir` is `src`, so only local-only config files need explicit ignores.
+.clasp.json
+.clasprc.json

--- a/cookbooks/jobs_triggers_orchestration/README.md
+++ b/cookbooks/jobs_triggers_orchestration/README.md
@@ -1,0 +1,187 @@
+# Jobs + Triggers Orchestration Cookbook
+
+This cookbook demonstrates reliable async orchestration with `AST.Jobs` and `AST.Triggers`.
+
+It uses only public `AST` APIs:
+
+- `ASTX.Jobs.enqueue(...)`
+- `ASTX.Jobs.resume(...)`
+- `ASTX.Jobs.status(...)`
+- `ASTX.Jobs.list(...)`
+- `ASTX.Jobs.run(...)`
+- `ASTX.Jobs.chain(...)`
+- `ASTX.Jobs.enqueueMany(...)`
+- `ASTX.Jobs.mapReduce(...)`
+- `ASTX.Jobs.schedule(...)`
+- `ASTX.Jobs.listFailed(...)`
+- `ASTX.Jobs.moveToDlq(...)`
+- `ASTX.Jobs.replayDlq(...)`
+- `ASTX.Jobs.purgeDlq(...)`
+- `ASTX.Triggers.upsert(...)`
+- `ASTX.Triggers.list(...)`
+- `ASTX.Triggers.runNow(...)`
+- `ASTX.Triggers.delete(...)`
+
+## What it covers
+
+Smoke flow:
+
+1. cleans stale cookbook trigger/job state
+2. creates one direct trigger with `ASTX.Triggers.upsert(...)`
+3. validates `list(...)` + `runNow(...)`
+4. enqueues a retryable job and verifies `queued -> paused -> completed` transitions via `resume(...)`
+5. deletes the trigger and removes cookbook state again
+
+Demo flow:
+
+1. runs a sequential `chain(...)`
+2. runs bounded fan-out via `enqueueMany(...)`
+3. runs a small `mapReduce(...)`
+4. provisions a trigger-backed scheduled job with `ASTX.Jobs.schedule(...)`
+5. executes `schedule(... run_now)` and then removes the trigger
+6. forces a failed job into DLQ, lists it, replays it idempotently, then purges replayed entries
+
+## Folder contract
+
+```text
+cookbooks/jobs_triggers_orchestration/
+  README.md
+  .clasp.json.example
+  .claspignore
+  src/
+    appsscript.json
+    00_Config.gs
+    10_EntryPoints.gs
+    20_Smoke.gs
+    30_Examples.gs
+    99_DevTools.gs
+```
+
+## Setup
+
+1. Copy `.clasp.json.example` to `.clasp.json`.
+2. Set your Apps Script `scriptId`.
+3. Replace `<PUBLISHED_AST_LIBRARY_VERSION>` in `src/appsscript.json`.
+4. Push with `clasp push`.
+5. Run `seedCookbookConfig()`.
+6. Run `runCookbookAll()`.
+
+## Script properties
+
+| Key | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `JOBS_TRIGGERS_APP_NAME` | Yes | `AST Jobs + Triggers Orchestration` | Display name included in cookbook output. |
+| `JOBS_TRIGGERS_JOB_PREFIX` | Yes | `AST_JOBS_COOKBOOK_` | Job state prefix used for deterministic cleanup. |
+| `JOBS_TRIGGERS_TRIGGER_PROPERTY_PREFIX` | Yes | `AST_TRIGGERS_COOKBOOK_` | Trigger definition prefix used for deterministic cleanup. |
+| `JOBS_TRIGGERS_TRIGGER_BASE_ID` | Yes | `ast_jobs_cookbook` | Base id used for created trigger definitions. |
+| `JOBS_TRIGGERS_TIMEZONE` | Yes | `Etc/UTC` | Time zone used for scheduled trigger examples. |
+| `JOBS_TRIGGERS_SCHEDULE_HOURS` | Yes | `6` | `every_hours` interval used by trigger examples. |
+| `JOBS_TRIGGERS_MAX_RETRIES` | Yes | `1` | Default retry budget for cookbook jobs. |
+| `JOBS_TRIGGERS_MAX_RUNTIME_MS` | Yes | `30000` | Default runtime budget for cookbook jobs. |
+| `JOBS_TRIGGERS_MAX_CONCURRENCY` | Yes | `2` | Bounded width for `enqueueMany(...)` and `mapReduce(...)`. |
+| `JOBS_TRIGGERS_VERBOSE` | No | `false` | Enables extra helper logging when true. |
+
+## Entrypoints
+
+Required template entrypoints:
+
+- `seedCookbookConfig()`
+- `validateCookbookConfig()`
+- `runCookbookSmoke()`
+- `runCookbookDemo()`
+- `runCookbookAll()`
+
+Additional helper entrypoints:
+
+- `cleanupCookbookArtifacts()`
+- `showCookbookContract()`
+- `showCookbookSources()`
+- `clearCookbookConfig()`
+
+## Expected outputs
+
+`runCookbookSmoke()` returns a payload like:
+
+```json
+{
+  "status": "ok",
+  "entrypoint": "runCookbookSmoke",
+  "trigger": {
+    "runNowMode": "direct"
+  },
+  "job": {
+    "transitions": ["queued", "paused", "completed"],
+    "finalStatus": "completed"
+  }
+}
+```
+
+`runCookbookDemo()` returns a payload like:
+
+```json
+{
+  "status": "ok",
+  "entrypoint": "runCookbookDemo",
+  "chain": {
+    "status": "completed"
+  },
+  "enqueueMany": {
+    "completedStatus": "completed"
+  },
+  "mapReduce": {
+    "status": "completed",
+    "reduce": 18
+  },
+  "schedule": {
+    "runNowMode": "jobs"
+  },
+  "dlq": {
+    "movedState": "queued",
+    "replayIdempotent": true
+  }
+}
+```
+
+## Idempotency and retry guidance
+
+- Use stable `propertyPrefix` values per app/workload so retries, resumes, and cleanup remain isolated.
+- Keep handler payloads JSON-serializable and deterministic.
+- Treat retries as re-execution, not continuation. Handlers should tolerate duplicate invocation.
+- Use bounded `maxConcurrency` for `enqueueMany(...)` and `mapReduce(...)` to control dependency width and Script Properties churn.
+- Use stable replay keys with `replayDlq(...)` when replay requests may be retried from an operator UI or webhook.
+
+## Safe trigger lifecycle patterns
+
+- Prefer stable `id` values on `ASTX.Triggers.upsert(...)` and `ASTX.Jobs.schedule(...)`.
+- Use `runNow(...)` or `schedule(... run_now)` to validate dispatch before waiting on real time-based execution.
+- Delete triggers explicitly when a cookbook/demo run is finished.
+- Keep trigger definitions and job checkpoints on separate prefixes so cleanup can be precise.
+- Run `cleanupCookbookArtifacts()` before repeating a manual test if a prior run was interrupted.
+
+## OAuth scopes
+
+Required Apps Script scope:
+
+- `https://www.googleapis.com/auth/script.scriptapp`
+
+## Troubleshooting
+
+`Cookbook config is invalid`
+
+- Run `seedCookbookConfig()` again.
+- Ensure numeric settings are valid integers within the documented bounds.
+
+`Trigger upsert fails with authorization errors`
+
+- Confirm the project has authorized `https://www.googleapis.com/auth/script.scriptapp`.
+- Re-run authorization after pushing updated scopes.
+
+`Job replay does not change status`
+
+- Confirm the job was moved into DLQ first with `moveToDlq(...)`.
+- Reuse the same `propertyPrefix` on replay that the original job used.
+
+`Repeated runs leave stale state`
+
+- Run `cleanupCookbookArtifacts()`.
+- Keep cookbook-specific `JOBS_TRIGGERS_JOB_PREFIX` and `JOBS_TRIGGERS_TRIGGER_PROPERTY_PREFIX` values unique per test project.

--- a/cookbooks/jobs_triggers_orchestration/README.md
+++ b/cookbooks/jobs_triggers_orchestration/README.md
@@ -75,7 +75,7 @@ cookbooks/jobs_triggers_orchestration/
 | `JOBS_TRIGGERS_TRIGGER_PROPERTY_PREFIX` | Yes | `AST_TRIGGERS_COOKBOOK_` | Trigger definition prefix used for deterministic cleanup. |
 | `JOBS_TRIGGERS_TRIGGER_BASE_ID` | Yes | `ast_jobs_cookbook` | Base id used for created trigger definitions. |
 | `JOBS_TRIGGERS_TIMEZONE` | Yes | `Etc/UTC` | Time zone used for scheduled trigger examples. |
-| `JOBS_TRIGGERS_SCHEDULE_HOURS` | Yes | `6` | `every_hours` interval used by trigger examples. |
+| `JOBS_TRIGGERS_SCHEDULE_HOURS` | Yes | `6` | `every_hours` interval used by trigger examples. Must be between `1` and `23`. |
 | `JOBS_TRIGGERS_MAX_RETRIES` | Yes | `1` | Default retry budget for cookbook jobs. |
 | `JOBS_TRIGGERS_MAX_RUNTIME_MS` | Yes | `30000` | Default runtime budget for cookbook jobs. |
 | `JOBS_TRIGGERS_MAX_CONCURRENCY` | Yes | `2` | Bounded width for `enqueueMany(...)` and `mapReduce(...)`. |

--- a/cookbooks/jobs_triggers_orchestration/src/00_Config.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/00_Config.gs
@@ -52,7 +52,7 @@ function cookbookConfigFields_() {
       defaultValue: 6,
       type: 'integer',
       min: 1,
-      max: 24,
+      max: 23,
       description: 'Hourly interval used by the scheduled trigger example.'
     },
     {

--- a/cookbooks/jobs_triggers_orchestration/src/00_Config.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/00_Config.gs
@@ -131,10 +131,10 @@ function cookbookNormalizeInteger_(value) {
     return null;
   }
   const normalized = Number(String(value).trim());
-  if (!Number.isFinite(normalized)) {
+  if (!Number.isFinite(normalized) || !Number.isInteger(normalized)) {
     return null;
   }
-  return Math.floor(normalized);
+  return normalized;
 }
 
 function cookbookNormalizeConfigValue_(field, rawValue) {

--- a/cookbooks/jobs_triggers_orchestration/src/00_Config.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/00_Config.gs
@@ -1,0 +1,346 @@
+function cookbookName_() {
+  return 'jobs_triggers_orchestration';
+}
+
+function cookbookAst_() {
+  return ASTLib.AST || ASTLib;
+}
+
+function cookbookScriptProperties_() {
+  return PropertiesService.getScriptProperties();
+}
+
+function cookbookTemplateVersion_() {
+  return 'v2';
+}
+
+function cookbookConfigFields_() {
+  return [
+    {
+      key: 'JOBS_TRIGGERS_APP_NAME',
+      required: true,
+      defaultValue: 'AST Jobs + Triggers Orchestration',
+      description: 'Human-readable name included in cookbook outputs.'
+    },
+    {
+      key: 'JOBS_TRIGGERS_JOB_PREFIX',
+      required: true,
+      defaultValue: 'AST_JOBS_COOKBOOK_',
+      description: 'Script properties prefix used for cookbook job state.'
+    },
+    {
+      key: 'JOBS_TRIGGERS_TRIGGER_PROPERTY_PREFIX',
+      required: true,
+      defaultValue: 'AST_TRIGGERS_COOKBOOK_',
+      description: 'Script properties prefix used for cookbook trigger definitions.'
+    },
+    {
+      key: 'JOBS_TRIGGERS_TRIGGER_BASE_ID',
+      required: true,
+      defaultValue: 'ast_jobs_cookbook',
+      description: 'Stable base id used for trigger definitions created by this cookbook.'
+    },
+    {
+      key: 'JOBS_TRIGGERS_TIMEZONE',
+      required: true,
+      defaultValue: 'Etc/UTC',
+      description: 'Time zone used for scheduled trigger examples.'
+    },
+    {
+      key: 'JOBS_TRIGGERS_SCHEDULE_HOURS',
+      required: true,
+      defaultValue: 6,
+      type: 'integer',
+      min: 1,
+      max: 24,
+      description: 'Hourly interval used by the scheduled trigger example.'
+    },
+    {
+      key: 'JOBS_TRIGGERS_MAX_RETRIES',
+      required: true,
+      defaultValue: 1,
+      type: 'integer',
+      min: 0,
+      max: 20,
+      description: 'Default retry budget used by cookbook job flows.'
+    },
+    {
+      key: 'JOBS_TRIGGERS_MAX_RUNTIME_MS',
+      required: true,
+      defaultValue: 30000,
+      type: 'integer',
+      min: 1000,
+      max: 600000,
+      description: 'Default runtime budget forwarded to AST.Jobs examples.'
+    },
+    {
+      key: 'JOBS_TRIGGERS_MAX_CONCURRENCY',
+      required: true,
+      defaultValue: 2,
+      type: 'integer',
+      min: 1,
+      max: 25,
+      description: 'Bounded fan-out width used by enqueueMany/mapReduce examples.'
+    },
+    {
+      key: 'JOBS_TRIGGERS_VERBOSE',
+      required: false,
+      defaultValue: false,
+      type: 'boolean',
+      description: 'Enable extra helper logging when true.'
+    }
+  ];
+}
+
+function cookbookConfigFieldMap_() {
+  const fields = cookbookConfigFields_();
+  const map = {};
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    map[fields[idx].key] = fields[idx];
+  }
+  return map;
+}
+
+function cookbookNormalizeString_(value, fallback) {
+  if (value == null) {
+    return fallback;
+  }
+  const normalized = String(value).trim();
+  return normalized === '' ? fallback : normalized;
+}
+
+function cookbookNormalizeBoolean_(value) {
+  if (value === true || value === false) {
+    return value;
+  }
+  if (value == null || value === '') {
+    return null;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (['true', '1', 'yes', 'y', 'on'].indexOf(normalized) !== -1) {
+    return true;
+  }
+  if (['false', '0', 'no', 'n', 'off'].indexOf(normalized) !== -1) {
+    return false;
+  }
+  return null;
+}
+
+function cookbookNormalizeInteger_(value) {
+  if (value == null || value === '') {
+    return null;
+  }
+  const normalized = Number(String(value).trim());
+  if (!Number.isFinite(normalized)) {
+    return null;
+  }
+  return Math.floor(normalized);
+}
+
+function cookbookNormalizeConfigValue_(field, rawValue) {
+  if (field.type === 'boolean') {
+    return cookbookNormalizeBoolean_(rawValue);
+  }
+  if (field.type === 'integer') {
+    return cookbookNormalizeInteger_(rawValue);
+  }
+  return cookbookNormalizeString_(rawValue, '');
+}
+
+function cookbookValidateOverrideKeys_(overrides) {
+  if (overrides == null) {
+    return;
+  }
+  if (Object.prototype.toString.call(overrides) !== '[object Object]') {
+    throw new Error('seedCookbookConfig overrides must be a plain object when provided.');
+  }
+  const known = cookbookConfigFieldMap_();
+  const unknown = [];
+  Object.keys(overrides).forEach(function (key) {
+    if (!known[key]) {
+      unknown.push(key);
+    }
+  });
+  if (unknown.length > 0) {
+    throw new Error('Unknown cookbook config overrides: ' + unknown.join(', '));
+  }
+}
+
+function cookbookValidationSummary_(result) {
+  return {
+    status: result.status,
+    cookbook: cookbookName_(),
+    templateVersion: result.templateVersion,
+    requiredKeys: result.requiredKeys,
+    optionalKeys: result.optionalKeys,
+    warnings: result.warnings,
+    errors: result.errors,
+    config: result.config
+  };
+}
+
+function cookbookLogResult_(label, payload) {
+  Logger.log(label + '\n' + JSON.stringify(payload, null, 2));
+  return payload;
+}
+
+function seedCookbookConfig(overrides) {
+  cookbookValidateOverrideKeys_(overrides);
+  const props = cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+  const next = {};
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    const field = fields[idx];
+    const overrideValue = overrides && Object.prototype.hasOwnProperty.call(overrides, field.key)
+      ? overrides[field.key]
+      : field.defaultValue;
+    next[field.key] = String(overrideValue);
+  }
+
+  props.setProperties(next, false);
+  return cookbookLogResult_(
+    'seedCookbookConfig',
+    cookbookValidationSummary_(validateCookbookConfig({ scriptProperties: props }))
+  );
+}
+
+function validateCookbookConfig(options) {
+  const runtimeOptions = options || {};
+  const props = runtimeOptions.scriptProperties || cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+  const config = {};
+  const warnings = [];
+  const errors = [];
+  const requiredKeys = [];
+  const optionalKeys = [];
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    const field = fields[idx];
+    const storedValue = props.getProperty(field.key);
+    const hasStoredValue = storedValue != null && storedValue !== '';
+    const rawValue = hasStoredValue ? storedValue : field.defaultValue;
+    const normalizedValue = cookbookNormalizeConfigValue_(field, rawValue);
+    config[field.key] = normalizedValue;
+
+    if (field.required) {
+      requiredKeys.push(field.key);
+    } else {
+      optionalKeys.push(field.key);
+    }
+
+    if (!hasStoredValue) {
+      warnings.push('Using cookbook default for ' + field.key + '.');
+    }
+
+    if (field.required && (normalizedValue == null || normalizedValue === '')) {
+      errors.push('Missing required cookbook config key ' + field.key + '.');
+    }
+
+    if (field.type === 'boolean' && normalizedValue == null) {
+      errors.push(field.key + ' must be a boolean-like value.');
+    }
+
+    if (field.type === 'integer') {
+      if (normalizedValue == null) {
+        errors.push(field.key + ' must be an integer.');
+      } else {
+        if (typeof field.min === 'number' && normalizedValue < field.min) {
+          errors.push(field.key + ' must be >= ' + field.min + '.');
+        }
+        if (typeof field.max === 'number' && normalizedValue > field.max) {
+          errors.push(field.key + ' must be <= ' + field.max + '.');
+        }
+      }
+    }
+  }
+
+  return {
+    status: errors.length > 0 ? 'error' : 'ok',
+    cookbook: cookbookName_(),
+    templateVersion: cookbookTemplateVersion_(),
+    requiredKeys: requiredKeys,
+    optionalKeys: optionalKeys,
+    warnings: warnings,
+    errors: errors,
+    config: config
+  };
+}
+
+function cookbookRequireValidConfig_() {
+  const validation = validateCookbookConfig();
+  if (validation.status !== 'ok') {
+    throw new Error('Cookbook config is invalid: ' + validation.errors.join(' | '));
+  }
+  return validation;
+}
+
+function cookbookPublicConfig_(config) {
+  return {
+    appName: config.JOBS_TRIGGERS_APP_NAME,
+    jobPrefix: config.JOBS_TRIGGERS_JOB_PREFIX,
+    triggerPropertyPrefix: config.JOBS_TRIGGERS_TRIGGER_PROPERTY_PREFIX,
+    triggerBaseId: config.JOBS_TRIGGERS_TRIGGER_BASE_ID,
+    timeZone: config.JOBS_TRIGGERS_TIMEZONE,
+    scheduleHours: config.JOBS_TRIGGERS_SCHEDULE_HOURS,
+    maxRetries: config.JOBS_TRIGGERS_MAX_RETRIES,
+    maxRuntimeMs: config.JOBS_TRIGGERS_MAX_RUNTIME_MS,
+    maxConcurrency: config.JOBS_TRIGGERS_MAX_CONCURRENCY,
+    verbose: config.JOBS_TRIGGERS_VERBOSE
+  };
+}
+
+function cookbookJobNames_(config) {
+  const namespace = config && config.JOBS_TRIGGERS_TRIGGER_BASE_ID
+    ? config.JOBS_TRIGGERS_TRIGGER_BASE_ID
+    : 'ast_jobs_cookbook';
+  return {
+    smokeRetry: namespace + ':smoke_retry_flow',
+    chain: namespace + ':demo_chain',
+    fanout: namespace + ':demo_fanout',
+    mapReduce: namespace + ':demo_map_reduce',
+    scheduled: namespace + ':demo_scheduled',
+    dlq: namespace + ':demo_dlq'
+  };
+}
+
+function cookbookDirectTriggerId_(config) {
+  return config.JOBS_TRIGGERS_TRIGGER_BASE_ID + '_direct';
+}
+
+function cookbookScheduledTriggerId_(config) {
+  return config.JOBS_TRIGGERS_TRIGGER_BASE_ID + '_scheduled';
+}
+
+function cookbookTriggerIds_(config) {
+  return [
+    cookbookDirectTriggerId_(config),
+    cookbookScheduledTriggerId_(config)
+  ];
+}
+
+function cookbookRetryMarkerKey_(config) {
+  return config.JOBS_TRIGGERS_JOB_PREFIX + 'COOKBOOK_RETRY_ONCE';
+}
+
+function cookbookDlqReplayMarkerKey_(config) {
+  return config.JOBS_TRIGGERS_JOB_PREFIX + 'COOKBOOK_DLQ_REPLAY';
+}
+
+function cookbookJobOptions_(config, overrides) {
+  const base = {
+    propertyPrefix: config.JOBS_TRIGGERS_JOB_PREFIX,
+    maxRetries: config.JOBS_TRIGGERS_MAX_RETRIES,
+    maxRuntimeMs: config.JOBS_TRIGGERS_MAX_RUNTIME_MS,
+    checkpointStore: 'properties'
+  };
+  return Object.assign(base, overrides || {});
+}
+
+function cookbookTriggerSchedule_(config) {
+  return {
+    type: 'every_hours',
+    every: config.JOBS_TRIGGERS_SCHEDULE_HOURS,
+    timeZone: config.JOBS_TRIGGERS_TIMEZONE
+  };
+}

--- a/cookbooks/jobs_triggers_orchestration/src/10_EntryPoints.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/10_EntryPoints.gs
@@ -1,0 +1,31 @@
+function runCookbookSmoke() {
+  const validation = cookbookRequireValidConfig_();
+  return cookbookLogResult_('runCookbookSmoke', runCookbookSmokeInternal_(validation.config));
+}
+
+function runCookbookDemo() {
+  const validation = cookbookRequireValidConfig_();
+  return cookbookLogResult_('runCookbookDemo', runCookbookDemoInternal_(validation.config));
+}
+
+function runCookbookAll() {
+  const validation = cookbookRequireValidConfig_();
+  const output = {
+    status: 'ok',
+    cookbook: cookbookName_(),
+    templateVersion: cookbookTemplateVersion_(),
+    config: cookbookPublicConfig_(validation.config),
+    smoke: runCookbookSmokeInternal_(validation.config),
+    demo: runCookbookDemoInternal_(validation.config),
+    completedAt: new Date().toISOString()
+  };
+  return cookbookLogResult_('runCookbookAll', output);
+}
+
+function cleanupCookbookArtifacts() {
+  const validation = cookbookRequireValidConfig_();
+  return cookbookLogResult_(
+    'cleanupCookbookArtifacts',
+    cookbookCleanupState_(cookbookAst_(), validation.config)
+  );
+}

--- a/cookbooks/jobs_triggers_orchestration/src/10_EntryPoints.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/10_EntryPoints.gs
@@ -24,8 +24,10 @@ function runCookbookAll() {
 
 function cleanupCookbookArtifacts() {
   const validation = cookbookRequireValidConfig_();
+  const ASTX = cookbookAst_();
+  cookbookConfigureRuntimes_(ASTX, validation.config);
   return cookbookLogResult_(
     'cleanupCookbookArtifacts',
-    cookbookCleanupState_(cookbookAst_(), validation.config)
+    cookbookCleanupState_(ASTX, validation.config)
   );
 }

--- a/cookbooks/jobs_triggers_orchestration/src/20_Smoke.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/20_Smoke.gs
@@ -1,0 +1,112 @@
+function runCookbookSmokeInternal_(config) {
+  const ASTX = cookbookAst_();
+  const startCleanup = cookbookCleanupState_(ASTX, config);
+  cookbookConfigureRuntimes_(ASTX, config);
+
+  const smokeJobName = cookbookJobNames_(config).smokeRetry;
+  const directTriggerId = cookbookDirectTriggerId_(config);
+  const directRequest = {
+    id: directTriggerId,
+    schedule: cookbookTriggerSchedule_(config),
+    dispatch: {
+      mode: 'direct',
+      handler: 'cookbookDirectTriggerHandler',
+      payload: {
+        marker: 'smoke'
+      }
+    },
+    metadata: {
+      cookbook: cookbookName_(),
+      flow: 'smoke'
+    }
+  };
+
+  const triggerUpsert = ASTX.Triggers.upsert(directRequest);
+  cookbookAssert_(
+    triggerUpsert.created === true || triggerUpsert.updated === true || triggerUpsert.noop === true,
+    'Expected direct trigger upsert to succeed.'
+  );
+
+  const triggerListed = ASTX.Triggers.list({
+    filters: {
+      ids: [directTriggerId]
+    },
+    options: {
+      limit: 10
+    }
+  });
+  cookbookAssert_(triggerListed.page.total === 1, 'Expected exactly one direct trigger definition.');
+
+  const triggerRunNow = ASTX.Triggers.runNow({
+    id: directTriggerId
+  });
+  cookbookAssert_(triggerRunNow.status === 'ok', 'Expected direct trigger runNow to succeed.');
+  cookbookAssert_(triggerRunNow.dispatchMode === 'direct', 'Expected direct dispatch mode.');
+
+  const queued = ASTX.Jobs.enqueue({
+    name: smokeJobName,
+    options: cookbookJobOptions_(config, {
+      maxRetries: 1
+    }),
+    steps: [
+      {
+        id: 'retry_once_step',
+        handler: 'cookbookJobsRetryableStep',
+        payload: {
+          value: 5
+        }
+      }
+    ]
+  });
+  cookbookAssert_(queued.status === 'queued', 'Expected smoke job to start queued.');
+
+  const firstResume = ASTX.Jobs.resume(queued.id);
+  cookbookAssert_(firstResume.status === 'paused', 'Expected first resume to pause for retry.');
+
+  const secondResume = ASTX.Jobs.resume(queued.id);
+  cookbookAssert_(secondResume.status === 'completed', 'Expected second resume to complete.');
+
+  const status = ASTX.Jobs.status(queued.id);
+  const listed = ASTX.Jobs.list({
+    name: smokeJobName,
+    limit: 10
+  });
+  cookbookAssert_(status.status === 'completed', 'Expected smoke status lookup to be completed.');
+  cookbookAssert_(listed.some(function (job) { return job.id === queued.id; }), 'Expected smoke job to appear in list output.');
+
+  const triggerDeleted = ASTX.Triggers.delete({
+    id: directTriggerId
+  });
+
+  const endCleanup = cookbookCleanupState_(ASTX, config);
+
+  return {
+    status: 'ok',
+    cookbook: cookbookName_(),
+    entrypoint: 'runCookbookSmoke',
+    appName: config.JOBS_TRIGGERS_APP_NAME,
+    startCleanup: startCleanup,
+    trigger: {
+      id: directTriggerId,
+      created: triggerUpsert.created === true,
+      updated: triggerUpsert.updated === true,
+      noop: triggerUpsert.noop === true,
+      listedTotal: triggerListed.page.total,
+      runNowMode: triggerRunNow.dispatchMode,
+      runNowSource: triggerRunNow.result && triggerRunNow.result.result
+        ? triggerRunNow.result.result.source
+        : null,
+      deleted: triggerDeleted.deleted || 0
+    },
+    job: {
+      id: queued.id,
+      name: smokeJobName,
+      transitions: [queued.status, firstResume.status, secondResume.status],
+      listedCount: listed.length,
+      finalStatus: status.status,
+      finalValue: status.results ? status.results.retry_once_step : null
+    },
+    endCleanup: endCleanup,
+    completedAt: new Date().toISOString()
+  };
+}

--- a/cookbooks/jobs_triggers_orchestration/src/20_Smoke.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/20_Smoke.gs
@@ -1,7 +1,9 @@
 function runCookbookSmokeInternal_(config) {
   const ASTX = cookbookAst_();
-  const startCleanup = cookbookCleanupState_(ASTX, config);
   cookbookConfigureRuntimes_(ASTX, config);
+  const startCleanup = cookbookCleanupState_(ASTX, config, {
+    preserveRuntimeConfig: true
+  });
 
   const smokeJobName = cookbookJobNames_(config).smokeRetry;
   const directTriggerId = cookbookDirectTriggerId_(config);

--- a/cookbooks/jobs_triggers_orchestration/src/30_Examples.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/30_Examples.gs
@@ -71,21 +71,56 @@ function cookbookCollectManagedTriggerIds_(ASTX, config) {
   return Object.keys(ids).sort();
 }
 
-function cookbookCollectKnownJobIds_(ASTX, config) {
-  const names = cookbookJobNames_(config);
+function cookbookTryParseObject_(rawValue) {
+  if (typeof rawValue !== 'string' || rawValue.length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function cookbookCollectKnownJobIds_(entries, config) {
   const ids = {};
+  const source = entries && typeof entries === 'object' ? entries : {};
+  const jobPrefix = config.JOBS_TRIGGERS_JOB_PREFIX;
+  const dlqPrefix = jobPrefix + 'DLQ_';
+  const keys = Object.keys(source);
 
-  Object.keys(names).forEach(function (key) {
-    const jobs = ASTX.Jobs.list({
-      name: names[key],
-      limit: 100
-    });
-    for (let idx = 0; idx < jobs.length; idx += 1) {
-      ids[jobs[idx].id] = true;
+  for (let idx = 0; idx < keys.length; idx += 1) {
+    const key = keys[idx];
+    if (key.indexOf(jobPrefix) !== 0 && key.indexOf(dlqPrefix) !== 0) {
+      continue;
     }
-  });
 
-  return Object.keys(ids);
+    const parsed = cookbookTryParseObject_(source[key]);
+    if (!parsed) {
+      continue;
+    }
+
+    if (typeof parsed.id === 'string' && parsed.id.length > 0) {
+      ids[parsed.id] = true;
+    }
+
+    if (typeof parsed.jobId === 'string' && parsed.jobId.length > 0) {
+      ids[parsed.jobId] = true;
+    }
+
+    if (parsed.items && typeof parsed.items === 'object') {
+      const itemIds = Object.keys(parsed.items);
+      for (let itemIdx = 0; itemIdx < itemIds.length; itemIdx += 1) {
+        if (itemIds[itemIdx]) {
+          ids[itemIds[itemIdx]] = true;
+        }
+      }
+    }
+  }
+
+  return Object.keys(ids).sort();
 }
 
 function cookbookCleanupState_(ASTX, config, options) {
@@ -119,7 +154,7 @@ function cookbookCleanupState_(ASTX, config, options) {
     }
   });
 
-  const jobIds = cookbookCollectKnownJobIds_(ASTX, config);
+  const jobIds = cookbookCollectKnownJobIds_(entries, config);
   for (let idx = 0; idx < jobIds.length; idx += 1) {
     keysToDelete['AST_JOBS_LOCATOR_' + jobIds[idx]] = true;
     keysToDelete['AST_JOBS_DLQ_LOCATOR_' + jobIds[idx]] = true;

--- a/cookbooks/jobs_triggers_orchestration/src/30_Examples.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/30_Examples.gs
@@ -45,7 +45,8 @@ function cookbookCollectKnownJobIds_(ASTX, config) {
   return Object.keys(ids);
 }
 
-function cookbookCleanupState_(ASTX, config) {
+function cookbookCleanupState_(ASTX, config, options) {
+  const runtimeOptions = options && typeof options === 'object' ? options : {};
   const props = cookbookScriptProperties_();
   const deletedTriggerIds = [];
   const triggerIds = cookbookTriggerIds_(config);
@@ -93,8 +94,10 @@ function cookbookCleanupState_(ASTX, config) {
     props.deleteProperty(deletedKeys[idx]);
   }
 
-  ASTX.Jobs.clearConfig();
-  ASTX.Triggers.clearConfig();
+  if (runtimeOptions.preserveRuntimeConfig !== true) {
+    ASTX.Jobs.clearConfig();
+    ASTX.Triggers.clearConfig();
+  }
 
   return {
     status: 'ok',
@@ -185,8 +188,10 @@ function cookbookJobsDlqReplayHandler() {
 
 function runCookbookDemoInternal_(config) {
   const ASTX = cookbookAst_();
-  const startCleanup = cookbookCleanupState_(ASTX, config);
   cookbookConfigureRuntimes_(ASTX, config);
+  const startCleanup = cookbookCleanupState_(ASTX, config, {
+    preserveRuntimeConfig: true
+  });
 
   const names = cookbookJobNames_(config);
   const scheduledTriggerId = cookbookScheduledTriggerId_(config);

--- a/cookbooks/jobs_triggers_orchestration/src/30_Examples.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/30_Examples.gs
@@ -1,0 +1,377 @@
+function cookbookAssert_(condition, message) {
+  if (!condition) {
+    throw new Error(message || 'Cookbook assertion failed.');
+  }
+}
+
+function cookbookConfigureRuntimes_(ASTX, config) {
+  ASTX.Jobs.clearConfig();
+  ASTX.Triggers.clearConfig();
+
+  ASTX.Jobs.configure({
+    AST_JOBS_DEFAULT_MAX_RETRIES: config.JOBS_TRIGGERS_MAX_RETRIES,
+    AST_JOBS_DEFAULT_MAX_RUNTIME_MS: config.JOBS_TRIGGERS_MAX_RUNTIME_MS,
+    AST_JOBS_LEASE_TTL_MS: config.JOBS_TRIGGERS_MAX_RUNTIME_MS,
+    AST_JOBS_CHECKPOINT_STORE: 'properties',
+    AST_JOBS_PROPERTY_PREFIX: config.JOBS_TRIGGERS_JOB_PREFIX
+  }, {
+    merge: false
+  });
+
+  ASTX.Triggers.configure({
+    AST_TRIGGERS_PROPERTY_PREFIX: config.JOBS_TRIGGERS_TRIGGER_PROPERTY_PREFIX,
+    AST_TRIGGERS_DEFAULT_TIMEZONE: config.JOBS_TRIGGERS_TIMEZONE,
+    AST_TRIGGERS_DEFAULT_DISPATCH_MODE: 'direct',
+    AST_TRIGGERS_JOBS_AUTO_RESUME: 'true'
+  }, {
+    merge: false
+  });
+}
+
+function cookbookCollectKnownJobIds_(ASTX, config) {
+  const names = cookbookJobNames_(config);
+  const ids = {};
+
+  Object.keys(names).forEach(function (key) {
+    const jobs = ASTX.Jobs.list({
+      name: names[key],
+      limit: 100
+    });
+    for (let idx = 0; idx < jobs.length; idx += 1) {
+      ids[jobs[idx].id] = true;
+    }
+  });
+
+  return Object.keys(ids);
+}
+
+function cookbookCleanupState_(ASTX, config) {
+  const props = cookbookScriptProperties_();
+  const deletedTriggerIds = [];
+  const triggerIds = cookbookTriggerIds_(config);
+
+  for (let idx = 0; idx < triggerIds.length; idx += 1) {
+    try {
+      const response = ASTX.Triggers.delete({
+        id: triggerIds[idx]
+      });
+      if (response && response.deleted > 0) {
+        deletedTriggerIds.push(triggerIds[idx]);
+      }
+    } catch (error) {
+      if (!error || !error.message || String(error.message).toLowerCase().indexOf('not found') === -1) {
+        throw error;
+      }
+    }
+  }
+
+  const entries = typeof props.getProperties === 'function' ? props.getProperties() : {};
+  const keysToDelete = {};
+  const protectedMarkers = [
+    cookbookRetryMarkerKey_(config),
+    cookbookDlqReplayMarkerKey_(config)
+  ];
+
+  Object.keys(entries).forEach(function (key) {
+    if (
+      key.indexOf(config.JOBS_TRIGGERS_JOB_PREFIX) === 0 ||
+      key.indexOf(config.JOBS_TRIGGERS_TRIGGER_PROPERTY_PREFIX) === 0 ||
+      protectedMarkers.indexOf(key) !== -1
+    ) {
+      keysToDelete[key] = true;
+    }
+  });
+
+  const jobIds = cookbookCollectKnownJobIds_(ASTX, config);
+  for (let idx = 0; idx < jobIds.length; idx += 1) {
+    keysToDelete['AST_JOBS_LOCATOR_' + jobIds[idx]] = true;
+    keysToDelete['AST_JOBS_DLQ_LOCATOR_' + jobIds[idx]] = true;
+  }
+
+  const deletedKeys = Object.keys(keysToDelete);
+  for (let idx = 0; idx < deletedKeys.length; idx += 1) {
+    props.deleteProperty(deletedKeys[idx]);
+  }
+
+  ASTX.Jobs.clearConfig();
+  ASTX.Triggers.clearConfig();
+
+  return {
+    status: 'ok',
+    cookbook: cookbookName_(),
+    deletedTriggerIds: deletedTriggerIds,
+    deletedJobIds: jobIds,
+    deletedPropertyCount: deletedKeys.length
+  };
+}
+
+function cookbookDirectTriggerHandler(input) {
+  return {
+    ok: true,
+    payload: input && input.payload ? input.payload : null,
+    source: input && input.source ? input.source : null
+  };
+}
+
+function cookbookJobsRetryableStep(input) {
+  const config = cookbookRequireValidConfig_().config;
+  const props = cookbookScriptProperties_();
+  const markerKey = cookbookRetryMarkerKey_(config);
+  if (props.getProperty(markerKey) !== 'done') {
+    props.setProperty(markerKey, 'done');
+    throw new Error('retry-once');
+  }
+  return {
+    recovered: true,
+    value: input && input.payload ? input.payload.value : null
+  };
+}
+
+function cookbookJobsChainSeedHandler(input) {
+  return Number(input && input.payload ? input.payload.base : 0) + 1;
+}
+
+function cookbookJobsChainFinalizeHandler(input) {
+  return Number(input && input.results ? input.results.chain_step_1 : 0) * 2;
+}
+
+function cookbookJobsFanoutHandler(input) {
+  const payload = input && input.payload ? input.payload : {};
+  const multiplier = payload.shared ? Number(payload.shared.multiplier || 1) : 1;
+  return {
+    item: payload.item || null,
+    scaled: Number(payload.item && payload.item.value ? payload.item.value : 0) * multiplier,
+    position: payload.position
+  };
+}
+
+function cookbookJobsMapHandler(input) {
+  const payload = input && input.payload ? input.payload : {};
+  const bias = payload.shared ? Number(payload.shared.bias || 0) : 0;
+  return Number(payload.item && payload.item.score ? payload.item.score : 0) + bias;
+}
+
+function cookbookJobsReduceHandler(input) {
+  const payload = input && input.payload ? input.payload : {};
+  const results = input && input.results ? input.results : {};
+  const ids = Array.isArray(payload.mapStepIds) ? payload.mapStepIds : [];
+  let sum = 0;
+  for (let idx = 0; idx < ids.length; idx += 1) {
+    sum += Number(results[ids[idx]] || 0);
+  }
+  return sum;
+}
+
+function cookbookJobsScheduledHandler(input) {
+  const payload = input && input.payload ? input.payload : {};
+  return {
+    processed: Number(payload.value || 0) * 2,
+    source: 'scheduled_job'
+  };
+}
+
+function cookbookJobsDlqReplayHandler() {
+  const config = cookbookRequireValidConfig_().config;
+  const props = cookbookScriptProperties_();
+  const markerKey = cookbookDlqReplayMarkerKey_(config);
+  if (props.getProperty(markerKey) !== 'ready') {
+    props.setProperty(markerKey, 'ready');
+    throw new Error('fail-before-dlq-replay');
+  }
+  return {
+    replayed: true
+  };
+}
+
+function runCookbookDemoInternal_(config) {
+  const ASTX = cookbookAst_();
+  const startCleanup = cookbookCleanupState_(ASTX, config);
+  cookbookConfigureRuntimes_(ASTX, config);
+
+  const names = cookbookJobNames_(config);
+  const scheduledTriggerId = cookbookScheduledTriggerId_(config);
+
+  const chain = ASTX.Jobs.chain({
+    name: names.chain,
+    tasks: [
+      {
+        handler: 'cookbookJobsChainSeedHandler',
+        payload: { base: 3 }
+      },
+      {
+        handler: 'cookbookJobsChainFinalizeHandler'
+      }
+    ],
+    options: cookbookJobOptions_(config)
+  });
+  cookbookAssert_(chain.status === 'completed', 'Expected chain helper to complete.');
+
+  const fanoutQueued = ASTX.Jobs.enqueueMany({
+    name: names.fanout,
+    mode: 'enqueue',
+    handler: 'cookbookJobsFanoutHandler',
+    items: [
+      { value: 2 },
+      { value: 4 },
+      { value: 6 }
+    ],
+    sharedPayload: {
+      multiplier: 3
+    },
+    maxConcurrency: config.JOBS_TRIGGERS_MAX_CONCURRENCY,
+    options: cookbookJobOptions_(config)
+  });
+  const fanoutCompleted = ASTX.Jobs.resume(fanoutQueued.id);
+  cookbookAssert_(fanoutCompleted.status === 'completed', 'Expected enqueueMany flow to complete after resume.');
+
+  const mapReduce = ASTX.Jobs.mapReduce({
+    name: names.mapReduce,
+    items: [
+      { score: 3 },
+      { score: 5 },
+      { score: 7 }
+    ],
+    mapHandler: 'cookbookJobsMapHandler',
+    reduceHandler: 'cookbookJobsReduceHandler',
+    mapPayload: {
+      bias: 1
+    },
+    maxConcurrency: config.JOBS_TRIGGERS_MAX_CONCURRENCY,
+    options: cookbookJobOptions_(config)
+  });
+  cookbookAssert_(mapReduce.status === 'completed', 'Expected mapReduce helper to complete.');
+
+  const scheduledUpsert = ASTX.Jobs.schedule({
+    operation: 'upsert',
+    id: scheduledTriggerId,
+    autoResumeJobs: true,
+    schedule: cookbookTriggerSchedule_(config),
+    name: names.scheduled,
+    steps: [
+      {
+        id: 'scheduled_step',
+        handler: 'cookbookJobsScheduledHandler',
+        payload: {
+          value: 11
+        }
+      }
+    ],
+    options: cookbookJobOptions_(config),
+    metadata: {
+      cookbook: cookbookName_(),
+      flow: 'demo_schedule'
+    }
+  });
+  const scheduledList = ASTX.Jobs.schedule({
+    operation: 'list',
+    limit: 20,
+    includeOrphans: false
+  });
+  const scheduledRunNow = ASTX.Jobs.schedule({
+    operation: 'run_now',
+    id: scheduledTriggerId
+  });
+  const scheduledDelete = ASTX.Jobs.schedule({
+    operation: 'delete',
+    id: scheduledTriggerId
+  });
+  cookbookAssert_(scheduledUpsert.status === 'ok', 'Expected schedule upsert to succeed.');
+  cookbookAssert_(scheduledRunNow.status === 'ok', 'Expected scheduled trigger run_now to succeed.');
+
+  const failedJob = ASTX.Jobs.run({
+    name: names.dlq,
+    options: cookbookJobOptions_(config, {
+      maxRetries: 0
+    }),
+    steps: [
+      {
+        id: 'dlq_step',
+        handler: 'cookbookJobsDlqReplayHandler'
+      }
+    ]
+  });
+  cookbookAssert_(failedJob.status === 'failed', 'Expected DLQ demo job to fail before replay.');
+
+  const movedToDlq = ASTX.Jobs.moveToDlq(failedJob.id);
+  const failedList = ASTX.Jobs.listFailed({
+    name: names.dlq,
+    inDlq: 'only',
+    includeJob: false,
+    limit: 20
+  });
+  const replayKey = config.JOBS_TRIGGERS_TRIGGER_BASE_ID + '_replay';
+  const replay = ASTX.Jobs.replayDlq({
+    name: names.dlq,
+    propertyPrefix: config.JOBS_TRIGGERS_JOB_PREFIX,
+    limit: 20,
+    maxConcurrency: 1,
+    idempotencyKey: replayKey
+  });
+  const replayRepeat = ASTX.Jobs.replayDlq({
+    name: names.dlq,
+    propertyPrefix: config.JOBS_TRIGGERS_JOB_PREFIX,
+    limit: 20,
+    maxConcurrency: 1,
+    idempotencyKey: replayKey
+  });
+  const purge = ASTX.Jobs.purgeDlq({
+    name: names.dlq,
+    propertyPrefix: config.JOBS_TRIGGERS_JOB_PREFIX,
+    state: 'replayed',
+    limit: 20
+  });
+
+  const demoSummary = {
+    status: 'ok',
+    cookbook: cookbookName_(),
+    entrypoint: 'runCookbookDemo',
+    appName: config.JOBS_TRIGGERS_APP_NAME,
+    startCleanup: startCleanup,
+    chain: {
+      status: chain.status,
+      result: chain.results ? chain.results.chain_step_2 : null
+    },
+    enqueueMany: {
+      queuedStatus: fanoutQueued.status,
+      completedStatus: fanoutCompleted.status,
+      item3Scaled: fanoutCompleted.results ? fanoutCompleted.results.item_3.scaled : null
+    },
+    mapReduce: {
+      status: mapReduce.status,
+      reduce: mapReduce.results ? mapReduce.results.reduce : null,
+      mapCount: mapReduce.orchestration && mapReduce.orchestration.stages && mapReduce.orchestration.stages.map
+        ? mapReduce.orchestration.stages.map.counts.total
+        : null
+    },
+    schedule: {
+      triggerId: scheduledTriggerId,
+      created: scheduledUpsert.result ? scheduledUpsert.result.created === true : false,
+      updated: scheduledUpsert.result ? scheduledUpsert.result.updated === true : false,
+      noop: scheduledUpsert.result ? scheduledUpsert.result.noop === true : false,
+      listedTotal: scheduledList.result && scheduledList.result.page ? scheduledList.result.page.total : null,
+      listedMatchCount: Array.isArray(scheduledList.result && scheduledList.result.items ? scheduledList.result.items : null)
+        ? scheduledList.result.items.filter(function (item) { return item.id === scheduledTriggerId; }).length
+        : 0,
+      runNowMode: scheduledRunNow.result ? scheduledRunNow.result.dispatchMode : null,
+      scheduledValue: scheduledRunNow.result
+        && scheduledRunNow.result.result
+        && scheduledRunNow.result.result.resumed
+        && scheduledRunNow.result.result.resumed.results
+        ? scheduledRunNow.result.result.resumed.results.scheduled_step.processed
+        : null,
+      deleted: scheduledDelete.result ? scheduledDelete.result.deleted || 0 : 0
+    },
+    dlq: {
+      failedStatus: failedJob.status,
+      movedState: movedToDlq.state,
+      listedCount: failedList.length,
+      replayed: replay.counts ? replay.counts.replayed : null,
+      replayIdempotent: replayRepeat.idempotent === true,
+      purged: purge.deletedCount
+    },
+    completedAt: new Date().toISOString()
+  };
+
+  demoSummary.endCleanup = cookbookCleanupState_(ASTX, config);
+  return demoSummary;
+}

--- a/cookbooks/jobs_triggers_orchestration/src/30_Examples.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/30_Examples.gs
@@ -48,23 +48,14 @@ function cookbookCollectKnownJobIds_(ASTX, config) {
 function cookbookCleanupState_(ASTX, config, options) {
   const runtimeOptions = options && typeof options === 'object' ? options : {};
   const props = cookbookScriptProperties_();
-  const deletedTriggerIds = [];
-  const triggerIds = cookbookTriggerIds_(config);
-
-  for (let idx = 0; idx < triggerIds.length; idx += 1) {
-    try {
-      const response = ASTX.Triggers.delete({
-        id: triggerIds[idx]
-      });
-      if (response && response.deleted > 0) {
-        deletedTriggerIds.push(triggerIds[idx]);
-      }
-    } catch (error) {
-      if (!error || !error.message || String(error.message).toLowerCase().indexOf('not found') === -1) {
-        throw error;
-      }
+  const deleteAllResponse = ASTX.Triggers.delete({
+    options: {
+      all: true
     }
-  }
+  });
+  const deletedTriggerIds = Array.isArray(deleteAllResponse && deleteAllResponse.items)
+    ? deleteAllResponse.items.map(function (item) { return item.id; })
+    : [];
 
   const entries = typeof props.getProperties === 'function' ? props.getProperties() : {};
   const keysToDelete = {};

--- a/cookbooks/jobs_triggers_orchestration/src/30_Examples.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/30_Examples.gs
@@ -28,6 +28,49 @@ function cookbookConfigureRuntimes_(ASTX, config) {
   });
 }
 
+function cookbookIsCookbookTriggerItem_(item, config) {
+  const currentIds = cookbookTriggerIds_(config);
+  for (let idx = 0; idx < currentIds.length; idx += 1) {
+    if (item && item.id === currentIds[idx]) {
+      return true;
+    }
+  }
+
+  const definition = item && item.definition ? item.definition : null;
+  const metadata = definition && definition.metadata ? definition.metadata : null;
+  return Boolean(metadata && metadata.cookbook === cookbookName_());
+}
+
+function cookbookCollectManagedTriggerIds_(ASTX, config) {
+  const ids = {};
+  let offset = 0;
+  const limit = 100;
+
+  while (true) {
+    const response = ASTX.Triggers.list({
+      options: {
+        limit: limit,
+        offset: offset,
+        includeRaw: true
+      }
+    });
+    const items = Array.isArray(response && response.items) ? response.items : [];
+
+    for (let idx = 0; idx < items.length; idx += 1) {
+      if (cookbookIsCookbookTriggerItem_(items[idx], config)) {
+        ids[items[idx].id] = true;
+      }
+    }
+
+    if (!response || !response.page || response.page.hasMore !== true) {
+      break;
+    }
+    offset += limit;
+  }
+
+  return Object.keys(ids).sort();
+}
+
 function cookbookCollectKnownJobIds_(ASTX, config) {
   const names = cookbookJobNames_(config);
   const ids = {};
@@ -48,14 +91,17 @@ function cookbookCollectKnownJobIds_(ASTX, config) {
 function cookbookCleanupState_(ASTX, config, options) {
   const runtimeOptions = options && typeof options === 'object' ? options : {};
   const props = cookbookScriptProperties_();
-  const deleteAllResponse = ASTX.Triggers.delete({
-    options: {
-      all: true
+  const managedTriggerIds = cookbookCollectManagedTriggerIds_(ASTX, config);
+  const deletedTriggerIds = [];
+
+  for (let idx = 0; idx < managedTriggerIds.length; idx += 1) {
+    const response = ASTX.Triggers.delete({
+      id: managedTriggerIds[idx]
+    });
+    if (response && response.deleted > 0) {
+      deletedTriggerIds.push(managedTriggerIds[idx]);
     }
-  });
-  const deletedTriggerIds = Array.isArray(deleteAllResponse && deleteAllResponse.items)
-    ? deleteAllResponse.items.map(function (item) { return item.id; })
-    : [];
+  }
 
   const entries = typeof props.getProperties === 'function' ? props.getProperties() : {};
   const keysToDelete = {};
@@ -67,7 +113,6 @@ function cookbookCleanupState_(ASTX, config, options) {
   Object.keys(entries).forEach(function (key) {
     if (
       key.indexOf(config.JOBS_TRIGGERS_JOB_PREFIX) === 0 ||
-      key.indexOf(config.JOBS_TRIGGERS_TRIGGER_PROPERTY_PREFIX) === 0 ||
       protectedMarkers.indexOf(key) !== -1
     ) {
       keysToDelete[key] = true;

--- a/cookbooks/jobs_triggers_orchestration/src/99_DevTools.gs
+++ b/cookbooks/jobs_triggers_orchestration/src/99_DevTools.gs
@@ -1,0 +1,48 @@
+function clearCookbookConfig() {
+  const props = cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    props.deleteProperty(fields[idx].key);
+  }
+  return cookbookLogResult_('clearCookbookConfig', {
+    status: 'ok',
+    cookbook: cookbookName_(),
+    templateVersion: cookbookTemplateVersion_(),
+    clearedKeys: fields.map(function (field) { return field.key; })
+  });
+}
+
+function showCookbookContract() {
+  return cookbookLogResult_('showCookbookContract', {
+    cookbook: cookbookName_(),
+    templateVersion: cookbookTemplateVersion_(),
+    requiredEntrypoints: [
+      'seedCookbookConfig',
+      'validateCookbookConfig',
+      'runCookbookSmoke',
+      'runCookbookDemo',
+      'runCookbookAll',
+      'cleanupCookbookArtifacts'
+    ],
+    scriptProperties: cookbookConfigFields_().map(function (field) {
+      return {
+        key: field.key,
+        required: field.required,
+        defaultValue: field.defaultValue,
+        description: field.description
+      };
+    })
+  });
+}
+
+function showCookbookSources() {
+  const validation = cookbookRequireValidConfig_();
+  return cookbookLogResult_('showCookbookSources', {
+    cookbook: cookbookName_(),
+    config: cookbookPublicConfig_(validation.config),
+    jobNames: cookbookJobNames_(validation.config),
+    triggerIds: cookbookTriggerIds_(validation.config),
+    schedule: cookbookTriggerSchedule_(validation.config),
+    jobOptions: cookbookJobOptions_(validation.config)
+  });
+}

--- a/cookbooks/jobs_triggers_orchestration/src/appsscript.json
+++ b/cookbooks/jobs_triggers_orchestration/src/appsscript.json
@@ -1,0 +1,17 @@
+{
+  "timeZone": "Etc/UTC",
+  "dependencies": {
+    "libraries": [
+      {
+        "userSymbol": "ASTLib",
+        "libraryId": "1gZ_6DiLeDhh-a4qcezluTFDshw4OEhTXbeD3wthl_UdHEAFkXf6i6Ho_",
+        "version": "<PUBLISHED_AST_LIBRARY_VERSION>"
+      }
+    ]
+  },
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/script.scriptapp"
+  ],
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
+}

--- a/docs/getting-started/cookbooks.md
+++ b/docs/getting-started/cookbooks.md
@@ -97,6 +97,7 @@ Put reusable logic back into the library (`apps_script_tools/`) only when it is 
 - `storage_ops`: practical `AST.Storage` cookbook covering object CRUD plus `walk`, `transfer`, `copyPrefix`, `deletePrefix`, and `sync`.
 - `github_issue_digest`: template-v2 GitHub automation cookbook for issues, PRs, checks, Actions, GraphQL, Projects v2, and dry-run mutation planning via `AST.GitHub`.
 - `http_ingestion_pipeline`: template-v2 `AST.Http` cookbook for resilient request flows, batch error handling, safe redaction, and optional cache/telemetry composition.
+- `jobs_triggers_orchestration`: template-v2 orchestration cookbook for `AST.Jobs` and `AST.Triggers`, including retry/resume flows, schedule bridge, and DLQ lifecycle.
 - `rag_chat_starter`: template-v2 webapp starter for grounded `AST.RAG` chat with `AST.Chat` thread persistence, linked citations, and configurable branding.
 - `dbt_manifest_summary`: template-v2 DBT artifact explorer covering manifest load/search, lineage, governance, and artifact comparison via `AST.DBT`.
 - `storage_cache_warmer`: focused `AST.Cache` example for warming persisted `storage_json` cache entries.


### PR DESCRIPTION
Closes #303
Part of #295.

## Summary
Add a template-v2 cookbook for reliable async orchestration with `AST.Jobs` and `AST.Triggers`.

## What this adds
- new cookbook: `cookbooks/jobs_triggers_orchestration`
- deterministic smoke flow for:
  - direct trigger lifecycle with `AST.Triggers.upsert/list/runNow/delete`
  - retry/resume status transitions with `AST.Jobs.enqueue/resume/status/list`
- richer demo flow for:
  - `AST.Jobs.chain`
  - `AST.Jobs.enqueueMany`
  - `AST.Jobs.mapReduce`
  - `AST.Jobs.schedule` bridge (`upsert`, `list`, `run_now`, `delete`)
  - DLQ lifecycle with `listFailed`, `moveToDlq`, `replayDlq`, and `purgeDlq`
- explicit cleanup entrypoint so cookbook runs are repeatable and do not leave cookbook-owned trigger/job state behind
- cookbook catalog updates in:
  - `cookbooks/README.md`
  - `docs/getting-started/cookbooks.md`

## Contract and implementation notes
- stays on template-v2 shape:
  - `seedCookbookConfig()`
  - `validateCookbookConfig()`
  - `runCookbookSmoke()`
  - `runCookbookDemo()`
  - `runCookbookAll()`
- uses only public `AST` APIs
- namespaces cookbook job names off the configured trigger base id so cleanup is scoped to cookbook-owned artifacts
- documents idempotency/retry guidance and safe trigger lifecycle patterns in the cookbook README

## Validation
- `npm run lint`
- `uv run mkdocs build --strict`
