### PR TITLE
feat(cookbooks): add messaging hub cookbook

### DIFF
--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -92,6 +92,7 @@ The template README documents:
 - `github_issue_digest`: template-v2 GitHub automation cookbook for issues, PRs, checks, Actions, GraphQL, Projects v2, and dry-run mutation planning via `AST.GitHub`.
 - `http_ingestion_pipeline`: template-v2 `AST.Http` cookbook for resilient request flows, batch error handling, safe redaction, and optional cache/telemetry composition.
 - `jobs_triggers_orchestration`: template-v2 orchestration cookbook for `AST.Jobs` and `AST.Triggers`, including retry/resume flows, schedule bridge, and DLQ lifecycle.
+- `messaging_hub`: template-v2 messaging cookbook for `AST.Messaging`, including email/chat dry-run plans, templates, tracking/logs, and signed inbound webhook fixtures.
 - `telemetry_alerting`: template-v2 observability cookbook for `AST.Telemetry` and `AST.TelemetryHelpers`, including redaction checks, grouped metrics, alert rules, and dry-run notifications.
 - `rag_chat_starter`: template-v2 webapp starter for grounded `AST.RAG` chat with `AST.Chat` thread persistence, linked citations, and configurable branding.
 - `dbt_manifest_summary`: template-v2 DBT artifact explorer for manifest search, lineage, governance, and artifact comparison via `AST.DBT`.

--- a/cookbooks/messaging_hub/.clasp.json.example
+++ b/cookbooks/messaging_hub/.clasp.json.example
@@ -1,0 +1,4 @@
+{
+  "scriptId": "<COOKBOOK_SCRIPT_ID>",
+  "rootDir": "src"
+}

--- a/cookbooks/messaging_hub/.claspignore
+++ b/cookbooks/messaging_hub/.claspignore
@@ -1,0 +1,3 @@
+# `rootDir` is `src`, so only local-only config files need explicit ignores.
+.clasp.json
+.clasprc.json

--- a/cookbooks/messaging_hub/README.md
+++ b/cookbooks/messaging_hub/README.md
@@ -1,0 +1,152 @@
+# Messaging Hub Cookbook
+
+Template-v2 cookbook for `AST.Messaging`.
+
+This cookbook demonstrates:
+- email send planning via `ASTX.Messaging.email.send(...)`
+- chat send planning across Google Chat, Slack, and Teams webhook transports
+- reusable template registration, rendering, and dry-run sends
+- tracking pixel and click URL generation plus event handling
+- delivery/event log persistence via the configured log backend
+- inbound verification, parsing, and routing for Slack and Google Chat fixtures
+
+## Setup
+
+1. Copy `.clasp.json.example` to `.clasp.json` and set the target `scriptId`.
+2. Replace `<PUBLISHED_AST_LIBRARY_VERSION>` in `src/appsscript.json`.
+3. `clasp push`
+4. Run `seedCookbookConfig()`.
+5. Run `runCookbookAll()`.
+
+## Script properties
+
+| Key | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `MESSAGING_HUB_APP_NAME` | Yes | `AST Messaging Hub` | Human-readable cookbook name used in outputs |
+| `MESSAGING_HUB_DEFAULT_EMAIL_TO` | Yes | `user@example.com` | Recipient used by email dry-run examples |
+| `MESSAGING_HUB_CHAT_TRANSPORT` | Yes | `webhook` | Default chat transport: `webhook`, `slack_webhook`, `teams_webhook` |
+| `MESSAGING_HUB_CHAT_WEBHOOK_URL` | No | Chat placeholder URL | Google Chat webhook used in dry-run planning |
+| `MESSAGING_HUB_SLACK_WEBHOOK_URL` | No | Slack placeholder URL | Slack webhook used in dry-run planning |
+| `MESSAGING_HUB_TEAMS_WEBHOOK_URL` | No | Teams placeholder URL | Teams webhook used in dry-run planning |
+| `MESSAGING_HUB_TRACKING_BASE_URL` | Yes | `https://example.com` | Base URL for click/open tracking helpers |
+| `MESSAGING_HUB_TRACKING_SIGNING_SECRET` | Yes | `messaging-hub-tracking-secret` | Signing secret for tracking URL validation |
+| `MESSAGING_HUB_TRACKING_ALLOWED_DOMAINS` | Yes | `example.com` | Comma-separated allowlist for click redirect examples |
+| `MESSAGING_HUB_INBOUND_SLACK_SIGNING_SECRET` | Yes | `messaging-hub-slack-secret` | Slack signing secret used by deterministic inbound fixtures |
+| `MESSAGING_HUB_INBOUND_GOOGLE_CHAT_TOKEN` | Yes | `messaging-hub-google-chat-token` | Google Chat verification token used by deterministic inbound fixtures |
+| `MESSAGING_HUB_LOG_BACKEND` | Yes | `memory` | Log backend: `memory`, `drive_json`, `script_properties`, `storage_json` |
+| `MESSAGING_HUB_LOG_NAMESPACE` | Yes | `ast_cookbook_messaging_logs` | Namespace for delivery/event logs |
+| `MESSAGING_HUB_LOG_DRIVE_FOLDER_ID` | No | `` | Required only when `MESSAGING_HUB_LOG_BACKEND=drive_json` |
+| `MESSAGING_HUB_LOG_DRIVE_FILE_NAME` | No | `ast_messaging_hub_logs.json` | Drive JSON file name for log backend |
+| `MESSAGING_HUB_LOG_STORAGE_URI` | No | `` | Required only when `MESSAGING_HUB_LOG_BACKEND=storage_json` |
+| `MESSAGING_HUB_TEMPLATE_BACKEND` | Yes | `memory` | Template backend: `memory`, `drive_json`, `script_properties`, `storage_json` |
+| `MESSAGING_HUB_TEMPLATE_NAMESPACE` | Yes | `ast_cookbook_messaging_templates` | Namespace for stored templates |
+| `MESSAGING_HUB_TEMPLATE_DRIVE_FOLDER_ID` | No | `` | Required only when `MESSAGING_HUB_TEMPLATE_BACKEND=drive_json` |
+| `MESSAGING_HUB_TEMPLATE_DRIVE_FILE_NAME` | No | `ast_messaging_hub_templates.json` | Drive JSON file name for templates |
+| `MESSAGING_HUB_TEMPLATE_STORAGE_URI` | No | `` | Required only when `MESSAGING_HUB_TEMPLATE_BACKEND=storage_json` |
+| `MESSAGING_HUB_VERBOSE` | No | `false` | Enables extra helper logging when customized |
+
+## Entry points
+
+### `runCookbookSmoke()`
+
+Deterministic smoke path that:
+- configures `AST.Messaging` from Script Properties
+- registers reusable email/chat templates
+- renders the email template and validates the rendered subject/body
+- runs dry-run send planning for one email and one chat message
+- records and lists one tracking event via the configured log backend
+- verifies and routes a signed Slack inbound fixture
+- verifies a Google Chat token-based inbound fixture
+
+Expected high-signal output:
+- `emailPlan.dryRun === true`
+- `chatPlan.dryRun === true`
+- `slackRoute.handled === true`
+- `googleChatVerification.valid === true`
+
+### `runCookbookDemo()`
+
+Richer public-surface demo that shows:
+- direct email dry-run planning
+- chat batch dry-run planning
+- template-based dry-run chat send
+- pixel URL generation and click redirect wrapping/handling
+- log get/delete roundtrip
+- Slack form-encoded parse example
+- Google Chat route handler selection
+
+### `runCookbookAll()`
+
+Runs validation, smoke, and demo in one call.
+
+## Least-privilege scopes
+
+The default `src/appsscript.json` intentionally does not add extra OAuth scopes. Add only what your deployment actually needs.
+
+Typical scope choices:
+- `https://www.googleapis.com/auth/script.external_request` for live Chat/Slack/Teams webhook delivery
+- `https://www.googleapis.com/auth/gmail.send` for live Gmail sends
+- `https://www.googleapis.com/auth/gmail.modify` if you want mailbox reads/label updates beyond this cookbook
+- Drive scopes only when using `drive_json` template/log backends
+
+Default cookbook behavior is safe:
+- outbound sends run as `dryRun`
+- inbound flows use deterministic fixtures
+- logs/templates default to `memory`
+
+That means the smoke path works without actually sending email or webhook traffic.
+
+## Secure webhook handling guidance
+
+- Keep real webhook URLs and signing secrets in Script Properties only.
+- Do not return secrets from editor entrypoints; this cookbook redacts them in public summaries.
+- Use HTTPS-only webhook URLs.
+- Keep `MESSAGING_HUB_TRACKING_ALLOWED_DOMAINS` narrow so click redirects stay constrained.
+- Use separate secrets for tracking signatures and inbound Slack verification.
+
+## Backend notes
+
+### `memory`
+- fastest for smoke/demo work
+- resets per execution
+- recommended default for validation
+
+### `drive_json`
+- durable storage in Drive
+- requires Drive folder IDs for logs/templates
+- useful for Apps Script-native operator workflows
+
+### `script_properties`
+- lightweight persistence without extra services
+- keep payload sizes modest
+
+### `storage_json`
+- durable object-storage backed logs/templates via `AST.Storage`
+- good when you want shared retention outside Apps Script
+
+## Troubleshooting
+
+`Cookbook config is invalid`
+- Run `seedCookbookConfig()` again.
+- Ensure all webhook URLs begin with `https://`.
+- If using `drive_json` or `storage_json`, set the matching folder/URI keys.
+
+`Inbound verification fails`
+- Confirm the Slack signing secret and Google Chat token values are consistent.
+- The cookbook generates its own deterministic Slack signature; if this fails, your AST library version is likely stale.
+
+`Tracking click handling rejects the URL`
+- Add the target host to `MESSAGING_HUB_TRACKING_ALLOWED_DOMAINS`.
+- Only HTTPS targets are accepted by the click handler.
+
+`Real delivery needs scopes`
+- Dry-run does not call Gmail or external webhook endpoints.
+- Live sends require you to add the matching OAuth scopes and reauthorize the script.
+
+## Suggested validation flow
+
+1. `seedCookbookConfig()`
+2. `validateCookbookConfig()`
+3. `runCookbookSmoke()`
+4. `runCookbookDemo()`
+5. `runCookbookAll()`

