### PR TITLE
docs(cookbooks): tighten cookbook docs and catalog accuracy

### DIFF
--- a/cookbooks/README.md
+++ b/cookbooks/README.md
@@ -83,6 +83,10 @@ The template README documents:
 - deployment checklist
 - troubleshooting notes
 
+One published cookbook is intentionally narrower than template-v2:
+
+- `storage_cache_warmer` is a focused legacy smoke example with a single entrypoint, kept because it is the smallest persisted-cache validation recipe in the repo.
+
 ## Published cookbook catalog
 
 | Cookbook | Type | AST modules covered | Required script properties | Entrypoints |
@@ -92,13 +96,13 @@ The template README documents:
 | `config_cache_patterns` | Script-run | `AST.Config`, `AST.Runtime`, `AST.Secrets`, `AST.Cache` | `CONFIG_CACHE_*` plus backend-specific cache secrets/URIs | standard template-v2 entrypoints |
 | `dataframe_series_advanced` | Script-run | `AST.DataFrame`, `AST.Series` advanced transforms only | `DF_ADV_*` | standard template-v2 entrypoints |
 | `data_workflows_starter` | Script-run | `AST.Series`, `AST.DataFrame`, `AST.GroupBy`, `AST.Drive`, `AST.Sheets`, `AST.Sql`, `AST.Utils` | `DATA_WORKFLOWS_*` plus optional Drive/Sheets/SQL config | standard template-v2 entrypoints |
-| `dbt_manifest_summary` | Script-run | `AST.DBT` | `DBT_*` / cookbook DBT source and cache properties | standard template-v2 entrypoints |
+| `dbt_manifest_summary` | Script-run | `AST.DBT` | `DBT_ARTIFACT_EXPLORER_*` | standard template-v2 entrypoints |
 | `github_issue_digest` | Script-run | `AST.GitHub` | `GITHUB_*` / cookbook GitHub defaults and token | standard template-v2 entrypoints |
 | `http_ingestion_pipeline` | Script-run | `AST.Http`, optional `AST.Cache`, `AST.Telemetry` | `HTTP_INGESTION_*` plus target API config | standard template-v2 entrypoints |
 | `jobs_triggers_orchestration` | Script-run | `AST.Jobs`, `AST.Triggers` | `JOBS_TRIGGERS_*` | standard template-v2 entrypoints |
 | `messaging_hub` | Script-run | `AST.Messaging` | `MESSAGING_HUB_*` plus optional live webhook/mail settings | standard template-v2 entrypoints |
 | `rag_chat_starter` | Webapp | `AST.RAG`, `AST.Chat`, `AST.AI`, `AST.Cache` | `RAG_CHAT_*` plus provider/index/cache settings | standard template-v2 entrypoints + HtmlService webapp |
-| `storage_cache_warmer` | Focused script-run | `AST.Cache`, `AST.Storage` | `STORAGE_CACHE_URI`, optional `STORAGE_CACHE_NAMESPACE`, provider auth | `runStorageCacheWarmerSmoke` |
+| `storage_cache_warmer` | Focused script-run | `AST.Cache`, `AST.Storage` | `STORAGE_CACHE_URI`, optional `STORAGE_CACHE_NAMESPACE`, provider auth for `gcs://|gs://|s3://|dbfs:/` | `runStorageCacheWarmerSmoke` |
 | `sql_execution_patterns` | Script-run | `AST.Sql`, optional `AST.DataFrame` write path | `SQL_COOKBOOK_*` plus provider credentials when live execution is enabled | standard template-v2 entrypoints |
 | `storage_ops` | Script-run | `AST.Storage` | `STORAGE_OPS_*` plus provider auth/URIs | standard template-v2 entrypoints |
 | `telemetry_alerting` | Script-run | `AST.Telemetry`, `AST.TelemetryHelpers` | `TELEMETRY_COOKBOOK_*` | standard template-v2 entrypoints |

