### PR TITLE
feat(cookbooks): add SQL execution patterns cookbook

### DIFF
--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -98,6 +98,7 @@ The template README documents:
 | `messaging_hub` | Script-run | `AST.Messaging` | `MESSAGING_HUB_*` plus optional live webhook/mail settings | standard template-v2 entrypoints |
 | `rag_chat_starter` | Webapp | `AST.RAG`, `AST.Chat`, `AST.AI`, `AST.Cache` | `RAG_CHAT_*` plus provider/index/cache settings | standard template-v2 entrypoints + HtmlService webapp |
 | `storage_cache_warmer` | Focused script-run | `AST.Cache`, `AST.Storage` | `STORAGE_CACHE_URI`, optional `STORAGE_CACHE_NAMESPACE`, provider auth | `runStorageCacheWarmerSmoke` |
+| `sql_execution_patterns` | Script-run | `AST.Sql`, optional `AST.DataFrame` write path | `SQL_COOKBOOK_*` plus provider credentials when live execution is enabled | standard template-v2 entrypoints |
 | `storage_ops` | Script-run | `AST.Storage` | `STORAGE_OPS_*` plus provider auth/URIs | standard template-v2 entrypoints |
 | `telemetry_alerting` | Script-run | `AST.Telemetry`, `AST.TelemetryHelpers` | `TELEMETRY_COOKBOOK_*` | standard template-v2 entrypoints |
 

--- a/cookbooks/sql_execution_patterns/.clasp.json.example
+++ b/cookbooks/sql_execution_patterns/.clasp.json.example
@@ -1,0 +1,4 @@
+{
+  "scriptId": "<COOKBOOK_SCRIPT_ID>",
+  "rootDir": "src"
+}

--- a/cookbooks/sql_execution_patterns/.claspignore
+++ b/cookbooks/sql_execution_patterns/.claspignore
@@ -1,0 +1,3 @@
+# `rootDir` is `src`, so only local-only config files need explicit ignores.
+.clasp.json
+.clasprc.json

--- a/cookbooks/sql_execution_patterns/README.md
+++ b/cookbooks/sql_execution_patterns/README.md
@@ -1,0 +1,187 @@
+# SQL Execution Patterns
+
+This cookbook demonstrates focused `AST.Sql` usage with template-v2 entrypoints.
+
+Primary coverage:
+
+- `AST.Sql.providers()` and `AST.Sql.capabilities(...)`
+- `AST.Sql.run(...)`
+- `AST.Sql.prepare(...)`
+- `AST.Sql.executePrepared(...)`
+- `AST.Sql.status(...)`
+- `AST.DataFrame.toTable(...)` with an explicit opt-in write path
+
+It is intentionally split into:
+
+- deterministic smoke output that works without cloud access
+- live Databricks or BigQuery examples when you explicitly enable them
+
+## Folder contract
+
+```text
+cookbooks/sql_execution_patterns/
+  README.md
+  .clasp.json.example
+  .claspignore
+  src/
+    appsscript.json
+    00_Config.gs
+    10_EntryPoints.gs
+    20_Smoke.gs
+    30_Examples.gs
+    99_DevTools.gs
+```
+
+## Setup
+
+1. Copy `.clasp.json.example` to `.clasp.json`.
+2. Set your Apps Script `scriptId`.
+3. Replace `<PUBLISHED_AST_LIBRARY_VERSION>` in `src/appsscript.json`.
+4. Push with `clasp push`.
+5. Run `seedCookbookConfig()`.
+6. Run `runCookbookSmoke()`.
+7. Only after config is correct, enable live execution and run `runCookbookDemo()`.
+
+## Script properties
+
+| Key | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `SQL_COOKBOOK_APP_NAME` | Yes | `AST SQL Execution Patterns` | App label used in cookbook outputs |
+| `SQL_COOKBOOK_DEFAULT_PROVIDER` | Yes | `databricks` | Provider used by smoke/demo: `databricks` or `bigquery` |
+| `SQL_COOKBOOK_ENABLE_LIVE` | No | `false` | Enables real provider execution instead of returning plans only |
+| `SQL_COOKBOOK_ENABLE_TABLE_WRITE` | No | `false` | Enables the opt-in `DataFrame.toTable(...)` example |
+| `SQL_COOKBOOK_RUN_STATUS_CHECK` | No | `true` | Calls `AST.Sql.status(...)` after prepared execution when possible |
+| `SQL_COOKBOOK_QUERY_TIMEOUT_MS` | No | `30000` | SQL timeout budget in milliseconds |
+| `SQL_COOKBOOK_POLL_INTERVAL_MS` | No | `500` | Poll interval in milliseconds |
+| `SQL_COOKBOOK_TARGET_TABLE` | No | `''` | Required only when table writes are enabled |
+| `SQL_COOKBOOK_DATABRICKS_HOST` | No | `''` | Databricks host for live Databricks runs |
+| `SQL_COOKBOOK_DATABRICKS_SQL_WAREHOUSE_ID` | No | `''` | Databricks SQL warehouse id |
+| `SQL_COOKBOOK_DATABRICKS_SCHEMA` | No | `default` | Databricks schema used by live runs |
+| `SQL_COOKBOOK_DATABRICKS_TOKEN` | No | `''` | Databricks PAT |
+| `SQL_COOKBOOK_BIGQUERY_PROJECT_ID` | No | `''` | BigQuery project id for live BigQuery runs |
+
+Provider-specific live requirements:
+
+- Databricks live runs require:
+  - `SQL_COOKBOOK_DATABRICKS_HOST`
+  - `SQL_COOKBOOK_DATABRICKS_SQL_WAREHOUSE_ID`
+  - `SQL_COOKBOOK_DATABRICKS_TOKEN`
+- BigQuery live runs require:
+  - `SQL_COOKBOOK_BIGQUERY_PROJECT_ID`
+
+## Entrypoints
+
+- `seedCookbookConfig()`: seeds the cookbook properties.
+- `validateCookbookConfig()`: validates provider settings and live execution prerequisites.
+- `runCookbookSmoke()`: deterministic provider/capability/prepared-statement summary; optionally executes one direct live query.
+- `runCookbookDemo()`: direct query, prepared query, optional status check, and optional table-write example.
+- `runCookbookAll()`: runs smoke + demo in one payload.
+
+## What the cookbook does
+
+Smoke flow:
+
+1. lists supported SQL providers and their capabilities
+2. compiles a prepared statement template with a typed schema
+3. returns direct/prepared/status/cancel request previews
+4. optionally executes a single live direct query if `SQL_COOKBOOK_ENABLE_LIVE=true`
+
+Demo flow:
+
+1. executes a direct SQL query through `AST.Sql.run(...)`
+2. executes a typed prepared statement through `AST.Sql.executePrepared(...)`
+3. optionally checks execution status through `AST.Sql.status(...)`
+4. returns cancel request and table write plans
+5. optionally writes a sample `DataFrame` into a provider table when both:
+   - `SQL_COOKBOOK_ENABLE_LIVE=true`
+   - `SQL_COOKBOOK_ENABLE_TABLE_WRITE=true`
+
+## Expected output examples
+
+`runCookbookSmoke()` returns a shape like:
+
+```json
+{
+  "status": "ok",
+  "entrypoint": "runCookbookSmoke",
+  "provider": "databricks",
+  "providers": ["bigquery", "databricks"],
+  "liveEnabled": false,
+  "prepared": {
+    "provider": "databricks",
+    "templateParams": ["sample_id", "sample_label"]
+  }
+}
+```
+
+`runCookbookDemo()` returns a shape like:
+
+```json
+{
+  "status": "ok",
+  "entrypoint": "runCookbookDemo",
+  "provider": "databricks",
+  "directQuery": {
+    "executed": false,
+    "skipped": true
+  },
+  "preparedQuery": {
+    "executed": false,
+    "skipped": true
+  },
+  "tableWrite": {
+    "executed": false,
+    "skipped": true
+  }
+}
+```
+
+## OAuth scopes
+
+This cookbook currently requests:
+
+- `https://www.googleapis.com/auth/script.external_request`
+- `https://www.googleapis.com/auth/bigquery`
+
+Keep this least-privilege:
+
+- If you only use Databricks live execution, `script.external_request` is the important scope.
+- If you run BigQuery examples, keep the BigQuery scope and ensure the BigQuery advanced service/runtime access is enabled in your Apps Script project as required by your environment.
+
+## Safety notes
+
+- Live execution is off by default.
+- Table writes are off by default.
+- Tokens are redacted from cookbook summaries and request plans.
+- `AST.Sql.cancel(...)` is shown as a request plan only; the cookbook does not auto-cancel statements because that would be nondeterministic and potentially destructive.
+
+## Troubleshooting
+
+`Cookbook config is invalid`
+
+- Run `seedCookbookConfig()` again.
+- Check that `SQL_COOKBOOK_DEFAULT_PROVIDER` is `databricks` or `bigquery`.
+- If live is enabled, confirm the provider-specific credentials are present.
+
+`The smoke/demo returns plans only`
+
+- This is expected until `SQL_COOKBOOK_ENABLE_LIVE=true`.
+
+`BigQuery live runs fail`
+
+- Confirm `SQL_COOKBOOK_BIGQUERY_PROJECT_ID` is set.
+- Confirm the Apps Script project is authorized for BigQuery access.
+
+`Databricks live runs fail`
+
+- Confirm the host, warehouse id, and PAT are all set.
+- Confirm the warehouse is running and the configured schema is accessible.
+
+`The demo skips table writes`
+
+- This is expected unless `SQL_COOKBOOK_ENABLE_TABLE_WRITE=true` and `SQL_COOKBOOK_TARGET_TABLE` is configured.
+
+`You want to inspect or reset the contract`
+
+- Run `showCookbookContract()`.
+- Run `clearCookbookConfig()`.