--- a/cookbooks/messaging_hub/src/00_Config.gs
+++ b/cookbooks/messaging_hub/src/00_Config.gs
@@ -1,0 +1,366 @@
+function cookbookAst_() {
+  return ASTLib.AST || ASTLib;
+}
+
+function cookbookName_() {
+  return 'messaging_hub';
+}
+
+function cookbookScriptProperties_() {
+  return PropertiesService.getScriptProperties();
+}
+
+function cookbookTemplateVersion_() {
+  return 'v2';
+}
+
+function cookbookConfigFields_() {
+  return [
+    {
+      key: 'MESSAGING_HUB_APP_NAME',
+      required: true,
+      defaultValue: 'AST Messaging Hub',
+      description: 'Human-readable cookbook name used in outputs.'
+    },
+    {
+      key: 'MESSAGING_HUB_DEFAULT_EMAIL_TO',
+      required: true,
+      defaultValue: 'user@example.com',
+      description: 'Default recipient used in email dry-run examples.'
+    },
+    {
+      key: 'MESSAGING_HUB_CHAT_TRANSPORT',
+      required: true,
+      defaultValue: 'webhook',
+      allowedValues: ['webhook', 'slack_webhook', 'teams_webhook'],
+      description: 'Default chat transport used by the smoke plan.'
+    },
+    {
+      key: 'MESSAGING_HUB_CHAT_WEBHOOK_URL',
+      required: false,
+      defaultValue: 'https://chat.googleapis.com/v1/spaces/SPACE/messages?key=example&token=example',
+      description: 'Google Chat webhook URL used in dry-run planning output.'
+    },
+    {
+      key: 'MESSAGING_HUB_SLACK_WEBHOOK_URL',
+      required: false,
+      defaultValue: 'https://hooks.slack.com/services/T00000000/B00000000/example',
+      description: 'Slack webhook URL used in dry-run planning output.'
+    },
+    {
+      key: 'MESSAGING_HUB_TEAMS_WEBHOOK_URL',
+      required: false,
+      defaultValue: 'https://outlook.office.com/webhook/example',
+      description: 'Teams webhook URL used in dry-run planning output.'
+    },
+    {
+      key: 'MESSAGING_HUB_TRACKING_BASE_URL',
+      required: true,
+      defaultValue: 'https://example.com',
+      description: 'Base URL used for click/open tracking examples.'
+    },
+    {
+      key: 'MESSAGING_HUB_TRACKING_SIGNING_SECRET',
+      required: true,
+      defaultValue: 'messaging-hub-tracking-secret',
+      description: 'Signing secret for tracking URL examples.'
+    },
+    {
+      key: 'MESSAGING_HUB_TRACKING_ALLOWED_DOMAINS',
+      required: true,
+      defaultValue: 'example.com',
+      description: 'Comma-separated allowlist for click redirect examples.'
+    },
+    {
+      key: 'MESSAGING_HUB_INBOUND_SLACK_SIGNING_SECRET',
+      required: true,
+      defaultValue: 'messaging-hub-slack-secret',
+      description: 'Signing secret used for deterministic Slack inbound fixtures.'
+    },
+    {
+      key: 'MESSAGING_HUB_INBOUND_GOOGLE_CHAT_TOKEN',
+      required: true,
+      defaultValue: 'messaging-hub-google-chat-token',
+      description: 'Verification token used for deterministic Google Chat inbound fixtures.'
+    },
+    {
+      key: 'MESSAGING_HUB_LOG_BACKEND',
+      required: true,
+      defaultValue: 'memory',
+      allowedValues: ['memory', 'drive_json', 'script_properties', 'storage_json'],
+      description: 'Backend used for tracking/delivery log examples.'
+    },
+    {
+      key: 'MESSAGING_HUB_LOG_NAMESPACE',
+      required: true,
+      defaultValue: 'ast_cookbook_messaging_logs',
+      description: 'Namespace used by log backends.'
+    },
+    {
+      key: 'MESSAGING_HUB_LOG_DRIVE_FOLDER_ID',
+      required: false,
+      defaultValue: '',
+      description: 'Drive folder required when log backend is drive_json.'
+    },
+    {
+      key: 'MESSAGING_HUB_LOG_DRIVE_FILE_NAME',
+      required: false,
+      defaultValue: 'ast_messaging_hub_logs.json',
+      description: 'Drive JSON filename for log backend.'
+    },
+    {
+      key: 'MESSAGING_HUB_LOG_STORAGE_URI',
+      required: false,
+      defaultValue: '',
+      description: 'Storage URI required when log backend is storage_json.'
+    },
+    {
+      key: 'MESSAGING_HUB_TEMPLATE_BACKEND',
+      required: true,
+      defaultValue: 'memory',
+      allowedValues: ['memory', 'drive_json', 'script_properties', 'storage_json'],
+      description: 'Backend used for reusable template examples.'
+    },
+    {
+      key: 'MESSAGING_HUB_TEMPLATE_NAMESPACE',
+      required: true,
+      defaultValue: 'ast_cookbook_messaging_templates',
+      description: 'Namespace used by template backends.'
+    },
+    {
+      key: 'MESSAGING_HUB_TEMPLATE_DRIVE_FOLDER_ID',
+      required: false,
+      defaultValue: '',
+      description: 'Drive folder required when template backend is drive_json.'
+    },
+    {
+      key: 'MESSAGING_HUB_TEMPLATE_DRIVE_FILE_NAME',
+      required: false,
+      defaultValue: 'ast_messaging_hub_templates.json',
+      description: 'Drive JSON filename for template backend.'
+    },
+    {
+      key: 'MESSAGING_HUB_TEMPLATE_STORAGE_URI',
+      required: false,
+      defaultValue: '',
+      description: 'Storage URI required when template backend is storage_json.'
+    },
+    {
+      key: 'MESSAGING_HUB_VERBOSE',
+      required: false,
+      defaultValue: 'false',
+      type: 'boolean',
+      description: 'Enables extra helper logging when true.'
+    }
+  ];
+}
+
+function cookbookConfigFieldMap_() {
+  const fields = cookbookConfigFields_();
+  const map = {};
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    map[fields[idx].key] = fields[idx];
+  }
+  return map;
+}
+
+function cookbookNormalizeBoolean_(value, fallback) {
+  if (value === true || value === false) {
+    return value;
+  }
+
+  if (value == null || value === '') {
+    return fallback;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (['true', '1', 'yes', 'y', 'on'].indexOf(normalized) !== -1) {
+    return true;
+  }
+  if (['false', '0', 'no', 'n', 'off'].indexOf(normalized) !== -1) {
+    return false;
+  }
+
+  return fallback;
+}
+
+function cookbookNormalizeConfigValue_(field, rawValue) {
+  if (field && field.type === 'boolean') {
+    return cookbookNormalizeBoolean_(rawValue, false);
+  }
+  return String(rawValue == null ? '' : rawValue).trim();
+}
+
+function cookbookValidateOverrideKeys_(overrides) {
+  if (overrides == null) {
+    return;
+  }
+
+  if (Object.prototype.toString.call(overrides) !== '[object Object]') {
+    throw new Error('seedCookbookConfig overrides must be a plain object when provided.');
+  }
+
+  const known = cookbookConfigFieldMap_();
+  const keys = Object.keys(overrides);
+  const unknown = [];
+  for (let idx = 0; idx < keys.length; idx += 1) {
+    if (!known[keys[idx]]) {
+      unknown.push(keys[idx]);
+    }
+  }
+
+  if (unknown.length > 0) {
+    throw new Error(`Unknown cookbook config overrides: ${unknown.join(', ')}`);
+  }
+}
+
+function cookbookNormalizeCsv_(value) {
+  if (value == null || value === '') {
+    return [];
+  }
+
+  const parts = String(value).split(',');
+  const out = [];
+  for (let idx = 0; idx < parts.length; idx += 1) {
+    const normalized = String(parts[idx]).trim();
+    if (normalized) {
+      out.push(normalized);
+    }
+  }
+  return out;
+}
+
+function cookbookValidationSummary_(result) {
+  return {
+    status: result.status,
+    templateVersion: result.templateVersion,
+    requiredKeys: result.requiredKeys,
+    optionalKeys: result.optionalKeys,
+    warnings: result.warnings,
+    errors: result.errors,
+    config: result.config
+  };
+}
+
+function cookbookLogResult_(label, payload) {
+  Logger.log(`${label}\n${JSON.stringify(payload, null, 2)}`);
+  return payload;
+}
+
+function seedCookbookConfig(overrides) {
+  cookbookValidateOverrideKeys_(overrides);
+
+  const props = cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+  const next = {};
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    const field = fields[idx];
+    const overrideValue = overrides && Object.prototype.hasOwnProperty.call(overrides, field.key)
+      ? overrides[field.key]
+      : field.defaultValue;
+    next[field.key] = String(overrideValue);
+  }
+
+  props.setProperties(next, false);
+
+  return cookbookLogResult_(
+    'seedCookbookConfig',
+    cookbookValidationSummary_(validateCookbookConfig({ scriptProperties: props }))
+  );
+}
+
+function validateCookbookConfig(options) {
+  const runtimeOptions = options || {};
+  const props = runtimeOptions.scriptProperties || cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+  const resolved = {};
+  const warnings = [];
+  const errors = [];
+  const requiredKeys = [];
+  const optionalKeys = [];
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    const field = fields[idx];
+    const storedValue = props.getProperty(field.key);
+    const hasStoredValue = storedValue != null && storedValue !== '';
+    const rawValue = hasStoredValue ? storedValue : field.defaultValue;
+    const normalizedValue = cookbookNormalizeConfigValue_(field, rawValue);
+
+    resolved[field.key] = normalizedValue;
+
+    if (field.required) {
+      requiredKeys.push(field.key);
+    } else {
+      optionalKeys.push(field.key);
+    }
+
+    if (!hasStoredValue) {
+      warnings.push(`Using cookbook default for ${field.key}.`);
+    }
+
+    if (field.required && (normalizedValue === '' || normalizedValue == null)) {
+      errors.push(`Missing required cookbook config key ${field.key}.`);
+    }
+
+    if (field.allowedValues && field.allowedValues.indexOf(normalizedValue) === -1) {
+      errors.push(
+        `${field.key} must be one of: ${field.allowedValues.join(', ')}. Received: ${normalizedValue}`
+      );
+    }
+  }
+
+  if (resolved.MESSAGING_HUB_TRACKING_BASE_URL && !/^https:\/\//i.test(resolved.MESSAGING_HUB_TRACKING_BASE_URL)) {
+    errors.push('MESSAGING_HUB_TRACKING_BASE_URL must start with https://');
+  }
+
+  if (resolved.MESSAGING_HUB_CHAT_WEBHOOK_URL && !/^https:\/\//i.test(resolved.MESSAGING_HUB_CHAT_WEBHOOK_URL)) {
+    errors.push('MESSAGING_HUB_CHAT_WEBHOOK_URL must start with https://');
+  }
+
+  if (resolved.MESSAGING_HUB_SLACK_WEBHOOK_URL && !/^https:\/\//i.test(resolved.MESSAGING_HUB_SLACK_WEBHOOK_URL)) {
+    errors.push('MESSAGING_HUB_SLACK_WEBHOOK_URL must start with https://');
+  }
+
+  if (resolved.MESSAGING_HUB_TEAMS_WEBHOOK_URL && !/^https:\/\//i.test(resolved.MESSAGING_HUB_TEAMS_WEBHOOK_URL)) {
+    errors.push('MESSAGING_HUB_TEAMS_WEBHOOK_URL must start with https://');
+  }
+
+  if (cookbookNormalizeCsv_(resolved.MESSAGING_HUB_TRACKING_ALLOWED_DOMAINS).length === 0) {
+    errors.push('MESSAGING_HUB_TRACKING_ALLOWED_DOMAINS must include at least one host.');
+  }
+
+  if (resolved.MESSAGING_HUB_LOG_BACKEND === 'drive_json' && !resolved.MESSAGING_HUB_LOG_DRIVE_FOLDER_ID) {
+    errors.push('MESSAGING_HUB_LOG_DRIVE_FOLDER_ID is required when MESSAGING_HUB_LOG_BACKEND=drive_json.');
+  }
+
+  if (resolved.MESSAGING_HUB_LOG_BACKEND === 'storage_json' && !resolved.MESSAGING_HUB_LOG_STORAGE_URI) {
+    errors.push('MESSAGING_HUB_LOG_STORAGE_URI is required when MESSAGING_HUB_LOG_BACKEND=storage_json.');
+  }
+
+  if (resolved.MESSAGING_HUB_TEMPLATE_BACKEND === 'drive_json' && !resolved.MESSAGING_HUB_TEMPLATE_DRIVE_FOLDER_ID) {
+    errors.push('MESSAGING_HUB_TEMPLATE_DRIVE_FOLDER_ID is required when MESSAGING_HUB_TEMPLATE_BACKEND=drive_json.');
+  }
+
+  if (resolved.MESSAGING_HUB_TEMPLATE_BACKEND === 'storage_json' && !resolved.MESSAGING_HUB_TEMPLATE_STORAGE_URI) {
+    errors.push('MESSAGING_HUB_TEMPLATE_STORAGE_URI is required when MESSAGING_HUB_TEMPLATE_BACKEND=storage_json.');
+  }
+
+  return {
+    status: errors.length > 0 ? 'error' : 'ok',
+    templateVersion: cookbookTemplateVersion_(),
+    requiredKeys,
+    optionalKeys,
+    warnings,
+    errors,
+    config: resolved
+  };
+}
+
+function cookbookRequireValidConfig_() {
+  const validation = validateCookbookConfig();
+  if (validation.status !== 'ok') {
+    throw new Error(`Cookbook config is invalid: ${validation.errors.join(' | ')}`);
+  }
+  return validation;
+}

