### PR TITLE
feat(cookbooks): add telemetry alerting cookbook

### DIFF
--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -92,6 +92,7 @@ The template README documents:
 - `github_issue_digest`: template-v2 GitHub automation cookbook for issues, PRs, checks, Actions, GraphQL, Projects v2, and dry-run mutation planning via `AST.GitHub`.
 - `http_ingestion_pipeline`: template-v2 `AST.Http` cookbook for resilient request flows, batch error handling, safe redaction, and optional cache/telemetry composition.
 - `jobs_triggers_orchestration`: template-v2 orchestration cookbook for `AST.Jobs` and `AST.Triggers`, including retry/resume flows, schedule bridge, and DLQ lifecycle.
+- `telemetry_alerting`: template-v2 observability cookbook for `AST.Telemetry` and `AST.TelemetryHelpers`, including redaction checks, grouped metrics, alert rules, and dry-run notifications.
 - `rag_chat_starter`: template-v2 webapp starter for grounded `AST.RAG` chat with `AST.Chat` thread persistence, linked citations, and configurable branding.
 - `dbt_manifest_summary`: template-v2 DBT artifact explorer for manifest search, lineage, governance, and artifact comparison via `AST.DBT`.
 - `storage_cache_warmer`: focused `AST.Cache` example for warming persisted `storage_json` cache entries.

--- a/cookbooks/telemetry_alerting/.clasp.json.example
+++ b/cookbooks/telemetry_alerting/.clasp.json.example
@@ -1,0 +1,4 @@
+{
+  "scriptId": "<COOKBOOK_SCRIPT_ID>",
+  "rootDir": "src"
+}

--- a/cookbooks/telemetry_alerting/.claspignore
+++ b/cookbooks/telemetry_alerting/.claspignore
@@ -1,0 +1,3 @@
+# `rootDir` is `src`, so only local-only config files need explicit ignores.
+.clasp.json
+.clasprc.json

