### PR TITLE
feat(cookbooks): add advanced dataframe and series cookbook

### DIFF
--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -90,6 +90,7 @@ The template README documents:
 | `_template` | Template v2 scaffold | `AST.DataFrame`, `AST.Cache` sample usage only | `COOKBOOK_*` | `seedCookbookConfig`, `validateCookbookConfig`, `runCookbookSmoke`, `runCookbookDemo`, `runCookbookAll` |
 | `ai_playground` | Script-run | `AST.AI` | `AI_PLAYGROUND_*` plus provider auth as needed | standard template-v2 entrypoints |
 | `config_cache_patterns` | Script-run | `AST.Config`, `AST.Runtime`, `AST.Secrets`, `AST.Cache` | `CONFIG_CACHE_*` plus backend-specific cache secrets/URIs | standard template-v2 entrypoints |
+| `dataframe_series_advanced` | Script-run | `AST.DataFrame`, `AST.Series` advanced transforms only | `DF_ADV_*` | standard template-v2 entrypoints |
 | `data_workflows_starter` | Script-run | `AST.Series`, `AST.DataFrame`, `AST.GroupBy`, `AST.Drive`, `AST.Sheets`, `AST.Sql`, `AST.Utils` | `DATA_WORKFLOWS_*` plus optional Drive/Sheets/SQL config | standard template-v2 entrypoints |
 | `dbt_manifest_summary` | Script-run | `AST.DBT` | `DBT_*` / cookbook DBT source and cache properties | standard template-v2 entrypoints |
 | `github_issue_digest` | Script-run | `AST.GitHub` | `GITHUB_*` / cookbook GitHub defaults and token | standard template-v2 entrypoints |

--- a/cookbooks/dataframe_series_advanced/.clasp.json.example
+++ b/cookbooks/dataframe_series_advanced/.clasp.json.example
@@ -1,0 +1,4 @@
+{
+  "scriptId": "<COOKBOOK_SCRIPT_ID>",
+  "rootDir": "src"
+}

--- a/cookbooks/dataframe_series_advanced/.claspignore
+++ b/cookbooks/dataframe_series_advanced/.claspignore
@@ -1,0 +1,3 @@
+# `rootDir` is `src`, so only local-only config files need explicit ignores.
+.clasp.json
+.clasprc.json

