### PR TITLE
docs(cookbooks): publish catalog and validation matrix

### DIFF
--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -1,13 +1,14 @@
 # Cookbooks
 
-`cookbooks/` holds project-specific Apps Script implementations that consume this library.
+`cookbooks/` holds project-specific Apps Script implementations that consume this library through the public `AST` surface.
 
 Goal:
 
 - Keep reusable platform code in `apps_script_tools/`.
 - Keep app-specific code (webapps, demos, integrations) in isolated cookbook projects.
+- Publish a discoverable catalog so each major `AST` surface has a runnable example.
 
-## Folder Model
+## Folder model
 
 ```text
 cookbooks/
@@ -40,7 +41,7 @@ cookbooks/
       99_DevTools.gs
 ```
 
-## Create a New Cookbook Project
+## Create a new cookbook project
 
 ```bash
 cp -R cookbooks/_template cookbooks/<project-name>
@@ -66,7 +67,7 @@ Run the template bootstrap in Apps Script:
 
 ## Template v2 contract
 
-All new cookbooks should start from `cookbooks/_template` and keep these required entrypoints:
+All new cookbook projects should start from `cookbooks/_template` and keep these required entrypoints:
 
 - `seedCookbookConfig()`
 - `validateCookbookConfig()`
@@ -82,30 +83,50 @@ The template README documents:
 - deployment checklist
 - troubleshooting notes
 
-## Available examples
+## Published cookbook catalog
 
-- `_template`: cookbook template v2 contract and starter scaffold.
-- `ai_playground`: practical `AST.AI` cookbook covering text, structured output, tool calls, stream callbacks, and optional provider routing/fallback.
-- `config_cache_patterns`: runtime composition cookbook for `AST.Config`, `AST.Runtime`, `AST.Secrets`, and `AST.Cache`.
-- `data_workflows_starter`: core data workflow example using `Series`, `DataFrame`, `GroupBy`, `AST.Drive`, `AST.Sheets`, `AST.Sql`, and `AST.Utils`.
-- `storage_ops`: practical `AST.Storage` example covering object CRUD, `walk`, `transfer`, `copyPrefix`, `deletePrefix`, and `sync`.
-- `github_issue_digest`: template-v2 GitHub automation cookbook for issues, PRs, checks, Actions, GraphQL, Projects v2, and dry-run mutation planning via `AST.GitHub`.
-- `http_ingestion_pipeline`: template-v2 `AST.Http` cookbook for resilient request flows, batch error handling, safe redaction, and optional cache/telemetry composition.
-- `jobs_triggers_orchestration`: template-v2 orchestration cookbook for `AST.Jobs` and `AST.Triggers`, including retry/resume flows, schedule bridge, and DLQ lifecycle.
-- `messaging_hub`: template-v2 messaging cookbook for `AST.Messaging`, including email/chat dry-run plans, templates, tracking/logs, and signed inbound webhook fixtures.
-- `telemetry_alerting`: template-v2 observability cookbook for `AST.Telemetry` and `AST.TelemetryHelpers`, including redaction checks, grouped metrics, alert rules, and dry-run notifications.
-- `rag_chat_starter`: template-v2 webapp starter for grounded `AST.RAG` chat with `AST.Chat` thread persistence, linked citations, and configurable branding.
-- `dbt_manifest_summary`: template-v2 DBT artifact explorer for manifest search, lineage, governance, and artifact comparison via `AST.DBT`.
-- `storage_cache_warmer`: focused `AST.Cache` example for warming persisted `storage_json` cache entries.
+| Cookbook | Type | AST modules covered | Required script properties | Entrypoints |
+| --- | --- | --- | --- | --- |
+| `_template` | Template v2 scaffold | `AST.DataFrame`, `AST.Cache` sample usage only | `COOKBOOK_*` | `seedCookbookConfig`, `validateCookbookConfig`, `runCookbookSmoke`, `runCookbookDemo`, `runCookbookAll` |
+| `ai_playground` | Script-run | `AST.AI` | `AI_PLAYGROUND_*` plus provider auth as needed | standard template-v2 entrypoints |
+| `config_cache_patterns` | Script-run | `AST.Config`, `AST.Runtime`, `AST.Secrets`, `AST.Cache` | `CONFIG_CACHE_*` plus backend-specific cache secrets/URIs | standard template-v2 entrypoints |
+| `data_workflows_starter` | Script-run | `AST.Series`, `AST.DataFrame`, `AST.GroupBy`, `AST.Drive`, `AST.Sheets`, `AST.Sql`, `AST.Utils` | `DATA_WORKFLOWS_*` plus optional Drive/Sheets/SQL config | standard template-v2 entrypoints |
+| `dbt_manifest_summary` | Script-run | `AST.DBT` | `DBT_*` / cookbook DBT source and cache properties | standard template-v2 entrypoints |
+| `github_issue_digest` | Script-run | `AST.GitHub` | `GITHUB_*` / cookbook GitHub defaults and token | standard template-v2 entrypoints |
+| `http_ingestion_pipeline` | Script-run | `AST.Http`, optional `AST.Cache`, `AST.Telemetry` | `HTTP_INGESTION_*` plus target API config | standard template-v2 entrypoints |
+| `jobs_triggers_orchestration` | Script-run | `AST.Jobs`, `AST.Triggers` | `JOBS_TRIGGERS_*` | standard template-v2 entrypoints |
+| `messaging_hub` | Script-run | `AST.Messaging` | `MESSAGING_HUB_*` plus optional live webhook/mail settings | standard template-v2 entrypoints |
+| `rag_chat_starter` | Webapp | `AST.RAG`, `AST.Chat`, `AST.AI`, `AST.Cache` | `RAG_CHAT_*` plus provider/index/cache settings | standard template-v2 entrypoints + HtmlService webapp |
+| `storage_cache_warmer` | Focused script-run | `AST.Cache`, `AST.Storage` | `STORAGE_CACHE_URI`, optional `STORAGE_CACHE_NAMESPACE`, provider auth | `runStorageCacheWarmerSmoke` |
+| `storage_ops` | Script-run | `AST.Storage` | `STORAGE_OPS_*` plus provider auth/URIs | standard template-v2 entrypoints |
+| `telemetry_alerting` | Script-run | `AST.Telemetry`, `AST.TelemetryHelpers` | `TELEMETRY_COOKBOOK_*` | standard template-v2 entrypoints |
+
+## Validation hooks
+
+Use the structural verifier before release or when adding a cookbook:
+
+```bash
+npm run check:cookbooks
+```
+
+This check verifies:
+
+- every published cookbook directory is catalogued
+- each template-v2 cookbook contains the required scaffold files
+- `cookbooks/README.md` and `docs/getting-started/cookbooks.md` both mention every catalogued cookbook
+
+`npm run lint` also runs this cookbook structure check.
 
 ## Smoke instructions
 
-Each example README includes required script properties and the entrypoint function to run.
+Each cookbook README includes required script properties and the primary entrypoint function to run.
 Recommended smoke order:
 
 1. `clasp push`
-2. Run the example's `*Smoke` function from Apps Script.
+2. Run the example's documented smoke entrypoint from Apps Script.
 3. Verify logged output and expected external side effects (where applicable).
+
+Use the full validation matrix in `docs/getting-started/cookbooks.md` for pre-release sign-off.
 
 ## Rules
 

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -46,6 +46,17 @@ CI workflow config:
 - Set repository secrets: `CLASP_CLIENT_ID`, `CLASP_CLIENT_SECRET`, `CLASP_REFRESH_TOKEN`.
 - Keep the pinned clasp version in `.github/actions/setup-clasp/action.yml` (`clasp-version`) current; bump it intentionally and validate CI before release.
 
+Cookbook validation:
+
+```bash
+npm run check:cookbooks
+```
+
+- Treat `docs/getting-started/cookbooks.md` as the source of truth for the manual cookbook smoke matrix.
+- Run every changed cookbook's smoke entrypoint before release.
+- For shared module changes, also run the cookbook rows that depend on those modules even if the cookbook itself did not change.
+- Keep `cookbooks/README.md` and `docs/getting-started/cookbooks.md` aligned with the published cookbook set.
+
 Consumer validation (recommended):
 
 - install library in a clean Apps Script project

--- a/docs/getting-started/cookbooks.md
+++ b/docs/getting-started/cookbooks.md
@@ -1,68 +1,12 @@
 # Cookbooks
 
-Use cookbook projects when you want to build app-specific Apps Script solutions (for example, a webapp chat UI) without adding project code into the core library package.
+Use cookbook projects when you want to build app-specific Apps Script solutions without adding project code into the core library package.
 
 ## Why this pattern
 
 - Keeps `apps_script_tools/` focused on reusable library features.
 - Lets each app have its own Apps Script deployment lifecycle and Script ID.
 - Prevents accidental coupling between library internals and one-off app logic.
-
-## Recommended structure
-
-```text
-cookbooks/
-  _template/
-  my-project/
-    .clasp.json          # local-only
-    .claspignore
-    README.md
-    src/
-      appsscript.json
-      00_Config.gs
-      10_EntryPoints.gs
-      20_Smoke.gs
-      30_Examples.gs
-      99_DevTools.gs
-      # optional HtmlService assets for webapp cookbooks:
-      # Index.html
-      # IndexLayout.html
-      # IndexStyles.html
-      # IndexScript.html
-```
-
-## Create a cookbook project
-
-```bash
-cp -R cookbooks/_template cookbooks/my-project
-cd cookbooks/my-project
-cp .clasp.json.example .clasp.json
-```
-
-Update `.clasp.json`:
-
-- `scriptId`: target script for this app
-- `rootDir`: keep as `src`
-
-Then push:
-
-```bash
-clasp push
-```
-
-Then run:
-
-1. `seedCookbookConfig()`
-2. `runCookbookAll()`
-
-## Use the library in cookbook code
-
-```javascript
-function runCookbook() {
-  const ASTX = ASTLib.AST || ASTLib;
-  Logger.log(ASTX.VERSION);
-}
-```
 
 ## Template contract
 
@@ -84,30 +28,67 @@ Each cookbook should:
 - include least-privilege OAuth scope guidance
 - explain common failure modes and setup steps
 
+## Setup tiers
+
+Use these tiers to decide how much setup is required before you run a cookbook.
+
+| Tier | Meaning | Cookbooks |
+| --- | --- | --- |
+| `Tier 0` | Local/editor-only validation; no external credentials required beyond the AST library binding | `_template`, `data_workflows_starter` |
+| `Tier 1` | Script Properties required; may use Drive, cache, or durable state but defaults stay local/dry-run | `config_cache_patterns`, `jobs_triggers_orchestration`, `messaging_hub`, `storage_cache_warmer`, `storage_ops`, `telemetry_alerting` |
+| `Tier 2` | External API/provider credentials required for realistic runs | `ai_playground`, `dbt_manifest_summary`, `github_issue_digest`, `http_ingestion_pipeline` |
+| `Tier 3` | Deployable webapp or richer app shell with UI/session/index configuration | `rag_chat_starter` |
+
+## Published cookbook index
+
+| Cookbook | Type | README | AST modules | Smoke | Demo |
+| --- | --- | --- | --- | --- | --- |
+| `_template` | Template v2 scaffold | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/_template/README.md) | `AST.DataFrame`, `AST.Cache` sample usage | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `ai_playground` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/ai_playground/README.md) | `AST.AI` | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `config_cache_patterns` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/config_cache_patterns/README.md) | `AST.Config`, `AST.Runtime`, `AST.Secrets`, `AST.Cache` | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `data_workflows_starter` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/data_workflows_starter/README.md) | `AST.Series`, `AST.DataFrame`, `AST.GroupBy`, `AST.Drive`, `AST.Sheets`, `AST.Sql`, `AST.Utils` | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `dbt_manifest_summary` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/dbt_manifest_summary/README.md) | `AST.DBT` | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `github_issue_digest` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/github_issue_digest/README.md) | `AST.GitHub` | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `http_ingestion_pipeline` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/http_ingestion_pipeline/README.md) | `AST.Http`, optional `AST.Cache`, `AST.Telemetry` | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `jobs_triggers_orchestration` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/jobs_triggers_orchestration/README.md) | `AST.Jobs`, `AST.Triggers` | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `messaging_hub` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/messaging_hub/README.md) | `AST.Messaging` | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `rag_chat_starter` | Webapp | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/rag_chat_starter/README.md) | `AST.RAG`, `AST.Chat`, `AST.AI`, `AST.Cache` | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `storage_cache_warmer` | Focused script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/storage_cache_warmer/README.md) | `AST.Cache`, `AST.Storage` | `runStorageCacheWarmerSmoke()` | n/a |
+| `storage_ops` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/storage_ops/README.md) | `AST.Storage` | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `telemetry_alerting` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/telemetry_alerting/README.md) | `AST.Telemetry`, `AST.TelemetryHelpers` | `runCookbookSmoke()` | `runCookbookDemo()` |
+
+## Manual smoke validation matrix
+
+Use this matrix for cookbook release-readiness checks.
+
+| Cookbook | Minimum prep | Validation run | Expected result |
+| --- | --- | --- | --- |
+| `_template` | set library version, run `seedCookbookConfig()` | `runCookbookAll()` | validation is `ok`; smoke/demo both return structured summaries |
+| `ai_playground` | seed `AI_PLAYGROUND_*`; configure one provider | `runCookbookAll()` | text/structured/tools paths return deterministic summaries or dry-run plans |
+| `config_cache_patterns` | seed `CONFIG_CACHE_*`; choose a cache backend | `runCookbookAll()` | runtime/config precedence and cache round-trips succeed |
+| `data_workflows_starter` | seed `DATA_WORKFLOWS_*`; optional Drive/Sheets/SQL config | `runCookbookAll()` | frame summaries and sample outputs render without external failures |
+| `dbt_manifest_summary` | provide manifest source/cache config | `runCookbookAll()` | manifest load, inspect, search, and lineage summaries are populated |
+| `github_issue_digest` | provide `GITHUB_TOKEN` / cookbook GitHub defaults | `runCookbookAll()` | read flows succeed; mutation examples return dry-run plans |
+| `http_ingestion_pipeline` | provide target endpoint config or leave dry-run/defaults | `runCookbookAll()` | request/response summaries show retries/redaction/caching behavior |
+| `jobs_triggers_orchestration` | seed `JOBS_TRIGGERS_*` | `runCookbookAll()` then `cleanupCookbookArtifacts()` | job, trigger, and DLQ flows succeed; cleanup removes cookbook-owned state |
+| `messaging_hub` | seed `MESSAGING_HUB_*` (defaults are safe) | `runCookbookAll()` | dry-run email/chat plans, template render, tracking logs, and inbound fixture routing succeed |
+| `rag_chat_starter` | configure index, provider, cache, and branding settings | `runCookbookSmoke()` + deploy webapp if needed | smoke confirms index/chat setup; webapp loads and grounded responses cite sources |
+| `storage_cache_warmer` | set `STORAGE_CACHE_URI` and provider auth | `runStorageCacheWarmerSmoke()` | cache object warms successfully and persisted backend responds |
+| `storage_ops` | seed `STORAGE_OPS_*` and provider auth | `runCookbookAll()` | CRUD/list/walk/sync summaries match the configured provider |
+| `telemetry_alerting` | seed `TELEMETRY_COOKBOOK_*`; keep sink `logger` for easiest run | `runCookbookAll()` | grouped metrics, redaction preview, alert evaluation, and dry-run notifications succeed |
+
+## Release-readiness checklist
+
+Before a release that touches cookbook code, docs, or the underlying AST modules they depend on:
+
+1. Run `npm run check:cookbooks`.
+2. Run `npm run lint`.
+3. Run `uv run mkdocs build --strict`.
+4. Execute the smoke entrypoint for every cookbook that changed in the release.
+5. For shared-module changes, also execute the matrix rows that depend on those modules.
+6. Confirm every cookbook README still matches its Script Properties and entrypoints.
+7. Confirm `cookbooks/README.md` and this page both list the same cookbook set.
+
 ## Scope guidance
 
 Put reusable logic back into the library (`apps_script_tools/`) only when it is generic enough for other consumers.
-
-## Available cookbook examples
-
-- `_template`: baseline scaffold for new cookbook projects.
-- `ai_playground`: `AST.AI` cookbook for text, structured output, tools, stream callbacks, and optional routing/fallback.
-- `config_cache_patterns`: runtime composition cookbook for `AST.Config`, `AST.Runtime`, `AST.Secrets`, and `AST.Cache`.
-- `data_workflows_starter`: end-to-end `Series`/`DataFrame`/`GroupBy` + Drive/Sheets/SQL workflow example.
-- `storage_ops`: practical `AST.Storage` cookbook covering object CRUD plus `walk`, `transfer`, `copyPrefix`, `deletePrefix`, and `sync`.
-- `github_issue_digest`: template-v2 GitHub automation cookbook for issues, PRs, checks, Actions, GraphQL, Projects v2, and dry-run mutation planning via `AST.GitHub`.
-- `http_ingestion_pipeline`: template-v2 `AST.Http` cookbook for resilient request flows, batch error handling, safe redaction, and optional cache/telemetry composition.
-- `jobs_triggers_orchestration`: template-v2 orchestration cookbook for `AST.Jobs` and `AST.Triggers`, including retry/resume flows, schedule bridge, and DLQ lifecycle.
-- `messaging_hub`: template-v2 messaging cookbook for `AST.Messaging`, including email/chat dry-run plans, templates, tracking/logs, and signed inbound webhook fixtures.
-- `telemetry_alerting`: template-v2 observability cookbook for `AST.Telemetry` and `AST.TelemetryHelpers`, including redaction checks, grouped metrics, alert rules, and dry-run notifications.
-- `rag_chat_starter`: template-v2 webapp starter for grounded `AST.RAG` chat with `AST.Chat` thread persistence, linked citations, and configurable branding.
-- `dbt_manifest_summary`: template-v2 DBT artifact explorer covering manifest load/search, lineage, governance, and artifact comparison via `AST.DBT`.
-- `storage_cache_warmer`: focused `AST.Cache` example for warming persisted `storage_json` cache entries.
-
-## Example validation
-
-For each cookbook:
-
-1. `clasp push` in the cookbook directory.
-2. Run the documented `*Smoke` entrypoint.
-3. Confirm log output and expected side effects.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.5",
   "description": "Google Apps Script data toolkit",
   "scripts": {
+    "check:cookbooks": "node scripts/check-cookbooks.mjs",
     "lint": "node scripts/lint.mjs",
     "test:local": "node --test tests/local/*.test.mjs",
     "test:local:coverage": "node scripts/run-local-coverage.mjs",

--- a/scripts/check-cookbooks.mjs
+++ b/scripts/check-cookbooks.mjs
@@ -1,0 +1,119 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const COOKBOOKS = Object.freeze([
+  { id: '_template', structure: 'template_v2' },
+  { id: 'ai_playground', structure: 'template_v2' },
+  { id: 'config_cache_patterns', structure: 'template_v2' },
+  { id: 'data_workflows_starter', structure: 'template_v2' },
+  { id: 'dbt_manifest_summary', structure: 'template_v2' },
+  { id: 'github_issue_digest', structure: 'template_v2' },
+  { id: 'http_ingestion_pipeline', structure: 'template_v2' },
+  { id: 'jobs_triggers_orchestration', structure: 'template_v2' },
+  { id: 'messaging_hub', structure: 'template_v2' },
+  { id: 'rag_chat_starter', structure: 'template_v2' },
+  { id: 'storage_cache_warmer', structure: 'focused_single_file' },
+  { id: 'storage_ops', structure: 'template_v2' },
+  { id: 'telemetry_alerting', structure: 'template_v2' }
+]);
+
+const NON_PUBLISHED_DIRECTORIES = Object.freeze([
+  'rag_chat_app'
+]);
+
+const REQUIRED_FILES = Object.freeze({
+  template_v2: Object.freeze([
+    '.clasp.json.example',
+    '.claspignore',
+    'README.md',
+    'src/appsscript.json',
+    'src/00_Config.gs',
+    'src/10_EntryPoints.gs',
+    'src/20_Smoke.gs',
+    'src/30_Examples.gs',
+    'src/99_DevTools.gs'
+  ]),
+  focused_single_file: Object.freeze([
+    '.clasp.json.example',
+    '.claspignore',
+    'README.md',
+    'src/appsscript.json',
+    'src/main.gs'
+  ])
+});
+
+function readText(file) {
+  return fs.readFileSync(file, 'utf8');
+}
+
+function cookbookDocsMention(fileText, cookbookId) {
+  return fileText.includes(`\`${cookbookId}\``);
+}
+
+export function runCookbookChecks(root = process.cwd()) {
+  const findings = [];
+  const cookbooksDir = path.join(root, 'cookbooks');
+  const cookbookReadme = readText(path.join(cookbooksDir, 'README.md'));
+  const docsCookbooks = readText(path.join(root, 'docs', 'getting-started', 'cookbooks.md'));
+
+  const actualCookbooks = fs.readdirSync(cookbooksDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .filter(entry => !NON_PUBLISHED_DIRECTORIES.includes(entry))
+    .sort();
+  const expectedCookbooks = COOKBOOKS.map(item => item.id).sort();
+
+  for (const cookbookId of expectedCookbooks) {
+    if (!actualCookbooks.includes(cookbookId)) {
+      findings.push(`Missing catalogued cookbook directory: cookbooks/${cookbookId}`);
+    }
+  }
+
+  for (const cookbookId of actualCookbooks) {
+    if (!expectedCookbooks.includes(cookbookId)) {
+      findings.push(`Cookbook directory is not catalogued in scripts/check-cookbooks.mjs: cookbooks/${cookbookId}`);
+    }
+  }
+
+  for (const cookbook of COOKBOOKS) {
+    const cookbookDir = path.join(cookbooksDir, cookbook.id);
+    if (!fs.existsSync(cookbookDir)) {
+      continue;
+    }
+
+    const required = REQUIRED_FILES[cookbook.structure] || [];
+    for (const relativeFile of required) {
+      const full = path.join(cookbookDir, relativeFile);
+      if (!fs.existsSync(full)) {
+        findings.push(`Cookbook ${cookbook.id} is missing required ${cookbook.structure} file: cookbooks/${cookbook.id}/${relativeFile}`);
+      }
+    }
+
+    if (!cookbookDocsMention(cookbookReadme, cookbook.id)) {
+      findings.push(`cookbooks/README.md is missing cookbook entry for ${cookbook.id}`);
+    }
+
+    if (!cookbookDocsMention(docsCookbooks, cookbook.id)) {
+      findings.push(`docs/getting-started/cookbooks.md is missing cookbook entry for ${cookbook.id}`);
+    }
+  }
+
+  return findings;
+}
+
+function main() {
+  const findings = runCookbookChecks(process.cwd());
+  if (findings.length > 0) {
+    for (const finding of findings) {
+      console.error(`- ${finding}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('Cookbook checks passed.');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
+import { runCookbookChecks } from './check-cookbooks.mjs';
 
 const ROOT = process.cwd();
 const APPS_DIR = path.join(ROOT, 'apps_script_tools');
@@ -148,6 +149,8 @@ function isInternalNameCompliant(name) {
 
 const jsFiles = walk(APPS_DIR).filter(file => file.endsWith('.js'));
 const findings = [];
+
+findings.push(...runCookbookChecks(ROOT));
 
 for (const file of jsFiles) {
   const text = readText(file);


### PR DESCRIPTION
## Summary
- publish a structured cookbook catalog in repo docs
- add a manual smoke validation matrix for release-readiness
- add a cookbook structure verifier and wire it into lint

## What Changed
- expanded `cookbooks/README.md` into a published cookbook catalog with types, module coverage, property summaries, and entrypoints
- expanded `docs/getting-started/cookbooks.md` with setup tiers, README links, and a manual smoke validation matrix
- added cookbook release-readiness guidance to `docs/development/release.md`
- added `scripts/check-cookbooks.mjs` and `npm run check:cookbooks`
- wired cookbook structure verification into `npm run lint`

## Validation
- `npm run check:cookbooks`
- `npm run lint`
- `uv run mkdocs build --strict`
- `git diff --check`

Closes #308
Part of #295.