--- a/cookbooks/messaging_hub/src/10_EntryPoints.gs
+++ b/cookbooks/messaging_hub/src/10_EntryPoints.gs
@@ -1,0 +1,25 @@
+function runCookbookSmoke() {
+  const validation = cookbookRequireValidConfig_();
+  return cookbookLogResult_('runCookbookSmoke', runCookbookSmokeInternal_(validation.config));
+}
+
+function runCookbookDemo() {
+  const validation = cookbookRequireValidConfig_();
+  return cookbookLogResult_('runCookbookDemo', runCookbookDemoInternal_(validation.config));
+}
+
+function runCookbookAll() {
+  const validation = validateCookbookConfig();
+  const smoke = validation.status === 'ok' ? runCookbookSmokeInternal_(validation.config) : null;
+  const demo = validation.status === 'ok' ? runCookbookDemoInternal_(validation.config) : null;
+
+  return cookbookLogResult_('runCookbookAll', {
+    status: validation.status,
+    cookbook: cookbookName_(),
+    templateVersion: cookbookTemplateVersion_(),
+    validation: cookbookValidationSummary_(validation),
+    smoke,
+    demo,
+    generatedAt: new Date().toISOString()
+  });
+}

--- a/cookbooks/messaging_hub/src/20_Smoke.gs
+++ b/cookbooks/messaging_hub/src/20_Smoke.gs
@@ -52,24 +52,29 @@ function runCookbookSmokeInternal_(config) {
     }
   });
 