--- a/cookbooks/dataframe_series_advanced/README.md
+++ b/cookbooks/dataframe_series_advanced/README.md
@@ -1,0 +1,128 @@
+# DataFrame Series Advanced
+
+This cookbook demonstrates advanced in-memory tabular patterns using public `AST` APIs only.
+
+Primary coverage:
+
+- `AST.DataFrame.selectExprDsl(...)`
+- `AST.DataFrame.window(...).assign(...)`
+- `AST.DataFrame.melt(...)`
+- `AST.DataFrame.pivotTable(...)`
+- `AST.DataFrame.stack(...)` / `unstack(...)`
+- `AST.DataFrame.resample(...)`
+- `AST.DataFrame.describe(...)`
+- `AST.DataFrame.nlargest(...)`
+- `Series.rank(...)`, `clip(...)`, `rolling(...)`, `pctChange(...)`, `diff(...)`, `expanding(...)`, `ewm(...)`, `toFrame(...)`
+
+It is designed as a deterministic, no-credentials cookbook for users who already know the basics and want richer tabular transformations.
+
+## Folder contract
+
+```text
+cookbooks/dataframe_series_advanced/
+  README.md
+  .clasp.json.example
+  .claspignore
+  src/
+    appsscript.json
+    00_Config.gs
+    10_EntryPoints.gs
+    20_Smoke.gs
+    30_Examples.gs
+    99_DevTools.gs
+```
+
+## Setup
+
+1. Copy `.clasp.json.example` to `.clasp.json`.
+2. Set your Apps Script `scriptId`.
+3. Replace `<PUBLISHED_AST_LIBRARY_VERSION>` in `src/appsscript.json`.
+4. Push with `clasp push`.
+5. Run `seedCookbookConfig()`.
+6. Run `runCookbookAll()`.
+
+## Script properties
+
+| Key | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `DF_ADV_APP_NAME` | Yes | `AST DataFrame Series Advanced` | App label used in cookbook outputs |
+| `DF_ADV_SAMPLE_RANDOM_STATE` | No | `42` | Deterministic seed for `sample()` |
+| `DF_ADV_RESAMPLE_RULE` | No | `1d` | Demo resample rule: `1h` or `1d` |
+| `DF_ADV_VERBOSE` | No | `false` | Adds extra preview metadata to smoke output |
+
+## Entrypoints
+
+- `seedCookbookConfig()`: writes defaults into Script Properties.
+- `validateCookbookConfig()`: validates deterministic cookbook config.
+- `runCookbookSmoke()`: lightweight advanced preview focused on expression DSL and Series analytics.
+- `runCookbookDemo()`: full advanced transformation flow with windowing, reshape, resample, and statistics.
+- `runCookbookAll()`: runs smoke + demo together.
+
+## What the cookbook does
+
+Smoke flow:
+
+1. builds a transactional `DataFrame`
+2. fills sparse numeric values and replaces status labels
+3. derives columns with `selectExprDsl(...)`
+4. runs deterministic `sample(...)`
+5. computes `Series.rank`, `rolling`, `pctChange`, and `clip`
+
+Demo flow:
+
+1. computes partitioned window columns with `window(...).assign(...)`
+2. reshapes wide monthly KPI data via `melt(...)`
+3. aggregates transactional data with `pivotTable(...)`
+4. validates a `stack()` / `unstack()` roundtrip
+5. resamples time-series rows with `resample(...)`
+6. returns statistical selectors with `describe(...)` and `nlargest(...)`
+7. computes `Series.diff`, `expanding`, `ewm`, and `toFrame(...)`
+
+## Expected output examples
+
+`runCookbookSmoke()` returns a shape like:
+
+```json
+{
+  "status": "ok",
+  "entrypoint": "runCookbookSmoke",
+  "rowCount": 6,
+  "exprColumns": ["product", "revenue", "units", "revenue_per_unit", "revenue_band"]
+}
+```
+
+`runCookbookDemo()` returns a shape like:
+
+```json
+{
+  "status": "ok",
+  "entrypoint": "runCookbookDemo",
+  "reshape": {
+    "stackRoundTripMatches": true
+  },
+  "seriesAnalytics": {
+    "diff": [null, -30, 18, 7, -17, -3]
+  }
+}
+```
+
+## OAuth scopes
+
+This cookbook does not require external service scopes. Keep `src/appsscript.json` minimal unless you extend the example with Drive, Sheets, or external APIs.
+
+## Troubleshooting
+
+`Cookbook config is invalid`
+
+- Run `seedCookbookConfig()` again.
+- Check that `DF_ADV_RESAMPLE_RULE` is `1h` or `1d`.
+- Check that `DF_ADV_SAMPLE_RANDOM_STATE` is an integer.
+
+`The stack roundtrip flag is false`
+
+- That means the pivoted frame and the reconstructed unstacked frame diverged. For this cookbook dataset they should match exactly.
+
+`You want to inspect or reset the contract`
+
+- Run `showCookbookContract()`.
+- Run `clearCookbookConfig()`.