--- a/cookbooks/telemetry_alerting/README.md
+++ b/cookbooks/telemetry_alerting/README.md
@@ -1,0 +1,133 @@
+# Telemetry Alerting Cookbook
+
+Template-v2 cookbook for `AST.Telemetry` and `AST.TelemetryHelpers`.
+
+This cookbook demonstrates:
+- manual span/event recording
+- grouped query and aggregate diagnostics
+- redaction behavior for secret-like keys
+- alert rule creation, listing, evaluation, and dry-run notification
+- helper-based instrumentation with `ASTX.TelemetryHelpers.withSpan(...)` and `wrap(...)`
+- inline telemetry export for inspection without external infrastructure
+
+## Setup
+
+1. Copy `.clasp.json.example` to `.clasp.json` and set the target `scriptId`.
+2. Replace `<PUBLISHED_AST_LIBRARY_VERSION>` in `src/appsscript.json`.
+3. `clasp push`
+4. Run `seedCookbookConfig()`.
+5. Run `runCookbookAll()`.
+
+## Script properties
+
+| Key | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `TELEMETRY_COOKBOOK_APP_NAME` | Yes | `AST Telemetry Alerting` | Human-readable cookbook name used in outputs and alert labels |
+| `TELEMETRY_COOKBOOK_SINK` | Yes | `logger` | Telemetry sink: `logger`, `drive_json`, `storage_json` |
+| `TELEMETRY_COOKBOOK_FLUSH_MODE` | Yes | `threshold` | Sink flush mode: `immediate`, `threshold`, `manual` |
+| `TELEMETRY_COOKBOOK_SAMPLE_RATE` | Yes | `1` | Runtime sample rate for general usage; smoke/demo force `1.0` for deterministic output |
+| `TELEMETRY_COOKBOOK_MAX_TRACES` | Yes | `200` | In-memory trace retention budget |
+| `TELEMETRY_COOKBOOK_BATCH_MAX_EVENTS` | Yes | `25` | Batch flush threshold for buffered sinks |
+| `TELEMETRY_COOKBOOK_EXPORT_FORMAT` | Yes | `ndjson` | Inline export format used by the demo |
+| `TELEMETRY_COOKBOOK_ALERT_THRESHOLD` | Yes | `1` | Error-count threshold used by the smoke alert rule |
+| `TELEMETRY_COOKBOOK_DRIVE_FOLDER_ID` | No | `` | Required only when `TELEMETRY_COOKBOOK_SINK=drive_json` |
+| `TELEMETRY_COOKBOOK_DRIVE_FILE_NAME` | No | `telemetry-alerting.ndjson` | Drive file basename for `drive_json` sink |
+| `TELEMETRY_COOKBOOK_STORAGE_URI` | No | `` | Required only when `TELEMETRY_COOKBOOK_SINK=storage_json` |
+| `TELEMETRY_COOKBOOK_NOTIFY_CHAT_WEBHOOK` | No | `` | Optional HTTPS Chat webhook included only in dry-run notification previews |
+| `TELEMETRY_COOKBOOK_NOTIFY_EMAIL_TO` | No | `` | Optional comma-separated email recipients included only in dry-run notification previews |
+| `TELEMETRY_COOKBOOK_VERBOSE` | No | `false` | Enables extra helper logging when customized |
+
+## Entry points
+
+### `runCookbookSmoke()`
+
+Deterministic smoke path that:
+- records one successful span and one failing span on the same trace
+- records associated events with secret-like payload keys
+- queries and aggregates the generated telemetry
+- creates and lists an alert rule
+- evaluates the rule without mutating suppression state
+- runs `notifyAlert(...)` in dry-run mode with logger channels
+
+Expected high-signal output:
+- `redactionPreview` shows `[REDACTED]` values for secret-like keys
+- `evaluationSummary.triggered` is at least `1`
+- `notificationDryRun.dryRun === true`
+
+### `runCookbookDemo()`
+
+Demonstrates app-style helper instrumentation:
+- `ASTX.TelemetryHelpers.withSpan(...)`
+- `ASTX.TelemetryHelpers.wrap(...)`
+- grouped aggregate output by span name
+- inline export preview (`json`, `ndjson`, or `csv`)
+- best-effort sink flush summary
+
+### `runCookbookAll()`
+
+Runs config validation, smoke, and demo in one call.
+
+## Least-privilege scopes
+
+Default `src/appsscript.json` intentionally has no extra OAuth scopes beyond the library dependency.
+
+Add scopes only if you enable these features:
+- `https://www.googleapis.com/auth/drive` when using `drive_json` sink
+- `https://www.googleapis.com/auth/script.external_request` when using `storage_json` sink or real Chat webhook delivery
+- `https://www.googleapis.com/auth/script.send_mail` or Gmail send scopes when using real email delivery
+
+The cookbook defaults to:
+- `sink=logger`
+- inline export
+- dry-run notifications
+
+That means the default smoke path does not require Drive, HTTP, or mail scopes.
+
+## Sink options
+
+### `logger`
+- fastest local feedback
+- no durable storage
+- recommended default for validating instrumentation and alert logic
+
+### `drive_json`
+- durable NDJSON batches in Drive
+- requires `TELEMETRY_COOKBOOK_DRIVE_FOLDER_ID`
+- useful for Apps Script-native audit trails
+
+### `storage_json`
+- durable NDJSON batches in object storage via `AST.Storage`
+- requires `TELEMETRY_COOKBOOK_STORAGE_URI`
+- use when you want centralized retention in GCS, S3, or DBFS
+
+## Redaction and security notes
+
+- `AST.Telemetry` redacts secret-like keys such as `apiKey`, `token`, `secret`, `authorization`, `password`, and `cookie`.
+- This cookbook intentionally records secret-shaped fields in smoke mode so you can verify redaction in query output.
+- `runCookbookSmoke()` redacts configured Chat webhook values from the returned config summary.
+- Notification examples run with `dryRun: true` by default to avoid accidental external sends.
+
+## Troubleshooting
+
+`Cookbook config is invalid`
+- Run `seedCookbookConfig()` again.
+- If using `drive_json`, set `TELEMETRY_COOKBOOK_DRIVE_FOLDER_ID`.
+- If using `storage_json`, set `TELEMETRY_COOKBOOK_STORAGE_URI`.
+- Fractional values for integer fields are rejected intentionally.
+
+`No telemetry records were returned`
+- Keep `TELEMETRY_COOKBOOK_SAMPLE_RATE` above `0`.
+- The cookbook forces `sampleRate=1` internally, so this usually indicates code was modified or the library version is stale.
+
+`Chat webhook or email preview fails validation`
+- Chat webhook URLs must start with `https://`.
+- Email recipients should be comma-separated addresses.
+- Real delivery requires additional OAuth scopes; dry-run does not.
+
+## Suggested validation flow
+
+1. `seedCookbookConfig()`
+2. `validateCookbookConfig()`
+3. `runCookbookSmoke()`
+4. `runCookbookDemo()`
+5. `runCookbookAll()`