-  const slackFixture = cookbookBuildSlackFixture_(config, {
-    eventId: 'evt_messaging_hub_smoke',
+  const slackVerifyFixture = cookbookBuildSlackFixture_(config, {
+    eventId: 'evt_messaging_hub_verify',
+    text: 'verify this inbound slack message'
+  });
+
+  const slackRouteFixture = cookbookBuildSlackFixture_(config, {
+    eventId: 'evt_messaging_hub_route',
     text: 'route this inbound slack message'
   });
 
   const slackVerified = ASTX.Messaging.verifyInbound({
     body: {
       provider: 'slack',
-      rawBody: slackFixture.rawBody,
-      headers: slackFixture.headers
+      rawBody: slackVerifyFixture.rawBody,
+      headers: slackVerifyFixture.headers
     }
   });
 
   const slackRouted = ASTX.Messaging.routeInbound({
     body: {
       provider: 'slack',
-      rawBody: slackFixture.rawBody,
-      headers: slackFixture.headers,
+      rawBody: slackRouteFixture.rawBody,
+      headers: slackRouteFixture.headers,
       routes: {
         'slack:message': routeContext => ({
           ok: true,

--- a/cookbooks/messaging_hub/src/20_Smoke.gs
+++ b/cookbooks/messaging_hub/src/20_Smoke.gs
@@ -1,0 +1,128 @@
+function runCookbookSmokeInternal_(config) {
+  const ASTX = cookbookAst_();
+  cookbookConfigureMessaging_(ASTX, config);
+
+  const templateIds = cookbookRegisterTemplates_(ASTX);
+  const rendered = ASTX.Messaging.renderTemplate({
+    body: {
+      templateId: templateIds.email,
+      variables: {
+        name: 'Cookbook User',
+        status: 'green',
+        release: '2026.03.14'
+      }
+    }
+  });
+
+  const emailPlan = ASTX.Messaging.sendTemplate({
+    body: {
+      templateId: templateIds.email,
+      to: [config.MESSAGING_HUB_DEFAULT_EMAIL_TO],
+      variables: {
+        name: 'Cookbook User',
+        status: 'green',
+        release: '2026.03.14'
+      }
+    },
+    options: {
+      dryRun: true
+    }
+  });
+
+  const chatPlan = ASTX.Messaging.chat.send({
+    body: cookbookBuildSmokeChatRequest_(config),
+    options: {
+      dryRun: true
+    }
+  });
+
+  const trackingEvent = ASTX.Messaging.tracking.recordEvent({
+    body: {
+      eventType: 'open',
+      deliveryId: 'messaging_hub_smoke_delivery',
+      trackingHash: 'messaging_hub_smoke_hash'
+    }
+  });
+
+  const listedLogs = ASTX.Messaging.logs.list({
+    body: {
+      limit: 10,
+      offset: 0,
+      includeEntries: true
+    }
+  });
+
+  const slackFixture = cookbookBuildSlackFixture_(config, {
+    eventId: 'evt_messaging_hub_smoke',
+    text: 'route this inbound slack message'
+  });
+
+  const slackVerified = ASTX.Messaging.verifyInbound({
+    body: {
+      provider: 'slack',
+      rawBody: slackFixture.rawBody,
+      headers: slackFixture.headers
+    }
+  });
+
+  const slackRouted = ASTX.Messaging.routeInbound({
+    body: {
+      provider: 'slack',
+      rawBody: slackFixture.rawBody,
+      headers: slackFixture.headers,
+      routes: {
+        'slack:message': routeContext => ({
+          ok: true,
+          provider: routeContext.provider,
+          eventType: routeContext.eventType,
+          text: routeContext.text
+        }),
+        default: () => ({ ok: false })
+      }
+    }
+  });
+
+  const googleChatVerified = ASTX.Messaging.verifyInbound({
+    body: {
+      provider: 'google_chat',
+      payload: cookbookBuildGoogleChatFixture_(config, {
+        eventId: 'evt_google_chat_smoke',
+        text: 'hello from google chat'
+      })
+    }
+  });
+
+  cookbookAssert_(rendered.data.rendered.subject === 'Release 2026.03.14 for Cookbook User', 'Rendered template subject did not match expected output.');
+  cookbookAssert_(emailPlan.dryRun && emailPlan.dryRun.enabled === true, 'Email dry-run did not return enabled plan output.');
+  cookbookAssert_(chatPlan.dryRun && chatPlan.dryRun.enabled === true, 'Chat dry-run did not return enabled plan output.');
+  cookbookAssert_(slackVerified.data.verified === true, 'Slack fixture verification failed.');
+  cookbookAssert_(slackRouted.data.route.handled === true, 'Slack route fixture was not handled.');
+  cookbookAssert_(googleChatVerified.data.verified === true, 'Google Chat token verification failed.');
+  cookbookAssert_(listedLogs.data.page.returned >= 1, 'Expected at least one messaging log entry.');
+
+  return {
+    status: 'ok',
+    entrypoint: 'runCookbookSmoke',
+    cookbook: cookbookName_(),
+    appName: config.MESSAGING_HUB_APP_NAME,
+    astVersion: ASTX.VERSION,
+    operationsCount: ASTX.Messaging.operations().length,
+    renderedPreview: rendered.data.rendered,
+    emailPlan: {
+      operation: emailPlan.operation,
+      dryRun: emailPlan.dryRun.enabled,
+      plannedOperation: emailPlan.dryRun.plannedRequest.operation
+    },
+    chatPlan: {
+      transport: chatPlan.transport,
+      dryRun: chatPlan.dryRun.enabled,
+      plannedOperation: chatPlan.dryRun.plannedRequest.operation
+    },
+    trackingEventId: trackingEvent.data.log.eventId,
+    logPage: listedLogs.data.page,
+    slackVerification: slackVerified.data.verification,
+    slackRoute: slackRouted.data.route,
+    googleChatVerification: googleChatVerified.data.verification,
+    generatedAt: new Date().toISOString()
+  };
+}

--- a/cookbooks/messaging_hub/src/30_Examples.gs
+++ b/cookbooks/messaging_hub/src/30_Examples.gs
@@ -1,0 +1,395 @@
+function cookbookConfigureMessaging_(ASTX, config) {
+  ASTX.Messaging.clearConfig();
+  ASTX.Messaging.configure({
+    MESSAGING_DEFAULT_FROM: 'alerts@example.com',
+    MESSAGING_DEFAULT_REPLY_TO: 'support@example.com',
+    MESSAGING_CHAT_WEBHOOK_URL: config.MESSAGING_HUB_CHAT_WEBHOOK_URL,
+    MESSAGING_SLACK_WEBHOOK_URL: config.MESSAGING_HUB_SLACK_WEBHOOK_URL,
+    MESSAGING_TEAMS_WEBHOOK_URL: config.MESSAGING_HUB_TEAMS_WEBHOOK_URL,
+    MESSAGING_TRACKING_ENABLED: 'true',
+    MESSAGING_TRACKING_OPEN_ENABLED: 'true',
+    MESSAGING_TRACKING_CLICK_ENABLED: 'true',
+    MESSAGING_TRACKING_BASE_URL: config.MESSAGING_HUB_TRACKING_BASE_URL,
+    MESSAGING_TRACKING_SIGNING_SECRET: config.MESSAGING_HUB_TRACKING_SIGNING_SECRET,
+    MESSAGING_TRACKING_ALLOWED_DOMAINS: config.MESSAGING_HUB_TRACKING_ALLOWED_DOMAINS,
+    MESSAGING_LOG_BACKEND: config.MESSAGING_HUB_LOG_BACKEND,
+    MESSAGING_LOG_NAMESPACE: config.MESSAGING_HUB_LOG_NAMESPACE,
+    MESSAGING_LOG_DRIVE_FOLDER_ID: config.MESSAGING_HUB_LOG_DRIVE_FOLDER_ID,
+    MESSAGING_LOG_DRIVE_FILE_NAME: config.MESSAGING_HUB_LOG_DRIVE_FILE_NAME,
+    MESSAGING_LOG_STORAGE_URI: config.MESSAGING_HUB_LOG_STORAGE_URI,
+    MESSAGING_TEMPLATE_BACKEND: config.MESSAGING_HUB_TEMPLATE_BACKEND,
+    MESSAGING_TEMPLATE_NAMESPACE: config.MESSAGING_HUB_TEMPLATE_NAMESPACE,
+    MESSAGING_TEMPLATE_DRIVE_FOLDER_ID: config.MESSAGING_HUB_TEMPLATE_DRIVE_FOLDER_ID,
+    MESSAGING_TEMPLATE_DRIVE_FILE_NAME: config.MESSAGING_HUB_TEMPLATE_DRIVE_FILE_NAME,
+    MESSAGING_TEMPLATE_STORAGE_URI: config.MESSAGING_HUB_TEMPLATE_STORAGE_URI,
+    MESSAGING_INBOUND_SLACK_SIGNING_SECRET: config.MESSAGING_HUB_INBOUND_SLACK_SIGNING_SECRET,
+    MESSAGING_INBOUND_GOOGLE_CHAT_VERIFICATION_TOKEN: config.MESSAGING_HUB_INBOUND_GOOGLE_CHAT_TOKEN,
+    MESSAGING_INBOUND_REPLAY_BACKEND: 'memory',
+    MESSAGING_INBOUND_REPLAY_NAMESPACE: `ast_cookbook_${cookbookName_()}_replay`,
+    MESSAGING_INBOUND_REPLAY_TTL_SEC: '600'
+  });
+}
+
+function cookbookTemplateIds_() {
+  return {
+    email: `${cookbookName_()}_release_email`,
+    chat: `${cookbookName_()}_release_chat`
+  };
+}
+
+function cookbookRegisterTemplates_(ASTX) {
+  const ids = cookbookTemplateIds_();
+
+  ASTX.Messaging.registerTemplate({
+    body: {
+      templateId: ids.email,
+      channel: 'email',
+      template: {
+        subject: 'Release {{release}} for {{name}}',
+        textBody: 'Status {{status}}',
+        htmlBody: '<p>Status {{status}}</p><a href="https://docs.example.com/release/{{release}}">Open release notes</a>',
+        variables: {
+          release: { type: 'string', required: true },
+          name: { type: 'string', required: true },
+          status: { type: 'string', required: true }
+        }
+      }
+    }
+  });
+
+  ASTX.Messaging.registerTemplate({
+    body: {
+      templateId: ids.chat,
+      channel: 'chat',
+      template: {
+        content: {
+          transport: 'webhook',
+          webhookUrl: 'https://chat.googleapis.com/v1/spaces/SPACE/messages?key=example&token=example',
+          message: {
+            text: 'Release {{release}} is {{status}}'
+          }
+        },
+        variables: {
+          release: { type: 'string', required: true },
+          status: { type: 'string', required: true }
+        }
+      }
+    }
+  });
+
+  return ids;
+}
+
+function cookbookBuildSmokeChatRequest_(config) {
+  const transport = config.MESSAGING_HUB_CHAT_TRANSPORT;
+  const message = {
+    text: `${config.MESSAGING_HUB_APP_NAME} smoke notification`
+  };
+
+  if (transport === 'slack_webhook') {
+    return {
+      transport,
+      webhookUrl: config.MESSAGING_HUB_SLACK_WEBHOOK_URL,
+      message
+    };
+  }
+
+  if (transport === 'teams_webhook') {
+    return {
+      transport,
+      webhookUrl: config.MESSAGING_HUB_TEAMS_WEBHOOK_URL,
+      message
+    };
+  }
+
+  return {
+    transport,
+    webhookUrl: config.MESSAGING_HUB_CHAT_WEBHOOK_URL,
+    message
+  };
+}
+
+function cookbookAssert_(condition, message) {
+  if (!condition) {
+    throw new Error(message || 'Cookbook assertion failed.');
+  }
+}
+
+function cookbookToHex_(bytes) {
+  let out = '';
+  for (let idx = 0; idx < bytes.length; idx += 1) {
+    const normalized = bytes[idx] < 0 ? bytes[idx] + 256 : bytes[idx];
+    out += normalized.toString(16).padStart(2, '0');
+  }
+  return out;
+}
+
+function cookbookBuildSlackSignature_(timestampSec, rawBody, secret) {
+  const base = `v0:${timestampSec}:${rawBody}`;
+  const bytes = Utilities.computeHmacSha256Signature(base, secret);
+  return `v0=${cookbookToHex_(bytes)}`;
+}
+
+function cookbookBuildSlackFixture_(config, options) {
+  const settings = options || {};
+  const timestampSec = settings.timestampSec || Math.floor(Date.now() / 1000);
+  const rawBody = JSON.stringify({
+    type: 'event_callback',
+    event_id: settings.eventId || `evt_${Date.now()}`,
+    event: {
+      type: 'message',
+      text: settings.text || 'hello from slack'
+    }
+  });
+  const signature = cookbookBuildSlackSignature_(
+    timestampSec,
+    rawBody,
+    config.MESSAGING_HUB_INBOUND_SLACK_SIGNING_SECRET
+  );
+
+  return {
+    rawBody,
+    headers: {
+      'x-slack-request-timestamp': String(timestampSec),
+      'x-slack-signature': signature
+    }
+  };
+}
+
+function cookbookBuildGoogleChatFixture_(config, options) {
+  const settings = options || {};
+  return {
+    type: 'MESSAGE',
+    token: config.MESSAGING_HUB_INBOUND_GOOGLE_CHAT_TOKEN,
+    eventId: settings.eventId || `evt_google_chat_${Date.now()}`,
+    message: {
+      text: settings.text || 'hello from google chat'
+    }
+  };
+}
+
+function cookbookQueryFromUrl_(url) {
+  const out = {};
+  if (!url || url.indexOf('?') === -1) {
+    return out;
+  }
+
+  const query = String(url).replace(/&amp;/g, '&').split('?').slice(1).join('?');
+  const pairs = query.split('&');
+  for (let idx = 0; idx < pairs.length; idx += 1) {
+    const pair = pairs[idx];
+    if (!pair) {
+      continue;
+    }
+    const parts = pair.split('=');
+    const key = decodeURIComponent(parts[0] || '');
+    const value = decodeURIComponent(parts.slice(1).join('=') || '');
+    out[key] = value;
+  }
+  return out;
+}
+
+function cookbookFirstTrackedHref_(html) {
+  const match = String(html || '').match(/href="([^"]+)"/i);
+  return match ? match[1] : '';
+}
+
+function cookbookPublicConfig_(config) {
+  return {
+    MESSAGING_HUB_APP_NAME: config.MESSAGING_HUB_APP_NAME,
+    MESSAGING_HUB_DEFAULT_EMAIL_TO: config.MESSAGING_HUB_DEFAULT_EMAIL_TO,
+    MESSAGING_HUB_CHAT_TRANSPORT: config.MESSAGING_HUB_CHAT_TRANSPORT,
+    MESSAGING_HUB_LOG_BACKEND: config.MESSAGING_HUB_LOG_BACKEND,
+    MESSAGING_HUB_LOG_NAMESPACE: config.MESSAGING_HUB_LOG_NAMESPACE,
+    MESSAGING_HUB_TEMPLATE_BACKEND: config.MESSAGING_HUB_TEMPLATE_BACKEND,
+    MESSAGING_HUB_TEMPLATE_NAMESPACE: config.MESSAGING_HUB_TEMPLATE_NAMESPACE,
+    MESSAGING_HUB_TRACKING_BASE_URL: config.MESSAGING_HUB_TRACKING_BASE_URL,
+    MESSAGING_HUB_TRACKING_ALLOWED_DOMAINS: config.MESSAGING_HUB_TRACKING_ALLOWED_DOMAINS,
+    MESSAGING_HUB_INBOUND_GOOGLE_CHAT_TOKEN: '[configured]',
+    MESSAGING_HUB_INBOUND_SLACK_SIGNING_SECRET: '[configured]',
+    MESSAGING_HUB_TRACKING_SIGNING_SECRET: '[configured]'
+  };
+}
+
+function runCookbookDemoInternal_(config) {
+  const ASTX = cookbookAst_();
+  cookbookConfigureMessaging_(ASTX, config);
+
+  const templateIds = cookbookRegisterTemplates_(ASTX);
+  const emailPlan = ASTX.Messaging.email.send({
+    body: {
+      to: [config.MESSAGING_HUB_DEFAULT_EMAIL_TO],
+      subject: 'Direct dry-run send',
+      textBody: 'This is a direct email dry-run example.',
+      htmlBody: '<p>Direct email</p><a href="https://docs.example.com/demo">Read docs</a>',
+      options: {
+        track: {
+          enabled: true,
+          open: true,
+          click: true
+        }
+      }
+    },
+    options: {
+      dryRun: true
+    }
+  });
+
+  const chatBatchPlan = ASTX.Messaging.chat.sendBatch({
+    body: {
+      transport: 'slack_webhook',
+      webhookUrl: config.MESSAGING_HUB_SLACK_WEBHOOK_URL,
+      messages: [
+        { message: { text: 'Release started' } },
+        { message: { text: 'Release finished' } }
+      ]
+    },
+    options: {
+      dryRun: true
+    }
+  });
+
+  const renderedEmail = ASTX.Messaging.renderTemplate({
+    body: {
+      templateId: templateIds.email,
+      variables: {
+        release: '2026.03.14',
+        name: 'Ops Team',
+        status: 'ok'
+      }
+    }
+  });
+
+  const templatePlan = ASTX.Messaging.sendTemplate({
+    body: {
+      templateId: templateIds.chat,
+      variables: {
+        release: '2026.03.14',
+        status: 'ok'
+      }
+    },
+    options: {
+      dryRun: true
+    }
+  });
+
+  const pixelUrl = ASTX.Messaging.tracking.buildPixelUrl({
+    body: {
+      deliveryId: 'delivery_demo_open',
+      eventType: 'open',
+      trackingHash: 'hash_demo_open'
+    }
+  });
+
+  const handledPixel = ASTX.Messaging.tracking.handleWebEvent({
+    body: {
+      query: cookbookQueryFromUrl_(pixelUrl.data.url)
+    }
+  });
+
+  const wrapped = ASTX.Messaging.tracking.wrapLinks({
+    body: {
+      html: '<a href="https://docs.example.com/releases/2026-03-14">Release notes</a>',
+      deliveryId: 'delivery_demo_click',
+      trackingHash: 'hash_demo_click',
+      allowedDomains: cookbookNormalizeCsv_(config.MESSAGING_HUB_TRACKING_ALLOWED_DOMAINS)
+    }
+  });
+
+  const trackedHref = cookbookFirstTrackedHref_(wrapped.data.html);
+  const handledClick = ASTX.Messaging.tracking.handleWebEvent({
+    body: {
+      query: cookbookQueryFromUrl_(trackedHref)
+    }
+  });
+
+  const recorded = ASTX.Messaging.tracking.recordEvent({
+    body: {
+      eventType: 'delivered',
+      deliveryId: 'delivery_demo_log',
+      trackingHash: 'hash_demo_log'
+    }
+  });
+
+  const eventId = recorded.data.log.eventId;
+  const fetchedLog = ASTX.Messaging.logs.get({ body: { eventId } });
+  const deletedLog = ASTX.Messaging.logs.delete({ body: { eventId } });
+
+  const slackFormPayload = JSON.stringify({
+    type: 'event_callback',
+    event_id: 'evt_form_slack_demo',
+    event: {
+      type: 'message',
+      text: 'form encoded payload'
+    }
+  });
+  const parsedSlack = ASTX.Messaging.parseInbound({
+    body: {
+      provider: 'slack',
+      rawBody: `payload=${encodeURIComponent(slackFormPayload)}`
+    }
+  });
+
+  const routedGoogleChat = ASTX.Messaging.routeInbound({
+    body: {
+      provider: 'google_chat',
+      payload: cookbookBuildGoogleChatFixture_(config, {
+        eventId: 'evt_google_chat_demo',
+        text: 'route this google chat message'
+      }),
+      routes: {
+        'google_chat:MESSAGE': routeContext => ({
+          ok: true,
+          provider: routeContext.provider,
+          text: routeContext.text
+        }),
+        default: () => ({ ok: false })
+      }
+    }
+  });
+
+  cookbookAssert_(handledPixel.data.pixel === true, 'Tracking pixel event did not resolve to a pixel response.');
+  cookbookAssert_(handledClick.data.redirectUrl === 'https://docs.example.com/releases/2026-03-14', 'Tracking click redirect did not preserve the expected target URL.');
+  cookbookAssert_(deletedLog.data.deleted === true, 'Messaging log delete did not confirm deletion.');
+  cookbookAssert_(routedGoogleChat.data.output.ok === true, 'Google Chat route handler did not execute successfully.');
+
+  return {
+    status: 'ok',
+    entrypoint: 'runCookbookDemo',
+    cookbook: cookbookName_(),
+    config: cookbookPublicConfig_(config),
+    emailPlan: {
+      dryRun: emailPlan.dryRun.enabled,
+      plannedOperation: emailPlan.dryRun.plannedRequest.operation
+    },
+    chatBatchPlan: {
+      plannedMessages: Array.isArray(chatBatchPlan.dryRun.plannedRequest.body.messages)
+        ? chatBatchPlan.dryRun.plannedRequest.body.messages.length
+        : 0,
+      dryRun: chatBatchPlan.dryRun.enabled,
+      transport: chatBatchPlan.transport
+    },
+    renderedEmail: renderedEmail.data.rendered,
+    templatePlan: {
+      transport: templatePlan.transport,
+      dryRun: templatePlan.dryRun.enabled,
+      templateId: templatePlan.dryRun.plannedRequest.body.templateId
+    },
+    tracking: {
+      pixelUrl: pixelUrl.data.url,
+      handledPixel: handledPixel.data,
+      wrappedCount: wrapped.data.wrappedCount,
+      redirectUrl: handledClick.data.redirectUrl
+    },
+    logs: {
+      fetchedEventId: fetchedLog.data.item.eventId,
+      deleted: deletedLog.data.deleted
+    },
+    inbound: {
+      parsedSlack: parsedSlack.data.parsed,
+      routedGoogleChat: routedGoogleChat.data.route,
+      output: routedGoogleChat.data.output
+    },
+    generatedAt: new Date().toISOString()
+  };
+}

--- a/cookbooks/messaging_hub/src/99_DevTools.gs
+++ b/cookbooks/messaging_hub/src/99_DevTools.gs
@@ -1,0 +1,41 @@
+function clearCookbookConfig() {
+  const props = cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+  const removed = [];
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    props.deleteProperty(fields[idx].key);
+    removed.push(fields[idx].key);
+  }
+
+  return cookbookLogResult_('clearCookbookConfig', {
+    status: 'ok',
+    cookbook: cookbookName_(),
+    removed
+  });
+}
+
+function showCookbookContract() {
+  return cookbookLogResult_('showCookbookContract', {
+    cookbook: cookbookName_(),
+    templateVersion: cookbookTemplateVersion_(),
+    requiredEntrypoints: [
+      'seedCookbookConfig',
+      'validateCookbookConfig',
+      'runCookbookSmoke',
+      'runCookbookDemo',
+      'runCookbookAll'
+    ],
+    configFields: cookbookConfigFields_()
+  });
+}
+
+function showMessagingRuntimeConfig() {
+  const ASTX = cookbookAst_();
+  return cookbookLogResult_('showMessagingRuntimeConfig', ASTX.Messaging.getConfig());
+}
+
+function clearMessagingRuntimeConfig() {
+  const ASTX = cookbookAst_();
+  return cookbookLogResult_('clearMessagingRuntimeConfig', ASTX.Messaging.clearConfig());
+}

--- a/cookbooks/messaging_hub/src/appsscript.json
+++ b/cookbooks/messaging_hub/src/appsscript.json
@@ -1,0 +1,14 @@
+{
+  "timeZone": "Etc/UTC",
+  "dependencies": {
+    "libraries": [
+      {
+        "userSymbol": "ASTLib",
+        "libraryId": "1gZ_6DiLeDhh-a4qcezluTFDshw4OEhTXbeD3wthl_UdHEAFkXf6i6Ho_",
+        "version": "<PUBLISHED_AST_LIBRARY_VERSION>"
+      }
+    ]
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
+}

--- a/docs/getting-started/cookbooks.md
+++ b/docs/getting-started/cookbooks.md
@@ -98,6 +98,7 @@ Put reusable logic back into the library (`apps_script_tools/`) only when it is 
 - `github_issue_digest`: template-v2 GitHub automation cookbook for issues, PRs, checks, Actions, GraphQL, Projects v2, and dry-run mutation planning via `AST.GitHub`.
 - `http_ingestion_pipeline`: template-v2 `AST.Http` cookbook for resilient request flows, batch error handling, safe redaction, and optional cache/telemetry composition.
 - `jobs_triggers_orchestration`: template-v2 orchestration cookbook for `AST.Jobs` and `AST.Triggers`, including retry/resume flows, schedule bridge, and DLQ lifecycle.
+- `messaging_hub`: template-v2 messaging cookbook for `AST.Messaging`, including email/chat dry-run plans, templates, tracking/logs, and signed inbound webhook fixtures.
 - `telemetry_alerting`: template-v2 observability cookbook for `AST.Telemetry` and `AST.TelemetryHelpers`, including redaction checks, grouped metrics, alert rules, and dry-run notifications.
 - `rag_chat_starter`: template-v2 webapp starter for grounded `AST.RAG` chat with `AST.Chat` thread persistence, linked citations, and configurable branding.
 - `dbt_manifest_summary`: template-v2 DBT artifact explorer covering manifest load/search, lineage, governance, and artifact comparison via `AST.DBT`.


### PR DESCRIPTION
## Summary
- add `cookbooks/messaging_hub` on the template-v2 cookbook contract
- demonstrate `AST.Messaging` email/chat dry-run flows, template register/render/send, tracking/logs, and inbound verification/routing
- update cookbook catalog docs to publish the new messaging example

## What Changed
- added `cookbooks/messaging_hub` with `00_Config.gs`, `10_EntryPoints.gs`, `20_Smoke.gs`, `30_Examples.gs`, and `99_DevTools.gs`
- implemented deterministic smoke coverage for dry-run email/chat planning, template rendering, tracking log writes, Slack signature verification, and Google Chat token verification
- added a richer demo covering click/open tracking handling, log get/delete, Slack form-encoded parsing, and Google Chat route dispatch
- updated `cookbooks/README.md` and `docs/getting-started/cookbooks.md`

## Validation
- `npm run lint`
- `uv run mkdocs build --strict`
- `git diff --check`

Closes #305
Part of #295.