--- a/cookbooks/dataframe_series_advanced/src/00_Config.gs
+++ b/cookbooks/dataframe_series_advanced/src/00_Config.gs
@@ -1,0 +1,239 @@
+function cookbookAst_() {
+  return ASTLib.AST || ASTLib;
+}
+
+function cookbookScriptProperties_() {
+  return PropertiesService.getScriptProperties();
+}
+
+function cookbookTemplateVersion_() {
+  return 'v2';
+}
+
+function cookbookName_() {
+  return 'dataframe_series_advanced';
+}
+
+function cookbookConfigFields_() {
+  return [
+    {
+      key: 'DF_ADV_APP_NAME',
+      required: true,
+      defaultValue: 'AST DataFrame Series Advanced',
+      description: 'Human-readable app label included in cookbook outputs.'
+    },
+    {
+      key: 'DF_ADV_SAMPLE_RANDOM_STATE',
+      required: false,
+      defaultValue: '42',
+      type: 'integer',
+      min: 0,
+      description: 'Deterministic random seed for sample() examples.'
+    },
+    {
+      key: 'DF_ADV_RESAMPLE_RULE',
+      required: false,
+      defaultValue: '1d',
+      allowedValues: ['1h', '1d'],
+      description: 'Resample rule used by the advanced demo.'
+    },
+    {
+      key: 'DF_ADV_VERBOSE',
+      required: false,
+      defaultValue: 'false',
+      type: 'boolean',
+      description: 'Enables extra logging metadata in outputs when true.'
+    }
+  ];
+}
+
+function cookbookConfigFieldMap_() {
+  const fields = cookbookConfigFields_();
+  const map = {};
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    map[fields[idx].key] = fields[idx];
+  }
+  return map;
+}
+
+function cookbookNormalizeBoolean_(value, fallback) {
+  if (value === true || value === false) {
+    return value;
+  }
+  if (value == null || value === '') {
+    return fallback;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (['true', '1', 'yes', 'y', 'on'].indexOf(normalized) !== -1) {
+    return true;
+  }
+  if (['false', '0', 'no', 'n', 'off'].indexOf(normalized) !== -1) {
+    return false;
+  }
+  return fallback;
+}
+
+function cookbookNormalizeInteger_(value, fallback) {
+  if (value == null || value === '') {
+    return fallback;
+  }
+  const numeric = typeof value === 'number' ? value : Number(String(value).trim());
+  if (!Number.isFinite(numeric) || !Number.isInteger(numeric)) {
+    return null;
+  }
+  return numeric;
+}
+
+function cookbookNormalizeConfigValue_(field, rawValue) {
+  if (field && field.type === 'boolean') {
+    return cookbookNormalizeBoolean_(rawValue, false);
+  }
+  if (field && field.type === 'integer') {
+    return cookbookNormalizeInteger_(rawValue, null);
+  }
+  return String(rawValue == null ? '' : rawValue).trim();
+}
+
+function cookbookValidateOverrideKeys_(overrides) {
+  if (overrides == null) {
+    return;
+  }
+  if (Object.prototype.toString.call(overrides) !== '[object Object]') {
+    throw new Error('seedCookbookConfig overrides must be a plain object when provided.');
+  }
+
+  const known = cookbookConfigFieldMap_();
+  const keys = Object.keys(overrides);
+  const unknown = [];
+  for (let idx = 0; idx < keys.length; idx += 1) {
+    if (!known[keys[idx]]) {
+      unknown.push(keys[idx]);
+    }
+  }
+  if (unknown.length > 0) {
+    throw new Error(`Unknown cookbook config overrides: ${unknown.join(', ')}`);
+  }
+}
+
+function cookbookValidationSummary_(result) {
+  return {
+    status: result.status,
+    templateVersion: result.templateVersion,
+    requiredKeys: result.requiredKeys,
+    optionalKeys: result.optionalKeys,
+    warnings: result.warnings,
+    errors: result.errors,
+    config: result.config
+  };
+}
+
+function cookbookLogResult_(label, payload) {
+  Logger.log(`${label}\n${JSON.stringify(payload, null, 2)}`);
+  return payload;
+}
+
+function seedCookbookConfig(overrides) {
+  cookbookValidateOverrideKeys_(overrides);
+
+  const props = cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+  const next = {};
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    const field = fields[idx];
+    const overrideValue = overrides && Object.prototype.hasOwnProperty.call(overrides, field.key)
+      ? overrides[field.key]
+      : field.defaultValue;
+    next[field.key] = String(overrideValue);
+  }
+
+  props.setProperties(next, false);
+
+  return cookbookLogResult_('seedCookbookConfig', cookbookValidationSummary_(validateCookbookConfig({ scriptProperties: props })));
+}
+
+function validateCookbookConfig(options) {
+  const runtimeOptions = options || {};
+  const props = runtimeOptions.scriptProperties || cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+  const resolved = {};
+  const warnings = [];
+  const errors = [];
+  const requiredKeys = [];
+  const optionalKeys = [];
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    const field = fields[idx];
+    const storedValue = props.getProperty(field.key);
+    const hasStoredValue = storedValue != null && storedValue !== '';
+    const rawValue = hasStoredValue ? storedValue : field.defaultValue;
+    const normalizedValue = cookbookNormalizeConfigValue_(field, rawValue);
+
+    resolved[field.key] = normalizedValue;
+
+    if (field.required) {
+      requiredKeys.push(field.key);
+    } else {
+      optionalKeys.push(field.key);
+    }
+
+    if (!hasStoredValue) {
+      warnings.push(`Using cookbook default for ${field.key}.`);
+    }
+
+    if (field.required && (normalizedValue === '' || normalizedValue == null)) {
+      errors.push(`Missing required cookbook config key ${field.key}.`);
+    }
+
+    if (field.type === 'integer') {
+      if (normalizedValue == null) {
+        errors.push(`${field.key} must be an integer value.`);
+      } else if (typeof field.min === 'number' && normalizedValue < field.min) {
+        errors.push(`${field.key} must be >= ${field.min}. Received: ${normalizedValue}`);
+      }
+    }
+
+    if (field.allowedValues && field.allowedValues.indexOf(normalizedValue) === -1) {
+      errors.push(`${field.key} must be one of: ${field.allowedValues.join(', ')}. Received: ${normalizedValue}`);
+    }
+  }
+
+  return {
+    status: errors.length > 0 ? 'error' : 'ok',
+    templateVersion: cookbookTemplateVersion_(),
+    requiredKeys,
+    optionalKeys,
+    warnings,
+    errors,
+    config: resolved
+  };
+}
+
+function cookbookRequireValidConfig_() {
+  const validation = validateCookbookConfig();
+  if (validation.status !== 'ok') {
+    throw new Error(`Cookbook config is invalid: ${validation.errors.join(' | ')}`);
+  }
+  return validation;
+}
+
+function cookbookBaseRecords_() {
+  return [
+    { ts: '2026-03-10T09:00:00Z', region: 'EU', channel: 'web', product: 'shoe', revenue: 120, units: 2, margin: 30, status: 'won' },
+    { ts: '2026-03-10T10:00:00Z', region: 'EU', channel: 'web', product: 'bag', revenue: 80, units: 1, margin: null, status: 'won' },
+    { ts: '2026-03-10T11:00:00Z', region: 'EU', channel: 'store', product: 'shoe', revenue: 60, units: 1, margin: 18, status: 'pending' },
+    { ts: '2026-03-11T09:00:00Z', region: 'US', channel: 'web', product: 'shoe', revenue: 90, units: 1, margin: 25, status: 'won' },
+    { ts: '2026-03-11T13:00:00Z', region: 'US', channel: 'store', product: 'bag', revenue: 40, units: 1, margin: 8, status: 'lost' },
+    { ts: '2026-03-12T10:00:00Z', region: 'US', channel: 'web', product: 'sock', revenue: 20, units: 4, margin: 5, status: 'won' }
+  ];
+}
+
+function cookbookWideMetricsFrame_() {
+  const ASTX = cookbookAst_();
+  return ASTX.DataFrame.fromRecords([
+    { sku: 'shoe', jan: 120, feb: 150, mar: 170 },
+    { sku: 'bag', jan: 80, feb: 90, mar: 95 },
+    { sku: 'sock', jan: 20, feb: 35, mar: 30 }
+  ]);
+}