--- a/cookbooks/sql_execution_patterns/src/00_Config.gs
+++ b/cookbooks/sql_execution_patterns/src/00_Config.gs
@@ -1,0 +1,405 @@
+function cookbookAst_() {
+  return ASTLib.AST || ASTLib;
+}
+
+function cookbookScriptProperties_() {
+  return PropertiesService.getScriptProperties();
+}
+
+function cookbookTemplateVersion_() {
+  return 'v2';
+}
+
+function cookbookName_() {
+  return 'sql_execution_patterns';
+}
+
+function cookbookConfigFields_() {
+  return [
+    {
+      key: 'SQL_COOKBOOK_APP_NAME',
+      required: true,
+      defaultValue: 'AST SQL Execution Patterns',
+      description: 'Human-readable app name included in cookbook output.'
+    },
+    {
+      key: 'SQL_COOKBOOK_DEFAULT_PROVIDER',
+      required: true,
+      defaultValue: 'databricks',
+      allowedValues: ['databricks', 'bigquery'],
+      description: 'Default SQL provider used by smoke and demo examples.'
+    },
+    {
+      key: 'SQL_COOKBOOK_ENABLE_LIVE',
+      required: false,
+      defaultValue: 'false',
+      type: 'boolean',
+      description: 'When true, live SQL execution examples run against the configured provider.'
+    },
+    {
+      key: 'SQL_COOKBOOK_ENABLE_TABLE_WRITE',
+      required: false,
+      defaultValue: 'false',
+      type: 'boolean',
+      description: 'When true, the demo may write sample rows into SQL tables using DataFrame.toTable().' 
+    },
+    {
+      key: 'SQL_COOKBOOK_RUN_STATUS_CHECK',
+      required: false,
+      defaultValue: 'true',
+      type: 'boolean',
+      description: 'When true, the demo calls AST.Sql.status() after prepared execution when execution metadata is available.'
+    },
+    {
+      key: 'SQL_COOKBOOK_QUERY_TIMEOUT_MS',
+      required: false,
+      defaultValue: '30000',
+      type: 'integer',
+      min: 1000,
+      description: 'Maximum SQL wait time in milliseconds for live calls.'
+    },
+    {
+      key: 'SQL_COOKBOOK_POLL_INTERVAL_MS',
+      required: false,
+      defaultValue: '500',
+      type: 'integer',
+      min: 100,
+      description: 'Polling interval in milliseconds for live SQL calls.'
+    },
+    {
+      key: 'SQL_COOKBOOK_TARGET_TABLE',
+      required: false,
+      defaultValue: '',
+      description: 'Optional destination table for the opt-in DataFrame.toTable() example.'
+    },
+    {
+      key: 'SQL_COOKBOOK_DATABRICKS_HOST',
+      required: false,
+      defaultValue: '',
+      description: 'Databricks workspace host, for example dbc-xxxx.cloud.databricks.com.'
+    },
+    {
+      key: 'SQL_COOKBOOK_DATABRICKS_SQL_WAREHOUSE_ID',
+      required: false,
+      defaultValue: '',
+      description: 'Databricks SQL warehouse id used for AST.Sql databricks runs.'
+    },
+    {
+      key: 'SQL_COOKBOOK_DATABRICKS_SCHEMA',
+      required: false,
+      defaultValue: 'default',
+      description: 'Optional Databricks schema for the demo queries.'
+    },
+    {
+      key: 'SQL_COOKBOOK_DATABRICKS_TOKEN',
+      required: false,
+      defaultValue: '',
+      description: 'Databricks PAT used for live SQL execution.'
+    },
+    {
+      key: 'SQL_COOKBOOK_BIGQUERY_PROJECT_ID',
+      required: false,
+      defaultValue: '',
+      description: 'BigQuery project id used for live SQL execution.'
+    }
+  ];
+}
+
+function cookbookConfigFieldMap_() {
+  const fields = cookbookConfigFields_();
+  const map = {};
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    map[fields[idx].key] = fields[idx];
+  }
+  return map;
+}
+
+function cookbookNormalizeBoolean_(value, fallback) {
+  if (value === true || value === false) {
+    return value;
+  }
+
+  if (value == null || value === '') {
+    return fallback;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (['true', '1', 'yes', 'y', 'on'].indexOf(normalized) !== -1) {
+    return true;
+  }
+  if (['false', '0', 'no', 'n', 'off'].indexOf(normalized) !== -1) {
+    return false;
+  }
+
+  return fallback;
+}
+
+function cookbookNormalizeInteger_(value, fallback) {
+  if (value == null || value === '') {
+    return fallback;
+  }
+
+  const numeric = typeof value === 'number' ? value : Number(String(value).trim());
+  if (!Number.isFinite(numeric) || !Number.isInteger(numeric)) {
+    return null;
+  }
+
+  return numeric;
+}
+
+function cookbookNormalizeConfigValue_(field, rawValue) {
+  if (field && field.type === 'boolean') {
+    return cookbookNormalizeBoolean_(rawValue, false);
+  }
+  if (field && field.type === 'integer') {
+    return cookbookNormalizeInteger_(rawValue, null);
+  }
+  return String(rawValue == null ? '' : rawValue).trim();
+}
+
+function cookbookValidateOverrideKeys_(overrides) {
+  if (overrides == null) {
+    return;
+  }
+
+  if (Object.prototype.toString.call(overrides) !== '[object Object]') {
+    throw new Error('seedCookbookConfig overrides must be a plain object when provided.');
+  }
+
+  const known = cookbookConfigFieldMap_();
+  const keys = Object.keys(overrides);
+  const unknown = [];
+  for (let idx = 0; idx < keys.length; idx += 1) {
+    if (!known[keys[idx]]) {
+      unknown.push(keys[idx]);
+    }
+  }
+
+  if (unknown.length > 0) {
+    throw new Error(`Unknown cookbook config overrides: ${unknown.join(', ')}`);
+  }
+}
+
+function cookbookValidationSummary_(result) {
+  return {
+    status: result.status,
+    templateVersion: result.templateVersion,
+    requiredKeys: result.requiredKeys,
+    optionalKeys: result.optionalKeys,
+    warnings: result.warnings,
+    errors: result.errors,
+    config: result.config
+  };
+}
+
+function cookbookLogResult_(label, payload) {
+  Logger.log(`${label}\n${JSON.stringify(payload, null, 2)}`);
+  return payload;
+}
+
+function seedCookbookConfig(overrides) {
+  cookbookValidateOverrideKeys_(overrides);
+
+  const props = cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+  const next = {};
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    const field = fields[idx];
+    const overrideValue = overrides && Object.prototype.hasOwnProperty.call(overrides, field.key)
+      ? overrides[field.key]
+      : field.defaultValue;
+    next[field.key] = String(overrideValue);
+  }
+
+  props.setProperties(next, false);
+
+  return cookbookLogResult_(
+    'seedCookbookConfig',
+    cookbookValidationSummary_(validateCookbookConfig({ scriptProperties: props }))
+  );
+}
+
+function validateCookbookConfig(options) {
+  const runtimeOptions = options || {};
+  const props = runtimeOptions.scriptProperties || cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+  const resolved = {};
+  const warnings = [];
+  const errors = [];
+  const requiredKeys = [];
+  const optionalKeys = [];
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    const field = fields[idx];
+    const storedValue = props.getProperty(field.key);
+    const hasStoredValue = storedValue != null && storedValue !== '';
+    const rawValue = hasStoredValue ? storedValue : field.defaultValue;
+    const normalizedValue = cookbookNormalizeConfigValue_(field, rawValue);
+
+    resolved[field.key] = normalizedValue;
+
+    if (field.required) {
+      requiredKeys.push(field.key);
+    } else {
+      optionalKeys.push(field.key);
+    }
+
+    if (!hasStoredValue) {
+      warnings.push(`Using cookbook default for ${field.key}.`);
+    }
+
+    if (field.required && (normalizedValue === '' || normalizedValue == null)) {
+      errors.push(`Missing required cookbook config key ${field.key}.`);
+    }
+
+    if (field.allowedValues && field.allowedValues.indexOf(normalizedValue) === -1) {
+      errors.push(
+        `${field.key} must be one of: ${field.allowedValues.join(', ')}. Received: ${normalizedValue}`
+      );
+    }
+
+    if (field.type === 'integer') {
+      if (normalizedValue == null) {
+        errors.push(`${field.key} must be an integer value.`);
+      } else if (typeof field.min === 'number' && normalizedValue < field.min) {
+        errors.push(`${field.key} must be >= ${field.min}. Received: ${normalizedValue}`);
+      }
+    }
+  }
+
+  if (resolved.SQL_COOKBOOK_POLL_INTERVAL_MS > resolved.SQL_COOKBOOK_QUERY_TIMEOUT_MS) {
+    errors.push('SQL_COOKBOOK_POLL_INTERVAL_MS cannot be greater than SQL_COOKBOOK_QUERY_TIMEOUT_MS.');
+  }
+
+  if (resolved.SQL_COOKBOOK_ENABLE_TABLE_WRITE && !resolved.SQL_COOKBOOK_ENABLE_LIVE) {
+    errors.push('SQL_COOKBOOK_ENABLE_TABLE_WRITE requires SQL_COOKBOOK_ENABLE_LIVE=true.');
+  }
+
+  if (resolved.SQL_COOKBOOK_ENABLE_TABLE_WRITE && !resolved.SQL_COOKBOOK_TARGET_TABLE) {
+    errors.push('SQL_COOKBOOK_TARGET_TABLE is required when SQL_COOKBOOK_ENABLE_TABLE_WRITE=true.');
+  }
+
+  if (resolved.SQL_COOKBOOK_ENABLE_LIVE) {
+    if (resolved.SQL_COOKBOOK_DEFAULT_PROVIDER === 'databricks') {
+      if (!resolved.SQL_COOKBOOK_DATABRICKS_HOST) {
+        errors.push('SQL_COOKBOOK_DATABRICKS_HOST is required for live Databricks execution.');
+      }
+      if (!resolved.SQL_COOKBOOK_DATABRICKS_SQL_WAREHOUSE_ID) {
+        errors.push('SQL_COOKBOOK_DATABRICKS_SQL_WAREHOUSE_ID is required for live Databricks execution.');
+      }
+      if (!resolved.SQL_COOKBOOK_DATABRICKS_TOKEN) {
+        errors.push('SQL_COOKBOOK_DATABRICKS_TOKEN is required for live Databricks execution.');
+      }
+    }
+
+    if (resolved.SQL_COOKBOOK_DEFAULT_PROVIDER === 'bigquery' && !resolved.SQL_COOKBOOK_BIGQUERY_PROJECT_ID) {
+      errors.push('SQL_COOKBOOK_BIGQUERY_PROJECT_ID is required for live BigQuery execution.');
+    }
+  }
+
+  return {
+    status: errors.length > 0 ? 'error' : 'ok',
+    templateVersion: cookbookTemplateVersion_(),
+    requiredKeys,
+    optionalKeys,
+    warnings,
+    errors,
+    config: resolved
+  };
+}
+
+function cookbookRequireValidConfig_() {
+  const validation = validateCookbookConfig();
+  if (validation.status !== 'ok') {
+    throw new Error(`Cookbook config is invalid: ${validation.errors.join(' | ')}`);
+  }
+  return validation;
+}
+
+function cookbookRedactSecrets_(value) {
+  if (value == null || value === '') {
+    return '';
+  }
+  return '***redacted***';
+}
+
+function cookbookBuildSqlParameters_(config, provider) {
+  if (provider === 'databricks') {
+    return {
+      host: config.SQL_COOKBOOK_DATABRICKS_HOST,
+      sqlWarehouseId: config.SQL_COOKBOOK_DATABRICKS_SQL_WAREHOUSE_ID,
+      schema: config.SQL_COOKBOOK_DATABRICKS_SCHEMA,
+      token: config.SQL_COOKBOOK_DATABRICKS_TOKEN
+    };
+  }
+
+  return {
+    projectId: config.SQL_COOKBOOK_BIGQUERY_PROJECT_ID
+  };
+}
+
+function cookbookBuildSqlOptions_(config) {
+  return {
+    maxWaitMs: config.SQL_COOKBOOK_QUERY_TIMEOUT_MS,
+    pollIntervalMs: config.SQL_COOKBOOK_POLL_INTERVAL_MS
+  };
+}
+
+function cookbookBuildSafeParameterPreview_(config, provider) {
+  const parameters = cookbookBuildSqlParameters_(config, provider);
+  if (provider === 'databricks') {
+    return {
+      host: parameters.host,
+      sqlWarehouseId: parameters.sqlWarehouseId,
+      schema: parameters.schema,
+      token: cookbookRedactSecrets_(parameters.token)
+    };
+  }
+  return parameters;
+}
+
+function cookbookExecutionId_(execution) {
+  if (!execution || typeof execution !== 'object') {
+    return '';
+  }
+  return String(execution.executionId || execution.statementId || execution.jobId || '').trim();
+}
+
+function cookbookSummarizeDataFrame_(frame) {
+  if (!frame || typeof frame.toRecords !== 'function' || !Array.isArray(frame.columns)) {
+    return null;
+  }
+
+  const previewRows = frame.head ? frame.head(3).toRecords() : frame.toRecords().slice(0, 3);
+  return {
+    rowCount: typeof frame.len === 'function' ? frame.len() : previewRows.length,
+    columns: frame.columns.slice(),
+    preview: previewRows,
+    markdownPreview: typeof frame.toMarkdown === 'function' ? frame.head(3).toMarkdown() : null
+  };
+}
+
+function cookbookDirectQuerySql_(provider) {
+  const label = provider === 'databricks' ? 'databricks_direct' : 'bigquery_direct';
+  return `select 1 as sample_id, '${label}' as sample_label, current_timestamp() as observed_at`;
+}
+
+function cookbookPreparedQueryTemplate_() {
+  return 'select {{sample_id}} as sample_id, {{sample_label}} as sample_label, current_timestamp() as observed_at';
+}
+
+function cookbookPreparedParamsSchema_() {
+  return {
+    sample_id: 'integer',
+    sample_label: 'string'
+  };
+}
+
+function cookbookWriteFrame_() {
+  const ASTX = cookbookAst_();
+  return ASTX.DataFrame.fromRecords([
+    { sample_id: 1, sample_label: 'alpha', observed_at: '2026-01-01T00:00:00Z' },
+    { sample_id: 2, sample_label: 'beta', observed_at: '2026-01-01T00:05:00Z' }
+  ]);
+}