--- a/cookbooks/storage_cache_warmer/README.md
+++ b/cookbooks/storage_cache_warmer/README.md
@@ -1,36 +1,94 @@
 # Storage Cache Warmer Cookbook
 
-Practical Apps Script cookbook that uses `AST.Cache` with `storage_json` backend to warm and validate a persisted cache object on GCS/S3/DBFS.
+Focused Apps Script cookbook that warms and validates a persisted `AST.Cache` object using the `storage_json` backend.
+
+It is intentionally smaller than the template-v2 cookbooks because it exists to prove one narrow pattern clearly:
+
+- write a cache heartbeat into object storage
+- read it back immediately
+- confirm the configured backend/namespace/URI are wired correctly
+
+Supported storage URI schemes:
+
+- `gcs://...` or `gs://...`
+- `s3://...`
+- `dbfs:/...`
+
+## What it covers
+
+- `AST.Cache.set(...)` with `backend: 'storage_json'`
+- `AST.Cache.get(...)` roundtrip verification
+- minimal persisted-cache smoke validation for scheduled warmers or health checks
 
 ## Files
 
 - `src/main.gs`: runnable entrypoint (`runStorageCacheWarmerSmoke`)
-- `src/appsscript.json`: library binding + scopes
+- `src/appsscript.json`: library binding + OAuth scopes
 - `.clasp.json.example`: local clasp config template
 
 ## Setup
 
-1. Copy clasp config and set your target script id:
+1. Copy `.clasp.json.example` to `.clasp.json`.
+2. Set your target `scriptId`.
+3. Replace `<PUBLISHED_AST_LIBRARY_VERSION>` in `src/appsscript.json`.
+4. Set the required Script Properties.
+5. Configure provider credentials using the normal `AST.Storage` properties for GCS/S3/DBFS.
+6. Push with `clasp push`.
+7. Run `runStorageCacheWarmerSmoke()`.
 
-```bash
-cp .clasp.json.example .clasp.json
+## Script properties
+
+| Key | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `STORAGE_CACHE_URI` | Yes | none | Target cache object URI. Use `gcs://`, `gs://`, `s3://`, or `dbfs:/`. |
+| `STORAGE_CACHE_NAMESPACE` | No | `cookbook_cache_warmer` | Cache namespace used for the warmed key. |
+
+## Entrypoint
+
+### `runStorageCacheWarmerSmoke()`
+
+The smoke run:
+
+1. reads `STORAGE_CACHE_URI` and optional namespace from Script Properties
+2. writes a heartbeat payload to the configured `storage_json` cache
+3. reads the same key back immediately
+4. returns whether the persisted cache roundtrip succeeded
+
+## Expected output shape
+
+`runStorageCacheWarmerSmoke()` returns a payload like:
+
+```json
+{
+  "namespace": "cookbook_cache_warmer",
+  "key": "warmup:heartbeat",
+  "hit": true,
+  "storageUri": "gcs://bucket/path/cache.json"
+}
 ```
 
-2. Set script properties:
+## OAuth scopes
 
-- `STORAGE_CACHE_URI` (for example `gcs://bucket/path/cache.json`)
-- `STORAGE_CACHE_NAMESPACE` (optional; defaults to `cookbook_cache_warmer`)
+`src/appsscript.json` currently requests:
 
-3. Configure provider credentials using AST.Storage-supported properties (for GCS/S3/DBFS).
-4. Set the published AST library version in `src/appsscript.json`.
-5. Push and run:
+- `https://www.googleapis.com/auth/script.external_request`
+- `https://www.googleapis.com/auth/cloud-platform`
 
-```bash
-clasp push
-# Run runStorageCacheWarmerSmoke from Apps Script editor or clasp run.
-```
+If you use only non-GCP backends, keep the manifest aligned with the provider you actually need.
 
-## Notes
+## Troubleshooting
 