--- a/cookbooks/dataframe_series_advanced/src/10_EntryPoints.gs
+++ b/cookbooks/dataframe_series_advanced/src/10_EntryPoints.gs
@@ -1,0 +1,23 @@
+function runCookbookSmoke() {
+  const validation = cookbookRequireValidConfig_();
+  return cookbookLogResult_('runCookbookSmoke', runCookbookSmokeInternal_(validation.config));
+}
+
+function runCookbookDemo() {
+  const validation = cookbookRequireValidConfig_();
+  return cookbookLogResult_('runCookbookDemo', runCookbookDemoInternal_(validation.config));
+}
+
+function runCookbookAll() {
+  const validation = cookbookRequireValidConfig_();
+  const output = {
+    status: 'ok',
+    templateVersion: cookbookTemplateVersion_(),
+    cookbook: cookbookName_(),
+    config: validation.config,
+    smoke: runCookbookSmokeInternal_(validation.config),
+    demo: runCookbookDemoInternal_(validation.config),
+    completedAt: new Date().toISOString()
+  };
+  return cookbookLogResult_('runCookbookAll', output);
+}

--- a/cookbooks/dataframe_series_advanced/src/20_Smoke.gs
+++ b/cookbooks/dataframe_series_advanced/src/20_Smoke.gs
@@ -1,0 +1,46 @@
+function runCookbookSmokeInternal_(config) {
+  const ASTX = cookbookAst_();
+  const frame = ASTX.DataFrame.fromRecords(cookbookBaseRecords_())
+    .fillNulls({ margin: 0 })
+    .replace('pending', 'open', { columns: ['status'] });
+
+  const expr = frame.selectExprDsl({
+    product: 'product',
+    revenue: 'revenue',
+    units: 'units',
+    revenue_per_unit: 'revenue / units',
+    revenue_band: "case when revenue >= 90 then 'focus' else 'core' end"
+  });
+
+  const revenueSeries = expr.revenue;
+  const sampled = expr.sample({ n: 3, randomState: config.DF_ADV_SAMPLE_RANDOM_STATE });
+  const ranked = revenueSeries.rank('dense').array;
+  const rollingMean = revenueSeries.rolling(2, 'mean').array;
+  const pctChange = revenueSeries.pctChange(1).array;
+  const clippedMargin = frame.margin.clip(0, 25).array;
+
+  return {
+    status: 'ok',
+    cookbook: cookbookName_(),
+    entrypoint: 'runCookbookSmoke',
+    appName: config.DF_ADV_APP_NAME,
+    astVersion: ASTX.VERSION,
+    rowCount: frame.len(),
+    sampledPreview: sampled.toRecords(),
+    exprColumns: expr.columns.slice(),
+    revenueStats: {
+      sum: revenueSeries.sum(),
+      mean: revenueSeries.mean(),
+      rankDense: ranked,
+      rollingMean,
+      pctChange,
+      clippedMargin
+    },
+    verbose: config.DF_ADV_VERBOSE
+      ? {
+          exprPreview: expr.head(4).toRecords()
+        }
+      : null,
+    generatedAt: new Date().toISOString()
+  };
+}