--- a/cookbooks/sql_execution_patterns/src/00_Config.gs
+++ b/cookbooks/sql_execution_patterns/src/00_Config.gs
@@ -188,7 +188,7 @@ function cookbookValidationSummary_(result) {
     optionalKeys: result.optionalKeys,
     warnings: result.warnings,
     errors: result.errors,
-    config: result.config
+    config: cookbookPublicConfig_(result.config)
   };
 }
 
@@ -322,6 +322,23 @@ function cookbookRedactSecrets_(value) {
     return '';
   }
   return '***redacted***';
+}
+
+function cookbookPublicConfig_(config) {
+  const resolved = config && typeof config === 'object' ? config : {};
+  const publicConfig = {};
+  const keys = Object.keys(resolved);
+
+  for (let idx = 0; idx < keys.length; idx += 1) {
+    const key = keys[idx];
+    publicConfig[key] = resolved[key];
+  }
+
+  if (Object.prototype.hasOwnProperty.call(publicConfig, 'SQL_COOKBOOK_DATABRICKS_TOKEN')) {
+    publicConfig.SQL_COOKBOOK_DATABRICKS_TOKEN = cookbookRedactSecrets_(publicConfig.SQL_COOKBOOK_DATABRICKS_TOKEN);
+  }
+
+  return publicConfig;
 }
 
 function cookbookBuildSqlParameters_(config, provider) {

--- a/cookbooks/sql_execution_patterns/src/10_EntryPoints.gs
+++ b/cookbooks/sql_execution_patterns/src/10_EntryPoints.gs
@@ -1,0 +1,23 @@
+function runCookbookSmoke() {
+  const validation = cookbookRequireValidConfig_();
+  return cookbookLogResult_('runCookbookSmoke', runCookbookSmokeInternal_(validation.config));
+}
+
+function runCookbookDemo() {
+  const validation = cookbookRequireValidConfig_();
+  return cookbookLogResult_('runCookbookDemo', runCookbookDemoInternal_(validation.config));
+}
+
+function runCookbookAll() {
+  const validation = cookbookRequireValidConfig_();
+  const output = {
+    status: 'ok',
+    templateVersion: cookbookTemplateVersion_(),
+    cookbook: cookbookName_(),
+    config: validation.config,
+    smoke: runCookbookSmokeInternal_(validation.config),
+    demo: runCookbookDemoInternal_(validation.config),
+    completedAt: new Date().toISOString()
+  };
+  return cookbookLogResult_('runCookbookAll', output);
+}

--- a/cookbooks/sql_execution_patterns/src/10_EntryPoints.gs
+++ b/cookbooks/sql_execution_patterns/src/10_EntryPoints.gs
@@ -14,7 +14,7 @@ function runCookbookAll() {
     status: 'ok',
     templateVersion: cookbookTemplateVersion_(),
     cookbook: cookbookName_(),
-    config: validation.config,
+    config: cookbookPublicConfig_(validation.config),
     smoke: runCookbookSmokeInternal_(validation.config),
     demo: runCookbookDemoInternal_(validation.config),
     completedAt: new Date().toISOString()

--- a/cookbooks/sql_execution_patterns/src/20_Smoke.gs
+++ b/cookbooks/sql_execution_patterns/src/20_Smoke.gs
@@ -1,0 +1,90 @@
+function runCookbookSmokeInternal_(config) {
+  const ASTX = cookbookAst_();
+  const provider = config.SQL_COOKBOOK_DEFAULT_PROVIDER;
+  const capabilities = {};
+  const providers = ASTX.Sql.providers();
+
+  for (let idx = 0; idx < providers.length; idx += 1) {
+    capabilities[providers[idx]] = ASTX.Sql.capabilities(providers[idx]);
+  }
+
+  const prepared = ASTX.Sql.prepare({
+    provider,
+    sql: cookbookPreparedQueryTemplate_(),
+    paramsSchema: cookbookPreparedParamsSchema_(),
+    parameters: cookbookBuildSqlParameters_(config, provider),
+    options: cookbookBuildSqlOptions_(config)
+  });
+
+  const smoke = {
+    status: 'ok',
+    entrypoint: 'runCookbookSmoke',
+    cookbook: cookbookName_(),
+    templateVersion: cookbookTemplateVersion_(),
+    appName: config.SQL_COOKBOOK_APP_NAME,
+    astVersion: ASTX.VERSION,
+    provider,
+    providers,
+    capabilities,
+    liveEnabled: config.SQL_COOKBOOK_ENABLE_LIVE,
+    prepared: {
+      provider: prepared.provider,
+      templateParams: prepared.templateParams,
+      paramTypes: Object.keys(prepared.paramSchema).reduce((acc, key) => {
+        const field = prepared.paramSchema[key];
+        acc[key] = field && field.type ? field.type : field;
+        return acc;
+      }, {})
+    },
+    requestPreview: {
+      directRun: {
+        provider,
+        sql: cookbookDirectQuerySql_(provider),
+        parameters: cookbookBuildSafeParameterPreview_(config, provider),
+        options: cookbookBuildSqlOptions_(config)
+      },
+      preparedExecution: {
+        statementId: '<statement-id from prepare()>',
+        params: {
+          sample_id: 7,
+          sample_label: `${provider}_prepared`
+        }
+      },
+      statusCheck: {
+        provider,
+        executionId: '<execution-id>',
+        parameters: cookbookBuildSafeParameterPreview_(config, provider)
+      },
+      cancelRequest: {
+        provider,
+        executionId: '<execution-id>',
+        parameters: cookbookBuildSafeParameterPreview_(config, provider)
+      }
+    },
+    live: {
+      executed: false,
+      skipped: !config.SQL_COOKBOOK_ENABLE_LIVE,
+      reason: config.SQL_COOKBOOK_ENABLE_LIVE ? '' : 'Set SQL_COOKBOOK_ENABLE_LIVE=true to run provider-backed SQL examples.'
+    },
+    generatedAt: new Date().toISOString()
+  };
+
+  if (!config.SQL_COOKBOOK_ENABLE_LIVE) {
+    return smoke;
+  }
+
+  const directResult = ASTX.Sql.run({
+    provider,
+    sql: cookbookDirectQuerySql_(provider),
+    parameters: cookbookBuildSqlParameters_(config, provider),
+    options: cookbookBuildSqlOptions_(config)
+  });
+
+  smoke.live = {
+    executed: true,
+    provider,
+    directResult: cookbookSummarizeDataFrame_(directResult)
+  };
+
+  return smoke;
+}

--- a/cookbooks/sql_execution_patterns/src/30_Examples.gs
+++ b/cookbooks/sql_execution_patterns/src/30_Examples.gs
@@ -1,0 +1,204 @@
+function runCookbookDemoInternal_(config) {
+  const ASTX = cookbookAst_();
+  const provider = config.SQL_COOKBOOK_DEFAULT_PROVIDER;
+  const parameters = cookbookBuildSqlParameters_(config, provider);
+  const options = cookbookBuildSqlOptions_(config);
+  const prepared = ASTX.Sql.prepare({
+    provider,
+    sql: cookbookPreparedQueryTemplate_(),
+    paramsSchema: cookbookPreparedParamsSchema_(),
+    parameters,
+    options
+  });
+
+  const demo = {
+    status: 'ok',
+    entrypoint: 'runCookbookDemo',
+    cookbook: cookbookName_(),
+    appName: config.SQL_COOKBOOK_APP_NAME,
+    provider,
+    liveEnabled: config.SQL_COOKBOOK_ENABLE_LIVE,
+    requestPlans: {
+      directRun: {
+        provider,
+        sql: cookbookDirectQuerySql_(provider),
+        parameters: cookbookBuildSafeParameterPreview_(config, provider),
+        options
+      },
+      preparedExecution: {
+        statementId: '<statement-id from prepare()>',
+        params: {
+          sample_id: 42,
+          sample_label: `${provider}_prepared_demo`
+        },
+        parameters: cookbookBuildSafeParameterPreview_(config, provider),
+        options
+      },
+      cancelRequest: {
+        provider,
+        executionId: '<execution-id>',
+        parameters: cookbookBuildSafeParameterPreview_(config, provider)
+      },
+      tableWrite: {
+        enabled: config.SQL_COOKBOOK_ENABLE_TABLE_WRITE,
+        targetTable: config.SQL_COOKBOOK_TARGET_TABLE,
+        provider,
+        framePreview: cookbookWriteFrame_().toRecords(),
+        config: cookbookBuildTableWritePlan_(config, provider)
+      }
+    },
+    directQuery: {
+      executed: false,
+      skipped: !config.SQL_COOKBOOK_ENABLE_LIVE,
+      result: null
+    },
+    preparedQuery: {
+      executed: false,
+      skipped: !config.SQL_COOKBOOK_ENABLE_LIVE,
+      result: null,
+      execution: null,
+      status: null
+    },
+    tableWrite: {
+      executed: false,
+      skipped: !config.SQL_COOKBOOK_ENABLE_TABLE_WRITE,
+      targetTable: config.SQL_COOKBOOK_TARGET_TABLE || ''
+    },
+    generatedAt: new Date().toISOString()
+  };
+
+  if (!config.SQL_COOKBOOK_ENABLE_LIVE) {
+    demo.directQuery.reason = 'Set SQL_COOKBOOK_ENABLE_LIVE=true to execute live provider queries.';
+    demo.preparedQuery.reason = 'Set SQL_COOKBOOK_ENABLE_LIVE=true to execute prepared statements.';
+    return demo;
+  }
+
+  const directResult = ASTX.Sql.run({
+    provider,
+    sql: cookbookDirectQuerySql_(provider),
+    parameters,
+    options
+  });
+  demo.directQuery = {
+    executed: true,
+    skipped: false,
+    result: cookbookSummarizeDataFrame_(directResult)
+  };
+
+  const preparedResult = ASTX.Sql.executePrepared({
+    statementId: prepared.statementId,
+    params: {
+      sample_id: 42,
+      sample_label: `${provider}_prepared_demo`
+    }
+  });
+  demo.preparedQuery = {
+    executed: true,
+    skipped: false,
+    sql: preparedResult.sql,
+    result: cookbookSummarizeDataFrame_(preparedResult.dataFrame),
+    execution: preparedResult.execution || null,
+    status: null
+  };
+
+  const executionId = cookbookExecutionId_(preparedResult.execution);
+  if (config.SQL_COOKBOOK_RUN_STATUS_CHECK && executionId) {
+    demo.preparedQuery.status = ASTX.Sql.status({
+      provider,
+      executionId,
+      parameters
+    });
+  }
+
+  if (config.SQL_COOKBOOK_ENABLE_TABLE_WRITE) {
+    const frame = cookbookWriteFrame_();
+    frame.toTable({
+      provider,
+      config: cookbookBuildTableWriteConfig_(config, provider),
+      headerOrder: ['sample_id', 'sample_label', 'observed_at']
+    });
+
+    demo.tableWrite = {
+      executed: true,
+      skipped: false,
+      targetTable: config.SQL_COOKBOOK_TARGET_TABLE,
+      rowsWritten: frame.len(),
+      columns: frame.columns.slice()
+    };
+  }
+
+  return demo;
+}
+
+function cookbookBuildTableWritePlan_(config, provider) {
+  if (!config.SQL_COOKBOOK_TARGET_TABLE) {
+    return {
+      targetTable: '',
+      schema: cookbookBuildTableSchema_(provider),
+      mode: 'insert',
+      providerConfig: cookbookBuildSafeTableParameters_(config, provider)
+    };
+  }
+
+  return {
+    targetTable: config.SQL_COOKBOOK_TARGET_TABLE,
+    schema: cookbookBuildTableSchema_(provider),
+    mode: 'insert',
+    providerConfig: cookbookBuildSafeTableParameters_(config, provider)
+  };
+}
+
+function cookbookBuildTableWriteConfig_(config, provider) {
+  const base = {
+    tableName: config.SQL_COOKBOOK_TARGET_TABLE,
+    tableSchema: cookbookBuildTableSchema_(provider),
+    mode: 'insert',
+    options: cookbookBuildSqlOptions_(config)
+  };
+
+  if (provider === 'databricks') {
+    base.databricks_parameters = {
+      host: config.SQL_COOKBOOK_DATABRICKS_HOST,
+      sqlWarehouseId: config.SQL_COOKBOOK_DATABRICKS_SQL_WAREHOUSE_ID,
+      schema: config.SQL_COOKBOOK_DATABRICKS_SCHEMA,
+      token: config.SQL_COOKBOOK_DATABRICKS_TOKEN
+    };
+    return base;
+  }
+
+  base.bigquery_parameters = {
+    projectId: config.SQL_COOKBOOK_BIGQUERY_PROJECT_ID
+  };
+  return base;
+}
+
+function cookbookBuildSafeTableParameters_(config, provider) {
+  if (provider === 'databricks') {
+    return {
+      host: config.SQL_COOKBOOK_DATABRICKS_HOST,
+      sqlWarehouseId: config.SQL_COOKBOOK_DATABRICKS_SQL_WAREHOUSE_ID,
+      schema: config.SQL_COOKBOOK_DATABRICKS_SCHEMA,
+      token: cookbookRedactSecrets_(config.SQL_COOKBOOK_DATABRICKS_TOKEN)
+    };
+  }
+
+  return {
+    projectId: config.SQL_COOKBOOK_BIGQUERY_PROJECT_ID
+  };
+}
+
+function cookbookBuildTableSchema_(provider) {
+  if (provider === 'databricks') {
+    return {
+      sample_id: 'INT',
+      sample_label: 'STRING',
+      observed_at: 'STRING'
+    };
+  }
+
+  return {
+    sample_id: 'INT64',
+    sample_label: 'STRING',
+    observed_at: 'STRING'
+  };
+}

--- a/cookbooks/sql_execution_patterns/src/99_DevTools.gs
+++ b/cookbooks/sql_execution_patterns/src/99_DevTools.gs
@@ -1,0 +1,35 @@
+function clearCookbookConfig() {
+  const props = cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    props.deleteProperty(fields[idx].key);
+  }
+
+  return cookbookLogResult_('clearCookbookConfig', {
+    status: 'ok',
+    clearedKeys: fields.map(field => field.key),
+    templateVersion: cookbookTemplateVersion_(),
+    cookbook: cookbookName_()
+  });
+}
+
+function showCookbookContract() {
+  return cookbookLogResult_('showCookbookContract', {
+    templateVersion: cookbookTemplateVersion_(),
+    cookbook: cookbookName_(),
+    requiredEntrypoints: [
+      'seedCookbookConfig',
+      'validateCookbookConfig',
+      'runCookbookSmoke',
+      'runCookbookDemo',
+      'runCookbookAll'
+    ],
+    scriptProperties: cookbookConfigFields_().map(field => ({
+      key: field.key,
+      required: field.required,
+      defaultValue: field.defaultValue,
+      description: field.description
+    }))
+  });
+}

--- a/cookbooks/sql_execution_patterns/src/appsscript.json
+++ b/cookbooks/sql_execution_patterns/src/appsscript.json
@@ -1,0 +1,18 @@
+{
+  "timeZone": "Etc/UTC",
+  "dependencies": {
+    "libraries": [
+      {
+        "userSymbol": "ASTLib",
+        "libraryId": "1gZ_6DiLeDhh-a4qcezluTFDshw4OEhTXbeD3wthl_UdHEAFkXf6i6Ho_",
+        "version": "<PUBLISHED_AST_LIBRARY_VERSION>"
+      }
+    ]
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/bigquery"
+  ]
+}

--- a/docs/getting-started/cookbooks.md
+++ b/docs/getting-started/cookbooks.md
@@ -36,7 +36,7 @@ Use these tiers to decide how much setup is required before you run a cookbook.
 | --- | --- | --- |
 | `Tier 0` | Local/editor-only validation; no external credentials required beyond the AST library binding | `_template`, `data_workflows_starter` |
 | `Tier 1` | Script Properties required; may use Drive, cache, or durable state but defaults stay local/dry-run | `config_cache_patterns`, `jobs_triggers_orchestration`, `messaging_hub`, `storage_cache_warmer`, `storage_ops`, `telemetry_alerting` |
-| `Tier 2` | External API/provider credentials required for realistic runs | `ai_playground`, `dbt_manifest_summary`, `github_issue_digest`, `http_ingestion_pipeline` |
+| `Tier 2` | External API/provider credentials required for realistic runs | `ai_playground`, `dbt_manifest_summary`, `github_issue_digest`, `http_ingestion_pipeline`, `sql_execution_patterns` |
 | `Tier 3` | Deployable webapp or richer app shell with UI/session/index configuration | `rag_chat_starter` |
 
 ## Published cookbook index
@@ -53,6 +53,7 @@ Use these tiers to decide how much setup is required before you run a cookbook.
 | `jobs_triggers_orchestration` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/jobs_triggers_orchestration/README.md) | `AST.Jobs`, `AST.Triggers` | `runCookbookSmoke()` | `runCookbookDemo()` |
 | `messaging_hub` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/messaging_hub/README.md) | `AST.Messaging` | `runCookbookSmoke()` | `runCookbookDemo()` |
 | `rag_chat_starter` | Webapp | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/rag_chat_starter/README.md) | `AST.RAG`, `AST.Chat`, `AST.AI`, `AST.Cache` | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `sql_execution_patterns` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/sql_execution_patterns/README.md) | `AST.Sql`, optional `AST.DataFrame` write path | `runCookbookSmoke()` | `runCookbookDemo()` |
 | `storage_cache_warmer` | Focused script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/storage_cache_warmer/README.md) | `AST.Cache`, `AST.Storage` | `runStorageCacheWarmerSmoke()` | n/a |
 | `storage_ops` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/storage_ops/README.md) | `AST.Storage` | `runCookbookSmoke()` | `runCookbookDemo()` |
 | `telemetry_alerting` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/telemetry_alerting/README.md) | `AST.Telemetry`, `AST.TelemetryHelpers` | `runCookbookSmoke()` | `runCookbookDemo()` |