--- a/cookbooks/telemetry_alerting/src/00_Config.gs
+++ b/cookbooks/telemetry_alerting/src/00_Config.gs
@@ -1,0 +1,362 @@
+function cookbookName_() {
+  return 'telemetry_alerting';
+}
+
+function cookbookAst_() {
+  return ASTLib.AST || ASTLib;
+}
+
+function cookbookScriptProperties_() {
+  return PropertiesService.getScriptProperties();
+}
+
+function cookbookTemplateVersion_() {
+  return 'v2';
+}
+
+function cookbookConfigFields_() {
+  return [
+    {
+      key: 'TELEMETRY_COOKBOOK_APP_NAME',
+      required: true,
+      defaultValue: 'AST Telemetry Alerting',
+      description: 'Human-readable cookbook name used in outputs and alert rule labels.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_SINK',
+      required: true,
+      defaultValue: 'logger',
+      allowedValues: ['logger', 'drive_json', 'storage_json'],
+      description: 'Telemetry sink used by smoke/demo runs.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_FLUSH_MODE',
+      required: true,
+      defaultValue: 'threshold',
+      allowedValues: ['immediate', 'threshold', 'manual'],
+      description: 'Telemetry flush mode used when the sink buffers records.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_SAMPLE_RATE',
+      required: true,
+      defaultValue: 1,
+      type: 'number',
+      min: 0,
+      max: 1,
+      description: 'Runtime sample rate for non-cookbook telemetry usage. Smoke/demo force 1.0 for determinism.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_MAX_TRACES',
+      required: true,
+      defaultValue: 200,
+      type: 'integer',
+      min: 10,
+      max: 5000,
+      description: 'Maximum in-memory traces to keep before eviction.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_BATCH_MAX_EVENTS',
+      required: true,
+      defaultValue: 25,
+      type: 'integer',
+      min: 1,
+      max: 1000,
+      description: 'Buffered event threshold before sink flush when using threshold mode.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_EXPORT_FORMAT',
+      required: true,
+      defaultValue: 'ndjson',
+      allowedValues: ['json', 'ndjson', 'csv'],
+      description: 'Inline export format used by the demo entrypoint.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_ALERT_THRESHOLD',
+      required: true,
+      defaultValue: 1,
+      type: 'integer',
+      min: 1,
+      max: 1000,
+      description: 'Threshold for the cookbook error-count alert rule.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_DRIVE_FOLDER_ID',
+      required: false,
+      defaultValue: '',
+      description: 'Required only when TELEMETRY_COOKBOOK_SINK=drive_json.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_DRIVE_FILE_NAME',
+      required: false,
+      defaultValue: 'telemetry-alerting.ndjson',
+      description: 'File basename used by the drive_json sink.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_STORAGE_URI',
+      required: false,
+      defaultValue: '',
+      description: 'Required only when TELEMETRY_COOKBOOK_SINK=storage_json.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_NOTIFY_CHAT_WEBHOOK',
+      required: false,
+      defaultValue: '',
+      description: 'Optional HTTPS Chat webhook used only for dry-run notification previews.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_NOTIFY_EMAIL_TO',
+      required: false,
+      defaultValue: '',
+      description: 'Optional comma-separated email recipients used only for dry-run notification previews.'
+    },
+    {
+      key: 'TELEMETRY_COOKBOOK_VERBOSE',
+      required: false,
+      defaultValue: false,
+      type: 'boolean',
+      description: 'Enable extra helper logging when true.'
+    }
+  ];
+}
+
+function cookbookConfigFieldMap_() {
+  const fields = cookbookConfigFields_();
+  const map = {};
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    map[fields[idx].key] = fields[idx];
+  }
+  return map;
+}
+
+function cookbookNormalizeString_(value, fallback) {
+  if (value == null) {
+    return fallback;
+  }
+  const normalized = String(value).trim();
+  return normalized === '' ? fallback : normalized;
+}
+
+function cookbookNormalizeBoolean_(value) {
+  if (value === true || value === false) {
+    return value;
+  }
+  if (value == null || value === '') {
+    return null;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (['true', '1', 'yes', 'y', 'on'].indexOf(normalized) !== -1) {
+    return true;
+  }
+  if (['false', '0', 'no', 'n', 'off'].indexOf(normalized) !== -1) {
+    return false;
+  }
+  return null;
+}
+
+function cookbookNormalizeInteger_(value) {
+  if (value == null || value === '') {
+    return null;
+  }
+  const normalized = Number(String(value).trim());
+  if (!Number.isFinite(normalized) || !Number.isInteger(normalized)) {
+    return null;
+  }
+  return normalized;
+}
+
+function cookbookNormalizeNumber_(value) {
+  if (value == null || value === '') {
+    return null;
+  }
+  const normalized = Number(String(value).trim());
+  if (!Number.isFinite(normalized)) {
+    return null;
+  }
+  return normalized;
+}
+
+function cookbookNormalizeConfigValue_(field, rawValue) {
+  if (field.type === 'boolean') {
+    return cookbookNormalizeBoolean_(rawValue);
+  }
+  if (field.type === 'integer') {
+    return cookbookNormalizeInteger_(rawValue);
+  }
+  if (field.type === 'number') {
+    return cookbookNormalizeNumber_(rawValue);
+  }
+  return cookbookNormalizeString_(rawValue, '');
+}
+
+function cookbookValidateOverrideKeys_(overrides) {
+  if (overrides == null) {
+    return;
+  }
+  if (Object.prototype.toString.call(overrides) !== '[object Object]') {
+    throw new Error('seedCookbookConfig overrides must be a plain object when provided.');
+  }
+
+  const known = cookbookConfigFieldMap_();
+  const unknown = [];
+  Object.keys(overrides).forEach(function (key) {
+    if (!known[key]) {
+      unknown.push(key);
+    }
+  });
+
+  if (unknown.length > 0) {
+    throw new Error('Unknown cookbook config overrides: ' + unknown.join(', '));
+  }
+}
+
+function cookbookPublicConfig_(config) {
+  const source = config && typeof config === 'object' ? config : {};
+  return {
+    TELEMETRY_COOKBOOK_APP_NAME: source.TELEMETRY_COOKBOOK_APP_NAME || '',
+    TELEMETRY_COOKBOOK_SINK: source.TELEMETRY_COOKBOOK_SINK || '',
+    TELEMETRY_COOKBOOK_FLUSH_MODE: source.TELEMETRY_COOKBOOK_FLUSH_MODE || '',
+    TELEMETRY_COOKBOOK_SAMPLE_RATE: source.TELEMETRY_COOKBOOK_SAMPLE_RATE,
+    TELEMETRY_COOKBOOK_MAX_TRACES: source.TELEMETRY_COOKBOOK_MAX_TRACES,
+    TELEMETRY_COOKBOOK_BATCH_MAX_EVENTS: source.TELEMETRY_COOKBOOK_BATCH_MAX_EVENTS,
+    TELEMETRY_COOKBOOK_EXPORT_FORMAT: source.TELEMETRY_COOKBOOK_EXPORT_FORMAT || '',
+    TELEMETRY_COOKBOOK_ALERT_THRESHOLD: source.TELEMETRY_COOKBOOK_ALERT_THRESHOLD,
+    TELEMETRY_COOKBOOK_DRIVE_FOLDER_ID: source.TELEMETRY_COOKBOOK_DRIVE_FOLDER_ID || '',
+    TELEMETRY_COOKBOOK_DRIVE_FILE_NAME: source.TELEMETRY_COOKBOOK_DRIVE_FILE_NAME || '',
+    TELEMETRY_COOKBOOK_STORAGE_URI: source.TELEMETRY_COOKBOOK_STORAGE_URI || '',
+    TELEMETRY_COOKBOOK_NOTIFY_CHAT_WEBHOOK: source.TELEMETRY_COOKBOOK_NOTIFY_CHAT_WEBHOOK ? '[configured]' : '',
+    TELEMETRY_COOKBOOK_NOTIFY_EMAIL_TO: source.TELEMETRY_COOKBOOK_NOTIFY_EMAIL_TO || '',
+    TELEMETRY_COOKBOOK_VERBOSE: source.TELEMETRY_COOKBOOK_VERBOSE === true
+  };
+}
+
+function cookbookValidationSummary_(result) {
+  return {
+    status: result.status,
+    cookbook: cookbookName_(),
+    templateVersion: result.templateVersion,
+    requiredKeys: result.requiredKeys,
+    optionalKeys: result.optionalKeys,
+    warnings: result.warnings,
+    errors: result.errors,
+    config: cookbookPublicConfig_(result.config)
+  };
+}
+
+function cookbookLogResult_(label, payload) {
+  Logger.log(label + '\n' + JSON.stringify(payload, null, 2));
+  return payload;
+}
+
+function seedCookbookConfig(overrides) {
+  cookbookValidateOverrideKeys_(overrides);
+  const props = cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+  const next = {};
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    const field = fields[idx];
+    const overrideValue = overrides && Object.prototype.hasOwnProperty.call(overrides, field.key)
+      ? overrides[field.key]
+      : field.defaultValue;
+    next[field.key] = String(overrideValue);
+  }
+
+  props.setProperties(next, false);
+  return cookbookLogResult_(
+    'seedCookbookConfig',
+    cookbookValidationSummary_(validateCookbookConfig({ scriptProperties: props }))
+  );
+}
+
+function validateCookbookConfig(options) {
+  const runtimeOptions = options || {};
+  const props = runtimeOptions.scriptProperties || cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+  const config = {};
+  const warnings = [];
+  const errors = [];
+  const requiredKeys = [];
+  const optionalKeys = [];
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    const field = fields[idx];
+    const storedValue = props.getProperty(field.key);
+    const hasStoredValue = storedValue != null && storedValue !== '';
+    const rawValue = hasStoredValue ? storedValue : field.defaultValue;
+    const normalizedValue = cookbookNormalizeConfigValue_(field, rawValue);
+    config[field.key] = normalizedValue;
+
+    if (field.required) {
+      requiredKeys.push(field.key);
+    } else {
+      optionalKeys.push(field.key);
+    }
+
+    if (!hasStoredValue) {
+      warnings.push('Using cookbook default for ' + field.key + '.');
+    }
+
+    if (field.required && (normalizedValue == null || normalizedValue === '')) {
+      errors.push('Missing required cookbook config key ' + field.key + '.');
+      continue;
+    }
+
+    if (field.allowedValues && field.allowedValues.indexOf(normalizedValue) === -1) {
+      errors.push(
+        field.key + ' must be one of: ' + field.allowedValues.join(', ') + '. Received: ' + normalizedValue
+      );
+    }
+
+    if ((field.type === 'integer' || field.type === 'number') && normalizedValue != null) {
+      if (field.min != null && normalizedValue < field.min) {
+        errors.push(field.key + ' must be >= ' + field.min + '. Received: ' + normalizedValue);
+      }
+      if (field.max != null && normalizedValue > field.max) {
+        errors.push(field.key + ' must be <= ' + field.max + '. Received: ' + normalizedValue);
+      }
+    }
+
+    if (field.type === 'boolean' && normalizedValue == null && hasStoredValue) {
+      errors.push(field.key + ' must be a boolean value.');
+    }
+  }
+
+  if (config.TELEMETRY_COOKBOOK_SINK === 'drive_json' && !config.TELEMETRY_COOKBOOK_DRIVE_FOLDER_ID) {
+    errors.push('TELEMETRY_COOKBOOK_DRIVE_FOLDER_ID is required when TELEMETRY_COOKBOOK_SINK=drive_json.');
+  }
+
+  if (config.TELEMETRY_COOKBOOK_SINK === 'storage_json' && !config.TELEMETRY_COOKBOOK_STORAGE_URI) {
+    errors.push('TELEMETRY_COOKBOOK_STORAGE_URI is required when TELEMETRY_COOKBOOK_SINK=storage_json.');
+  }
+
+  if (config.TELEMETRY_COOKBOOK_SAMPLE_RATE === 0) {
+    errors.push('TELEMETRY_COOKBOOK_SAMPLE_RATE must be greater than 0 for cookbook instrumentation.');
+  }
+
+  if (
+    config.TELEMETRY_COOKBOOK_NOTIFY_CHAT_WEBHOOK
+    && String(config.TELEMETRY_COOKBOOK_NOTIFY_CHAT_WEBHOOK).indexOf('https://') !== 0
+  ) {
+    errors.push('TELEMETRY_COOKBOOK_NOTIFY_CHAT_WEBHOOK must use https when configured.');
+  }
+
+  return {
+    status: errors.length > 0 ? 'error' : 'ok',
+    cookbook: cookbookName_(),
+    templateVersion: cookbookTemplateVersion_(),
+    requiredKeys,
+    optionalKeys,
+    warnings,
+    errors,
+    config: config
+  };
+}
+
+function cookbookRequireValidConfig_() {
+  const validation = validateCookbookConfig();
+  if (validation.status !== 'ok') {
+    throw new Error('Cookbook config is invalid: ' + validation.errors.join(' | '));
+  }
+  return validation;
+}