--- a/cookbooks/dataframe_series_advanced/src/30_Examples.gs
+++ b/cookbooks/dataframe_series_advanced/src/30_Examples.gs
@@ -1,0 +1,72 @@
+function runCookbookDemoInternal_(config) {
+  const ASTX = cookbookAst_();
+  const sales = ASTX.DataFrame.fromRecords(cookbookBaseRecords_()).fillNulls({ margin: 0 });
+
+  const windowed = sales
+    .window({
+      partitionBy: ['region', 'channel'],
+      orderBy: [{ column: 'ts', ascending: true }]
+    })
+    .assign({
+      row_number: windowCtx => windowCtx.rowNumber(),
+      previous_revenue: windowCtx => windowCtx.col('revenue').lag(1),
+      running_revenue: windowCtx => windowCtx.col('revenue').running('sum')
+    });
+
+  const reshaped = cookbookWideMetricsFrame_().melt({
+    idVars: ['sku'],
+    valueVars: ['jan', 'feb', 'mar'],
+    varName: 'month',
+    valueName: 'revenue'
+  });
+
+  const pivoted = sales.pivotTable({
+    index: 'region',
+    columns: 'channel',
+    values: ['revenue', 'units'],
+    aggFunc: 'sum',
+    fillValue: 0
+  });
+
+  const stacked = pivoted.stack({ dropNulls: false });
+  const unstacked = stacked.unstack({ agg: 'first' });
+
+  const resampled = sales.resample(config.DF_ADV_RESAMPLE_RULE, {
+    on: 'ts',
+    columns: ['revenue', 'units'],
+    agg: {
+      revenue: 'sum',
+      units: 'count'
+    },
+    fillValue: 0
+  });
+
+  const described = sales.select(['revenue', 'units', 'margin']).describe({ percentiles: [0.5] });
+  const largest = sales.nlargest(3, ['revenue', 'units']);
+
+  const marginSeries = sales.margin;
+  const seriesAnalytics = {
+    diff: marginSeries.diff(1).array,
+    expandingSum: marginSeries.expanding('sum').array,
+    ewm: marginSeries.ewm({ alpha: 0.5, adjust: false }).array,
+    toFramePreview: marginSeries.toFrame({ name: 'margin_only' }).head(3).toRecords()
+  };
+
+  return {
+    status: 'ok',
+    cookbook: cookbookName_(),
+    entrypoint: 'runCookbookDemo',
+    appName: config.DF_ADV_APP_NAME,
+    windowPreview: windowed.toRecords(),
+    reshape: {
+      melted: reshaped.toRecords(),
+      pivoted: pivoted.toRecords(),
+      stackRoundTripMatches: JSON.stringify(pivoted.toRecords()) === JSON.stringify(unstacked.toRecords())
+    },
+    resamplePreview: resampled.toRecords(),
+    describePreview: described.toRecords(),
+    topRevenueRows: largest.toRecords(),
+    seriesAnalytics,
+    generatedAt: new Date().toISOString()
+  };
+}