@@ -73,6 +74,7 @@ Use this matrix for cookbook release-readiness checks.
 | `jobs_triggers_orchestration` | seed `JOBS_TRIGGERS_*` | `runCookbookAll()` then `cleanupCookbookArtifacts()` | job, trigger, and DLQ flows succeed; cleanup removes cookbook-owned state |
 | `messaging_hub` | seed `MESSAGING_HUB_*` (defaults are safe) | `runCookbookAll()` | dry-run email/chat plans, template render, tracking logs, and inbound fixture routing succeed |
 | `rag_chat_starter` | configure index, provider, cache, and branding settings | `runCookbookSmoke()` + deploy webapp if needed | smoke confirms index/chat setup; webapp loads and grounded responses cite sources |
+| `sql_execution_patterns` | seed `SQL_COOKBOOK_*`; provide Databricks or BigQuery config only when live execution is enabled | `runCookbookAll()` | smoke returns provider/prepared summaries; demo returns direct/prepared/status/write plans or live execution summaries |
 | `storage_cache_warmer` | set `STORAGE_CACHE_URI` and provider auth | `runStorageCacheWarmerSmoke()` | cache object warms successfully and persisted backend responds |
 | `storage_ops` | seed `STORAGE_OPS_*` and provider auth | `runCookbookAll()` | CRUD/list/walk/sync summaries match the configured provider |
 | `telemetry_alerting` | seed `TELEMETRY_COOKBOOK_*`; keep sink `logger` for easiest run | `runCookbookAll()` | grouped metrics, redaction preview, alert evaluation, and dry-run notifications succeed |