--- a/cookbooks/telemetry_alerting/src/10_EntryPoints.gs
+++ b/cookbooks/telemetry_alerting/src/10_EntryPoints.gs
@@ -1,0 +1,23 @@
+function runCookbookSmoke() {
+  const validation = cookbookRequireValidConfig_();
+  return cookbookLogResult_('runCookbookSmoke', runCookbookSmokeInternal_(validation.config));
+}
+
+function runCookbookDemo() {
+  const validation = cookbookRequireValidConfig_();
+  return cookbookLogResult_('runCookbookDemo', runCookbookDemoInternal_(validation.config));
+}
+
+function runCookbookAll() {
+  const validation = cookbookRequireValidConfig_();
+  const output = {
+    status: 'ok',
+    cookbook: cookbookName_(),
+    templateVersion: cookbookTemplateVersion_(),
+    config: cookbookPublicConfig_(validation.config),
+    smoke: runCookbookSmokeInternal_(validation.config),
+    demo: runCookbookDemoInternal_(validation.config),
+    completedAt: new Date().toISOString()
+  };
+  return cookbookLogResult_('runCookbookAll', output);
+}

--- a/cookbooks/telemetry_alerting/src/20_Smoke.gs
+++ b/cookbooks/telemetry_alerting/src/20_Smoke.gs
@@ -1,0 +1,80 @@
+function runCookbookSmokeInternal_(config) {
+  const ASTX = cookbookAst_();
+  cookbookConfigureTelemetry_(ASTX, config);
+
+  const run = cookbookBuildRunContext_('smoke');
+  const traces = cookbookRecordSmokeTraces_(ASTX, run);
+  const query = ASTX.Telemetry.query({
+    filters: {
+      traceIds: [run.traceId],
+      types: ['span', 'event']
+    },
+    includeRaw: true,
+    page: {
+      limit: 100,
+      offset: 0
+    },
+    sort: {
+      by: 'timestamp',
+      direction: 'asc'
+    }
+  });
+  const aggregate = ASTX.Telemetry.aggregate({
+    filters: {
+      traceIds: [run.traceId],
+      types: ['span']
+    },
+    groupBy: ['module', 'name']
+  });
+
+  const createdRule = ASTX.Telemetry.createAlertRule(
+    cookbookBuildAlertRule_(run, config),
+    { upsert: true }
+  );
+  const listedRules = ASTX.Telemetry.listAlertRules({
+    ruleIds: [run.ruleId]
+  });
+  const evaluated = ASTX.Telemetry.evaluateAlerts({
+    ruleIds: [run.ruleId],
+    notify: false,
+    dryRun: true,
+    includeSuppressed: true
+  });
+  const triggeredAlerts = evaluated.items.filter(function (item) {
+    return item && item.status === 'triggered';
+  });
+  cookbookAssert_(triggeredAlerts.length > 0, 'Expected smoke alert rule to trigger.');
+  const notification = ASTX.Telemetry.notifyAlert({
+    alerts: triggeredAlerts,
+    channels: cookbookBuildNotificationChannels_(config),
+    dryRun: true
+  });
+  const trace = ASTX.Telemetry.getTrace(run.traceId);
+  const flush = ASTX.Telemetry.flush();
+
+  return {
+    status: 'ok',
+    entrypoint: 'runCookbookSmoke',
+    cookbook: cookbookName_(),
+    appName: config.TELEMETRY_COOKBOOK_APP_NAME,
+    astVersion: ASTX.VERSION || 'unknown',
+    sink: config.TELEMETRY_COOKBOOK_SINK,
+    flushMode: config.TELEMETRY_COOKBOOK_FLUSH_MODE,
+    traceId: run.traceId,
+    spansRecorded: trace && Array.isArray(trace.spans) ? trace.spans.length : 0,
+    eventsRecorded: trace && Array.isArray(trace.events) ? trace.events.length : 0,
+    queriedRecords: query && query.page ? query.page.total : 0,
+    redactionPreview: cookbookBuildRedactionPreview_(query),
+    aggregatePreview: aggregate && Array.isArray(aggregate.items) ? aggregate.items.slice(0, 3) : [],
+    alertRule: createdRule && createdRule.rule ? {
+      id: createdRule.rule.id,
+      metric: createdRule.rule.metric,
+      threshold: createdRule.rule.threshold
+    } : null,
+    listedRuleCount: listedRules && listedRules.page ? listedRules.page.total : 0,
+    evaluationSummary: evaluated ? evaluated.summary : null,
+    notificationDryRun: notification,
+    flush: flush,
+    traces: traces
+  };
+}