--- a/cookbooks/dataframe_series_advanced/src/99_DevTools.gs
+++ b/cookbooks/dataframe_series_advanced/src/99_DevTools.gs
@@ -1,0 +1,35 @@
+function clearCookbookConfig() {
+  const props = cookbookScriptProperties_();
+  const fields = cookbookConfigFields_();
+
+  for (let idx = 0; idx < fields.length; idx += 1) {
+    props.deleteProperty(fields[idx].key);
+  }
+
+  return cookbookLogResult_('clearCookbookConfig', {
+    status: 'ok',
+    clearedKeys: fields.map(field => field.key),
+    templateVersion: cookbookTemplateVersion_(),
+    cookbook: cookbookName_()
+  });
+}
+
+function showCookbookContract() {
+  return cookbookLogResult_('showCookbookContract', {
+    templateVersion: cookbookTemplateVersion_(),
+    cookbook: cookbookName_(),
+    requiredEntrypoints: [
+      'seedCookbookConfig',
+      'validateCookbookConfig',
+      'runCookbookSmoke',
+      'runCookbookDemo',
+      'runCookbookAll'
+    ],
+    scriptProperties: cookbookConfigFields_().map(field => ({
+      key: field.key,
+      required: field.required,
+      defaultValue: field.defaultValue,
+      description: field.description
+    }))
+  });
+}

--- a/cookbooks/dataframe_series_advanced/src/appsscript.json
+++ b/cookbooks/dataframe_series_advanced/src/appsscript.json
@@ -1,0 +1,14 @@
+{
+  "timeZone": "Etc/UTC",
+  "dependencies": {
+    "libraries": [
+      {
+        "userSymbol": "ASTLib",
+        "libraryId": "1gZ_6DiLeDhh-a4qcezluTFDshw4OEhTXbeD3wthl_UdHEAFkXf6i6Ho_",
+        "version": "<PUBLISHED_AST_LIBRARY_VERSION>"
+      }
+    ]
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
+}

--- a/docs/getting-started/cookbooks.md
+++ b/docs/getting-started/cookbooks.md
@@ -34,7 +34,7 @@ Use these tiers to decide how much setup is required before you run a cookbook.
 
 | Tier | Meaning | Cookbooks |
 | --- | --- | --- |
-| `Tier 0` | Local/editor-only validation; no external credentials required beyond the AST library binding | `_template`, `data_workflows_starter` |
+| `Tier 0` | Local/editor-only validation; no external credentials required beyond the AST library binding | `_template`, `data_workflows_starter`, `dataframe_series_advanced` |
 | `Tier 1` | Script Properties required; may use Drive, cache, or durable state but defaults stay local/dry-run | `config_cache_patterns`, `jobs_triggers_orchestration`, `messaging_hub`, `storage_cache_warmer`, `storage_ops`, `telemetry_alerting` |
 | `Tier 2` | External API/provider credentials required for realistic runs | `ai_playground`, `dbt_manifest_summary`, `github_issue_digest`, `http_ingestion_pipeline`, `sql_execution_patterns` |
 | `Tier 3` | Deployable webapp or richer app shell with UI/session/index configuration | `rag_chat_starter` |
@@ -46,6 +46,7 @@ Use these tiers to decide how much setup is required before you run a cookbook.
 | `_template` | Template v2 scaffold | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/_template/README.md) | `AST.DataFrame`, `AST.Cache` sample usage | `runCookbookSmoke()` | `runCookbookDemo()` |
 | `ai_playground` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/ai_playground/README.md) | `AST.AI` | `runCookbookSmoke()` | `runCookbookDemo()` |
 | `config_cache_patterns` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/config_cache_patterns/README.md) | `AST.Config`, `AST.Runtime`, `AST.Secrets`, `AST.Cache` | `runCookbookSmoke()` | `runCookbookDemo()` |