--- a/scripts/check-cookbooks.mjs
+++ b/scripts/check-cookbooks.mjs
@@ -13,6 +13,7 @@ const COOKBOOKS = Object.freeze([
   { id: 'jobs_triggers_orchestration', structure: 'template_v2' },
   { id: 'messaging_hub', structure: 'template_v2' },
   { id: 'rag_chat_starter', structure: 'template_v2' },
+  { id: 'sql_execution_patterns', structure: 'template_v2' },
   { id: 'storage_cache_warmer', structure: 'focused_single_file' },
   { id: 'storage_ops', structure: 'template_v2' },
   { id: 'telemetry_alerting', structure: 'template_v2' }


### PR DESCRIPTION
## Summary
- add a dedicated `cookbooks/sql_execution_patterns` cookbook on the template-v2 contract
- cover `AST.Sql` provider discovery, direct runs, prepared statements, status checks, and opt-in `DataFrame.toTable(...)` writes
- publish the cookbook in the catalog/docs and register it in `scripts/check-cookbooks.mjs`

## Why
The cookbook epic `#295` closed out the broad module coverage program, but it still explicitly called out `AST.Sql` as a remaining cookbook gap. The generic `data_workflows_starter` touches SQL, but it does not give users a focused SQL-only setup and execution reference.

This PR fixes that by adding a cookbook that is safe by default:
- deterministic smoke output without live cloud credentials
- explicit opt-in live execution for Databricks or BigQuery
- explicit opt-in table writes
- redacted parameter previews in summaries/logs

## What changed
### New cookbook
- `cookbooks/sql_execution_patterns/README.md`
- `cookbooks/sql_execution_patterns/.clasp.json.example`
- `cookbooks/sql_execution_patterns/.claspignore`
- `cookbooks/sql_execution_patterns/src/appsscript.json`
- `cookbooks/sql_execution_patterns/src/00_Config.gs`
- `cookbooks/sql_execution_patterns/src/10_EntryPoints.gs`
- `cookbooks/sql_execution_patterns/src/20_Smoke.gs`
- `cookbooks/sql_execution_patterns/src/30_Examples.gs`
- `cookbooks/sql_execution_patterns/src/99_DevTools.gs`

### Catalog/docs updates
- `cookbooks/README.md`
- `docs/getting-started/cookbooks.md`
- `scripts/check-cookbooks.mjs`

## Cookbook behavior
### Smoke
- lists SQL providers/capabilities
- compiles a typed prepared statement
- returns direct/prepared/status/cancel request previews
- optionally executes one live direct query when `SQL_COOKBOOK_ENABLE_LIVE=true`

### Demo
- executes a direct SQL query with `AST.Sql.run(...)`
- executes a prepared statement with `AST.Sql.executePrepared(...)`
- optionally checks execution status with `AST.Sql.status(...)`
- returns cancel and table-write plans by default
- optionally writes sample rows with `DataFrame.toTable(...)` only when both:
  - `SQL_COOKBOOK_ENABLE_LIVE=true`
  - `SQL_COOKBOOK_ENABLE_TABLE_WRITE=true`

## Validation
- `npm run check:cookbooks`
- `npm run lint`
- `uv run mkdocs build --strict`
- `git diff --check`