--- a/cookbooks/telemetry_alerting/src/30_Examples.gs
+++ b/cookbooks/telemetry_alerting/src/30_Examples.gs
@@ -1,0 +1,312 @@
+function cookbookModule_() {
+  return 'cookbooks.telemetry_alerting';
+}
+
+function cookbookNowTag_() {
+  return new Date().toISOString().replace(/[^0-9]/g, '').slice(0, 17);
+}
+
+function cookbookAssert_(condition, message) {
+  if (!condition) {
+    throw new Error(message || 'Cookbook assertion failed.');
+  }
+}
+
+function cookbookSplitCsv_(value) {
+  if (!value) {
+    return [];
+  }
+  return String(value)
+    .split(',')
+    .map(function (item) {
+      return item.trim();
+    })
+    .filter(function (item) {
+      return item !== '';
+    });
+}
+
+function cookbookBuildRunContext_(mode) {
+  const stamp = cookbookNowTag_();
+  return {
+    cookbook: cookbookName_(),
+    module: cookbookModule_(),
+    mode: mode,
+    traceId: 'trace_' + cookbookName_() + '_' + mode + '_' + stamp,
+    ruleId: 'alert.' + cookbookName_() + '.' + mode + '.' + stamp,
+    labels: ['cookbook', cookbookName_(), mode]
+  };
+}
+
+function cookbookConfigureTelemetry_(ASTX, config) {
+  ASTX.Telemetry.clearConfig();
+  ASTX.Telemetry.configure({
+    sink: config.TELEMETRY_COOKBOOK_SINK,
+    flushMode: config.TELEMETRY_COOKBOOK_FLUSH_MODE,
+    sampleRate: 1,
+    maxTraceCount: config.TELEMETRY_COOKBOOK_MAX_TRACES,
+    batchMaxEvents: config.TELEMETRY_COOKBOOK_BATCH_MAX_EVENTS,
+    driveFolderId: config.TELEMETRY_COOKBOOK_DRIVE_FOLDER_ID,
+    driveFileName: config.TELEMETRY_COOKBOOK_DRIVE_FILE_NAME,
+    storageUri: config.TELEMETRY_COOKBOOK_STORAGE_URI,
+    redactSecrets: true
+  }, {
+    merge: false
+  });
+}
+
+function cookbookBuildNotificationChannels_(config) {
+  const channels = {
+    logger: true
+  };
+  if (config.TELEMETRY_COOKBOOK_NOTIFY_CHAT_WEBHOOK) {
+    channels.chatWebhookUrl = config.TELEMETRY_COOKBOOK_NOTIFY_CHAT_WEBHOOK;
+  }
+  const emailTo = cookbookSplitCsv_(config.TELEMETRY_COOKBOOK_NOTIFY_EMAIL_TO);
+  if (emailTo.length > 0) {
+    channels.emailTo = emailTo;
+    channels.emailSubjectPrefix = '[' + cookbookName_() + ']';
+  }
+  return channels;
+}
+
+function cookbookBuildAlertRule_(run, config) {
+  return {
+    id: run.ruleId,
+    name: config.TELEMETRY_COOKBOOK_APP_NAME + ' error count',
+    metric: 'error_count',
+    operator: 'gte',
+    threshold: config.TELEMETRY_COOKBOOK_ALERT_THRESHOLD,
+    windowSec: 300,
+    suppressionSec: 600,
+    minSamples: 1,
+    query: {
+      filters: {
+        traceIds: [run.traceId],
+        types: ['span']
+      }
+    },
+    labels: run.labels,
+    channels: cookbookBuildNotificationChannels_(config)
+  };
+}
+
+function cookbookRecordSmokeTraces_(ASTX, run) {
+  const successSpanId = ASTX.Telemetry.startSpan('telemetry.cookbook.ingest', {
+    traceId: run.traceId,
+    module: run.module,
+    cookbook: run.cookbook,
+    mode: run.mode,
+    apiKey: 'secret-value'
+  });
+  ASTX.Telemetry.recordEvent({
+    traceId: run.traceId,
+    spanId: successSpanId,
+    name: 'telemetry.cookbook.rows_loaded',
+    level: 'info',
+    payload: {
+      rows: 3,
+      token: 'top-secret-token'
+    }
+  });
+  const success = ASTX.Telemetry.endSpan(successSpanId, {
+    status: 'ok',
+    result: {
+      rows: 3,
+      total: 42
+    }
+  });
+
+  const errorSpanId = ASTX.Telemetry.startSpan('telemetry.cookbook.publish', {
+    traceId: run.traceId,
+    module: run.module,
+    cookbook: run.cookbook,
+    mode: run.mode,
+    authorization: 'Bearer cookbook-secret'
+  });
+  ASTX.Telemetry.recordEvent({
+    traceId: run.traceId,
+    spanId: errorSpanId,
+    name: 'telemetry.cookbook.publish_failed',
+    level: 'error',
+    payload: {
+      step: 'publish',
+      secret: 'should-redact'
+    }
+  });
+  const failure = ASTX.Telemetry.endSpan(errorSpanId, {
+    status: 'error',
+    error: new Error('synthetic cookbook failure')
+  });
+
+  return {
+    success: {
+      spanId: successSpanId,
+      traceId: run.traceId,
+      status: success.status
+    },
+    failure: {
+      spanId: errorSpanId,
+      traceId: run.traceId,
+      status: failure.status
+    }
+  };
+}
+
+function cookbookBuildRedactionPreview_(query) {
+  const items = query && Array.isArray(query.items) ? query.items : [];
+  let spanPreview = null;
+  let eventPreview = null;
+
+  for (let idx = 0; idx < items.length; idx += 1) {
+    const item = items[idx];
+    if (!spanPreview && item && item.type === 'span') {
+      spanPreview = {
+        name: item.name,
+        apiKey: item.raw && item.raw.context ? item.raw.context.apiKey : null,
+        authorization: item.raw && item.raw.context ? item.raw.context.authorization : null
+      };
+    }
+    if (!eventPreview && item && item.type === 'event') {
+      eventPreview = {
+        name: item.name,
+        token: item.raw && item.raw.payload ? item.raw.payload.token : null,
+        secret: item.raw && item.raw.payload ? item.raw.payload.secret : null
+      };
+    }
+  }
+
+  return {
+    span: spanPreview,
+    event: eventPreview
+  };
+}
+
+function cookbookBuildExportPreview_(data) {
+  if (data == null) {
+    return null;
+  }
+  const text = typeof data === 'string' ? data : JSON.stringify(data);
+  return text.length > 240 ? text.slice(0, 240) + '...' : text;
+}
+
+function runCookbookDemoInternal_(config) {
+  const ASTX = cookbookAst_();
+  cookbookConfigureTelemetry_(ASTX, config);
+
+  const run = cookbookBuildRunContext_('demo');
+  const baseTotal = ASTX.TelemetryHelpers.withSpan(
+    'telemetry.cookbook.load_config',
+    {
+      traceId: run.traceId,
+      module: run.module,
+      cookbook: run.cookbook,
+      mode: run.mode
+    },
+    function () {
+      ASTX.Telemetry.recordEvent({
+        traceId: run.traceId,
+        name: 'telemetry.cookbook.config_loaded',
+        level: 'info',
+        payload: {
+          sink: config.TELEMETRY_COOKBOOK_SINK,
+          appName: config.TELEMETRY_COOKBOOK_APP_NAME
+        }
+      });
+      return ASTX.Utils.arraySum([2, 4, 6, 8]);
+    },
+    {
+      includeResult: true
+    }
+  );
+
+  const wrappedTransform = ASTX.TelemetryHelpers.wrap(
+    'telemetry.cookbook.transform',
+    function (values) {
+      const output = [];
+      for (let idx = 0; idx < values.length; idx += 1) {
+        output.push(values[idx] * 2);
+      }
+      ASTX.Telemetry.recordEvent({
+        traceId: run.traceId,
+        name: 'telemetry.cookbook.transform_complete',
+        level: 'info',
+        payload: {
+          count: output.length,
+          maxValue: output.length > 0 ? Math.max.apply(null, output) : 0
+        }
+      });
+      return output;
+    },
+    {
+      contextFactory: function (args) {
+        return {
+          traceId: run.traceId,
+          module: run.module,
+          cookbook: run.cookbook,
+          mode: run.mode,
+          inputCount: Array.isArray(args[0]) ? args[0].length : 0
+        };
+      },
+      includeResult: true
+    }
+  );
+
+  const transformed = wrappedTransform([baseTotal, baseTotal + 1, baseTotal + 2]);
+  const transformedSum = ASTX.Utils.arraySum(transformed);
+  cookbookAssert_(transformedSum > baseTotal, 'Expected wrapped transform output to increase the total.');
+
+  const aggregate = ASTX.Telemetry.aggregate({
+    filters: {
+      traceIds: [run.traceId],
+      types: ['span']
+    },
+    groupBy: ['name']
+  });
+  const exported = ASTX.Telemetry.export({
+    format: config.TELEMETRY_COOKBOOK_EXPORT_FORMAT,
+    query: {
+      filters: {
+        traceIds: [run.traceId]
+      },
+      page: {
+        limit: 1000,
+        offset: 0
+      }
+    },
+    includeData: true
+  });
+  const trace = ASTX.Telemetry.getTrace(run.traceId);
+  const flush = ASTX.Telemetry.flush();
+
+  return {
+    status: 'ok',
+    entrypoint: 'runCookbookDemo',
+    cookbook: cookbookName_(),
+    appName: config.TELEMETRY_COOKBOOK_APP_NAME,
+    traceId: run.traceId,
+    helperUsage: {
+      withSpan: 'telemetry.cookbook.load_config',
+      wrap: 'telemetry.cookbook.transform'
+    },
+    totals: {
+      baseTotal: baseTotal,
+      transformed: transformed,
+      transformedSum: transformedSum
+    },
+    aggregatePreview: aggregate && Array.isArray(aggregate.items) ? aggregate.items.slice(0, 3) : [],
+    export: exported ? {
+      format: exported.format,
+      count: exported.count,
+      bytes: exported.bytes,
+      destination: exported.destination,
+      preview: cookbookBuildExportPreview_(exported.data)
+    } : null,
+    traceSummary: trace ? {
+      status: trace.status,
+      spans: Array.isArray(trace.spans) ? trace.spans.length : 0,
+      events: Array.isArray(trace.events) ? trace.events.length : 0
+    } : null,
+    flush: flush
+  };
+}