-- Uses public `AST.Cache` APIs only.
-- Good baseline for scheduled warm-cache jobs.
+`Missing script property STORAGE_CACHE_URI`
+
+- Set `STORAGE_CACHE_URI` in Script Properties before running the smoke function.
+
+`The smoke run returns hit=false`
+
+- Confirm provider auth is configured correctly.
+- Confirm the URI uses a supported scheme: `gcs://`, `gs://`, `s3://`, or `dbfs:/`.
+- Confirm the target object path is writable by the configured identity.
+
+`You want a fuller cache/config cookbook`
+
+- Use `cookbooks/config_cache_patterns` for the broader template-v2 example.
+- Keep this cookbook for the smallest persisted-cache smoke path.

--- a/docs/getting-started/cookbooks.md
+++ b/docs/getting-started/cookbooks.md
@@ -28,6 +28,10 @@ Each cookbook should:
 - include least-privilege OAuth scope guidance
 - explain common failure modes and setup steps
 
+One published cookbook is intentionally smaller than template-v2:
+
+- `storage_cache_warmer` keeps a single smoke entrypoint because it exists as the narrowest possible persisted-cache validation example.
+
 ## Setup tiers
 
 Use these tiers to decide how much setup is required before you run a cookbook.
@@ -77,7 +81,7 @@ Use this matrix for cookbook release-readiness checks.
 | `messaging_hub` | seed `MESSAGING_HUB_*` (defaults are safe) | `runCookbookAll()` | dry-run email/chat plans, template render, tracking logs, and inbound fixture routing succeed |
 | `rag_chat_starter` | configure index, provider, cache, and branding settings | `runCookbookSmoke()` + deploy webapp if needed | smoke confirms index/chat setup; webapp loads and grounded responses cite sources |
 | `sql_execution_patterns` | seed `SQL_COOKBOOK_*`; provide Databricks or BigQuery config only when live execution is enabled | `runCookbookAll()` | smoke returns provider/prepared summaries; demo returns direct/prepared/status/write plans or live execution summaries |
-| `storage_cache_warmer` | set `STORAGE_CACHE_URI` and provider auth | `runStorageCacheWarmerSmoke()` | cache object warms successfully and persisted backend responds |
+| `storage_cache_warmer` | set `STORAGE_CACHE_URI`, optional namespace, and provider auth for `gcs://`, `gs://`, `s3://`, or `dbfs:/` | `runStorageCacheWarmerSmoke()` | cache object warms successfully and persisted backend responds |
 | `storage_ops` | seed `STORAGE_OPS_*` and provider auth | `runCookbookAll()` | CRUD/list/walk/sync summaries match the configured provider |
 | `telemetry_alerting` | seed `TELEMETRY_COOKBOOK_*`; keep sink `logger` for easiest run | `runCookbookAll()` | grouped metrics, redaction preview, alert evaluation, and dry-run notifications succeed |
 


### PR DESCRIPTION
## Summary
- audit the published cookbook set for clarity, accuracy, and documentation quality
- expand `storage_cache_warmer` so it is documented to the same standard as the rest of the published cookbook catalog
- fix cookbook catalog accuracy for DBT property prefixes and clarify the one focused non-template cookbook

## What changed
- expanded `cookbooks/storage_cache_warmer/README.md` with:
  - supported URI schemes
  - explicit script property table
  - smoke entrypoint behavior
  - expected output shape
  - OAuth scope guidance
  - troubleshooting notes
- updated `cookbooks/README.md` to:
  - call out `storage_cache_warmer` as the intentionally narrow non-template cookbook
  - correct the DBT cookbook property prefix to `DBT_ARTIFACT_EXPLORER_*`
  - clarify provider URI expectations for `storage_cache_warmer`
- updated `docs/getting-started/cookbooks.md` to mirror the same cookbook contract and smoke matrix clarifications

## Validation
- `npm run check:cookbooks`
- `npm run lint`
- `uv run mkdocs build --strict`