+| `dataframe_series_advanced` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/dataframe_series_advanced/README.md) | `AST.DataFrame`, `AST.Series` advanced transforms | `runCookbookSmoke()` | `runCookbookDemo()` |
 | `data_workflows_starter` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/data_workflows_starter/README.md) | `AST.Series`, `AST.DataFrame`, `AST.GroupBy`, `AST.Drive`, `AST.Sheets`, `AST.Sql`, `AST.Utils` | `runCookbookSmoke()` | `runCookbookDemo()` |
 | `dbt_manifest_summary` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/dbt_manifest_summary/README.md) | `AST.DBT` | `runCookbookSmoke()` | `runCookbookDemo()` |
 | `github_issue_digest` | Script-run | [README](https://github.com/joe-broadhead/apps-script-tools/blob/master/cookbooks/github_issue_digest/README.md) | `AST.GitHub` | `runCookbookSmoke()` | `runCookbookDemo()` |
@@ -67,6 +68,7 @@ Use this matrix for cookbook release-readiness checks.
 | `_template` | set library version, run `seedCookbookConfig()` | `runCookbookAll()` | validation is `ok`; smoke/demo both return structured summaries |
 | `ai_playground` | seed `AI_PLAYGROUND_*`; configure one provider | `runCookbookAll()` | text/structured/tools paths return deterministic summaries or dry-run plans |
 | `config_cache_patterns` | seed `CONFIG_CACHE_*`; choose a cache backend | `runCookbookAll()` | runtime/config precedence and cache round-trips succeed |
+| `dataframe_series_advanced` | seed `DF_ADV_*` | `runCookbookAll()` | advanced expression/window/reshape/statistical examples return deterministic summaries |
 | `data_workflows_starter` | seed `DATA_WORKFLOWS_*`; optional Drive/Sheets/SQL config | `runCookbookAll()` | frame summaries and sample outputs render without external failures |
 | `dbt_manifest_summary` | provide manifest source/cache config | `runCookbookAll()` | manifest load, inspect, search, and lineage summaries are populated |
 | `github_issue_digest` | provide `GITHUB_TOKEN` / cookbook GitHub defaults | `runCookbookAll()` | read flows succeed; mutation examples return dry-run plans |

--- a/scripts/check-cookbooks.mjs
+++ b/scripts/check-cookbooks.mjs
@@ -6,6 +6,7 @@ const COOKBOOKS = Object.freeze([
   { id: '_template', structure: 'template_v2' },
   { id: 'ai_playground', structure: 'template_v2' },
   { id: 'config_cache_patterns', structure: 'template_v2' },
+  { id: 'dataframe_series_advanced', structure: 'template_v2' },
   { id: 'data_workflows_starter', structure: 'template_v2' },
   { id: 'dbt_manifest_summary', structure: 'template_v2' },
   { id: 'github_issue_digest', structure: 'template_v2' },


### PR DESCRIPTION
## Summary
- add a dedicated `cookbooks/dataframe_series_advanced` cookbook on the template-v2 contract
- cover advanced in-memory `AST.DataFrame` and `AST.Series` transformations with deterministic smoke/demo entrypoints
- publish the cookbook in the catalog/docs and register it in `scripts/check-cookbooks.mjs`

## Why
The cookbook coverage epic is now complete, but one adjacent gap remained: the basic `data_workflows_starter` shows end-to-end workflows, not the richer in-memory transformation patterns users need when they are mapping pandas-like operations into Apps Script.

This PR fills that gap with a focused cookbook for:
- expression DSL
- window functions
- reshape operations
- resampling
- statistical selectors
- advanced Series analytics

## What changed
### New cookbook
- `cookbooks/dataframe_series_advanced/README.md`
- `cookbooks/dataframe_series_advanced/.clasp.json.example`
- `cookbooks/dataframe_series_advanced/.claspignore`
- `cookbooks/dataframe_series_advanced/src/appsscript.json`
- `cookbooks/dataframe_series_advanced/src/00_Config.gs`
- `cookbooks/dataframe_series_advanced/src/10_EntryPoints.gs`
- `cookbooks/dataframe_series_advanced/src/20_Smoke.gs`
- `cookbooks/dataframe_series_advanced/src/30_Examples.gs`
- `cookbooks/dataframe_series_advanced/src/99_DevTools.gs`

### Catalog/docs updates
- `cookbooks/README.md`
- `docs/getting-started/cookbooks.md`
- `scripts/check-cookbooks.mjs`

## Validation
- `npm run check:cookbooks`
- `npm run lint`
- `uv run mkdocs build --strict`
- `git diff --check`