--- a/cookbooks/telemetry_alerting/src/99_DevTools.gs
+++ b/cookbooks/telemetry_alerting/src/99_DevTools.gs
@@ -1,0 +1,56 @@
+function clearCookbookConfig() {
+  const props = cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    props.deleteProperty(fields[idx].key);
+  }
+
+  return cookbookLogResult_('clearCookbookConfig', {
+    status: 'ok',
+    cookbook: cookbookName_(),
+    clearedKeys: fields.map(function (field) {
+      return field.key;
+    }),
+    templateVersion: cookbookTemplateVersion_()
+  });
+}
+
+function showCookbookContract() {
+  return cookbookLogResult_('showCookbookContract', {
+    cookbook: cookbookName_(),
+    templateVersion: cookbookTemplateVersion_(),
+    requiredEntrypoints: [
+      'seedCookbookConfig',
+      'validateCookbookConfig',
+      'runCookbookSmoke',
+      'runCookbookDemo',
+      'runCookbookAll'
+    ],
+    scriptProperties: cookbookConfigFields_().map(function (field) {
+      return {
+        key: field.key,
+        required: field.required,
+        defaultValue: field.defaultValue,
+        description: field.description
+      };
+    })
+  });
+}
+
+function showTelemetryRuntimeConfig() {
+  const ASTX = cookbookAst_();
+  return cookbookLogResult_('showTelemetryRuntimeConfig', {
+    cookbook: cookbookName_(),
+    runtimeConfig: ASTX.Telemetry.getConfig()
+  });
+}
+
+function clearTelemetryRuntimeConfig() {
+  const ASTX = cookbookAst_();
+  ASTX.Telemetry.clearConfig();
+  return cookbookLogResult_('clearTelemetryRuntimeConfig', {
+    cookbook: cookbookName_(),
+    status: 'ok'
+  });
+}

--- a/cookbooks/telemetry_alerting/src/appsscript.json
+++ b/cookbooks/telemetry_alerting/src/appsscript.json
@@ -1,0 +1,14 @@
+{
+  "timeZone": "Etc/UTC",
+  "dependencies": {
+    "libraries": [
+      {
+        "userSymbol": "ASTLib",
+        "libraryId": "1gZ_6DiLeDhh-a4qcezluTFDshw4OEhTXbeD3wthl_UdHEAFkXf6i6Ho_",
+        "version": "<PUBLISHED_AST_LIBRARY_VERSION>"
+      }
+    ]
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
+}

--- a/docs/getting-started/cookbooks.md
+++ b/docs/getting-started/cookbooks.md
@@ -98,6 +98,7 @@ Put reusable logic back into the library (`apps_script_tools/`) only when it is 
 - `github_issue_digest`: template-v2 GitHub automation cookbook for issues, PRs, checks, Actions, GraphQL, Projects v2, and dry-run mutation planning via `AST.GitHub`.
 - `http_ingestion_pipeline`: template-v2 `AST.Http` cookbook for resilient request flows, batch error handling, safe redaction, and optional cache/telemetry composition.
 - `jobs_triggers_orchestration`: template-v2 orchestration cookbook for `AST.Jobs` and `AST.Triggers`, including retry/resume flows, schedule bridge, and DLQ lifecycle.
+- `telemetry_alerting`: template-v2 observability cookbook for `AST.Telemetry` and `AST.TelemetryHelpers`, including redaction checks, grouped metrics, alert rules, and dry-run notifications.
 - `rag_chat_starter`: template-v2 webapp starter for grounded `AST.RAG` chat with `AST.Chat` thread persistence, linked citations, and configurable branding.
 - `dbt_manifest_summary`: template-v2 DBT artifact explorer covering manifest load/search, lineage, governance, and artifact comparison via `AST.DBT`.
 - `storage_cache_warmer`: focused `AST.Cache` example for warming persisted `storage_json` cache entries.


### PR DESCRIPTION
## Summary
- add `cookbooks/telemetry_alerting` on the template-v2 cookbook contract
- demonstrate `AST.Telemetry` instrumentation, querying, aggregation, export, and alert lifecycle flows
- document sink setup, notification channels, redaction behavior, and deterministic smoke/demo entrypoints

## What Changed
- added `cookbooks/telemetry_alerting` with `00_Config.gs`, `10_EntryPoints.gs`, `20_Smoke.gs`, `30_Examples.gs`, and `99_DevTools.gs`
- implemented deterministic smoke coverage for spans/events, aggregate queries, alert rule creation, evaluation, and notification dry-run
- added helper-driven demo coverage using `AST.TelemetryHelpers.withSpan(...)` and `AST.TelemetryHelpers.wrap(...)`
- updated cookbook catalog docs in `cookbooks/README.md` and `docs/getting-started/cookbooks.md`

## Validation
- `npm run lint`
- `uv run mkdocs build --strict`
- `git diff --check`

Closes #304
Part of #295.
